### PR TITLE
Updates documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,57 @@
+List of contributors
+====================
+
+This lists the contributions for the miscellaneous artwork assets in the
+repository. The logo's attribution and license is documented in the logo
+directory.
+
+Unless otherwise noted, contributions are shared under the license of this
+repository.
+
+## @cillianderoiste
+
+  * No specific license, all rights reserved @cillianderoiste. PR #10
+      * `swag/flyers/happier-hacking/flyer-multi.pdf`
+      * `swag/flyers/happier-hacking/flyer-optimized.svg`
+      * `swag/flyers/happier-hacking/Readme.md`
+
+## @ericsagnes
+
+  * No specific license, all rights reserved @ericsagnes. PR #15
+      * `wallpapers/nix-wallpaper-mosaic-blue.png`
+      * `wallpapers/nix-wallpaper-simple-blue.png`
+      * `wallpapers/nix-wallpaper-simple-dark-gray.png`
+      * `wallpapers/nix-wallpaper-simple-light-gray.png`
+      * `wallpapers/nix-wallpaper-simple-red.png`
+      * `wallpapers/nix-wallpaper-stripes-logo.png`
+      * `wallpapers/nix-wallpaper-stripes.png`
+
+## @jagajaga
+
+  * [Upstream](https://github.com/jagajaga/nixos-slim-theme), MIT.
+      * `slim/themes/nixos-theme.tar.gz`
+  * No specific license, all rights reserved @jagajaga. PR #2
+      * `grub-background/grub-1.xpm`
+
+## @lethalman
+
+  * No specific license, all rights reserved @lethalman. Issue #1
+      * `gnome/Gnome_Dark.png`
+      * `gnome/share/backgrounds/gnome/Gnome_Dark.jpg`
+  * No specified liense, upstream wallpaper is GPL, modification by @lethalman. Assumed to be GPL. Commit b1c912ad918c256c7ebf2f5c2960a66cbc58570a
+	  * [Original by ivan-cukic](https://ivan-cukic.deviantart.com/art/KDE-Stripes-175023606)
+	  * [Contributed to the KDE project](https://github.com/KDE/kde-workspace/commit/bbd0bc62c7cbb074783af01086602c4de03fe8ac) as [GPL](https://github.com/KDE/kde-workspace/blob/bbd0bc62c7cbb074783af01086602c4de03fe8ac/COPYING)
+      * `kde/share/wallpapers/nixos-stripes/nixos-stripes.png`
+      * `kde/share/wallpapers/nixos-stripes/nixos-stripes.xcf`
+
+## @robberer
+
+  * No specific license, all rights reserved @robberer. PR #5
+      * `common/wallpapers/nixos-border.png`
+  * No specific license, all rights reserved @robberer. PR #4
+      * `common/grub2-background/grub-nixos-1.png`
+      * `common/grub2-background/grub-nixos-1.xcf`
+      * `common/grub2-background/grub-nixos-2.png`
+      * `common/grub2-background/grub-nixos-2.xcf`
+      * `common/grub2-background/grub-nixos-3.png`
+      * `common/grub2-background/grub-nixos-3.xcf`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-## Artwork for the [NixOS](http://nixos.org) organization.
+[<img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
 
-* [NixOS installation instructions](http://nixos.org/nixos/manual/#ch-installation)
-* [Manual (How to write packages for Nix)](http://nixos.org/nixpkgs/manual/)
-* [Manual (NixOS)](http://nixos.org/nixos/manual/)
-* [Continuous build](http://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Tests](http://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Mailing list](https://groups.google.com/forum/#!forum/nix-devel)
-* [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
+## Artwork for the [NixOS](http://nixos.org) organization.
 
 ** BIG NOTE ** the directory layout is in flux. Do not assume anything
 about the stability of the path of the images in this repository, yet.
@@ -16,3 +10,20 @@ References to other Linux distributions:
 * <https://wiki.debian.org/Grub/SplashImage>
 * <https://github.com/openSUSE/artwork>
 * <https://gitorious.org/opensuse/kdebase4-opensuse/>
+
+* * *
+
+## NixOS project links
+
+[NixOS and nixpkgs are in a separate repository](https://github.com/NixOS/nixpkgs)
+
+* [NixOS installation instructions](https://nixos.org/nixos/manual/#ch-installation)
+* [Documentation (Nix Expression Language chapter)](https://nixos.org/nix/manual/#ch-expression-language)
+* [Manual (How to write packages for Nix)](https://nixos.org/nixpkgs/manual/)
+* [Manual (NixOS)](https://nixos.org/nixos/manual/)
+* [Community maintained wiki](https://nixos.wiki/)
+
+Communication:
+
+* [Mailing list](https://groups.google.com/forum/#!forum/nix-devel)
+* [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)


### PR DESCRIPTION
Updates README to look like the upstream nixpkgs repository's README.

 * Adds logo
 * Adds/changes links (except for hydra links)
 * Leaves the actual text of the current README.

* * *

Adds CONTRIBUTORS document, with attribution for the source files. I am unsure of the actual shape such a document should hold, but I am quite sure that being at the root of the repository is fine, this will make it easier for build scripts / makefiles to simply copy artwork directories as needed and copy the CONTRIBUTORS document in the proper documentation folder afterwards. Files next to the artwork files causes an issue where they may be unwanted in the target folders.

The CONTRIBUTORS document will need to be updated when #23 receives answers.