### PR TITLE
Remove some inkscape-isms from the SVGS

### DIFF
--- a/bootloader/efi-background.svg
+++ b/bootloader/efi-background.svg
@@ -2,28 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="1920"
    height="1080"
    viewBox="0 0 507.99998 285.75"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="efi-background.svg"
-   inkscape:export-filename="/Users/samuel/Projects/nixos/nixos-artwork/bootloader/efi-background.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <defs
      id="defs2">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5960">
       <stop
          style="stop-color:#637ddf;stop-opacity:1"
@@ -40,7 +30,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5562"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5564"
          offset="0"
@@ -56,7 +46,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5053"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5055"
          offset="0"
@@ -72,7 +62,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5867"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5869"
          offset="0"
@@ -87,7 +77,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5867"
        id="linearGradient5855-8"
        gradientUnits="userSpaceOnUse"
@@ -97,7 +86,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient4544"
        gradientUnits="userSpaceOnUse"
@@ -135,7 +123,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5137"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="506.18814"
        x2="290.08701"
@@ -145,9 +133,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5162"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient2490"
        gradientUnits="userSpaceOnUse"
@@ -157,7 +144,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1095"
        gradientUnits="userSpaceOnUse"
@@ -167,7 +153,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1097"
        gradientUnits="userSpaceOnUse"
@@ -177,96 +162,10 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#e2e8ff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="748.14171"
-     inkscape:cy="545.65976"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer11"
-     showgrid="false"
-     units="px"
-     inkscape:pagecheckerboard="true"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     inkscape:window-x="0"
-     inkscape:window-y="35"
-     inkscape:window-maximized="1"
-     borderlayer="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <sodipodi:guide
-       position="0,12.170833"
-       orientation="0,1"
-       id="guide1048"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,9.5249999"
-       orientation="0,1"
-       id="guide1050"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,123.853"
-       orientation="0,1"
-       id="guide1052"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,143.941"
-       orientation="0,1"
-       id="guide1054"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="71.966666,0"
-       orientation="1,0"
-       id="guide1068"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="136.78958,0"
-       orientation="1,0"
-       id="guide1070"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,79.374999"
-       orientation="0,1"
-       id="guide1084"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:label="Drawing"
-     inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-11.24998)"
      style="display:inline;opacity:1">
@@ -278,9 +177,7 @@
        x="71.966667"
        y="217.62498" />
     <g
-       inkscape:groupmode="layer"
        id="layer11"
-       inkscape:label="bg"
        style="display:inline;opacity:0.05">
       <g
          style="display:inline;opacity:1;stroke-width:0.27874291"
@@ -289,7 +186,6 @@
         <g
            transform="translate(-23.75651,-24.84972)"
            style="display:none;stroke-width:0.27874291"
-           inkscape:label="bg"
            id="layer7-7">
           <rect
              y="-957.77832"
@@ -303,12 +199,8 @@
         <g
            transform="translate(-156.33871,933.1905)"
            style="display:none;stroke-width:0.27874291"
-           inkscape:label="logo-guide"
            id="layer6-7">
           <rect
-             inkscape:export-ydpi="22.07"
-             inkscape:export-xdpi="22.07"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect5379-3"
              width="550.41602"
@@ -316,9 +208,6 @@
              x="132.65129"
              y="-958.02759" />
           <rect
-             inkscape:export-ydpi="212.2"
-             inkscape:export-xdpi="212.2"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
              y="-933.02759"
              x="156.12303"
              height="434.30405"
@@ -337,28 +226,20 @@
            transform="translate(-156.33871,933.1905)"
            style="display:inline;stroke-width:0.27874291"
            id="layer1-63"
-           inkscape:label="print-logo">
+           >
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4861-9"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4863-48"
              d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4865-1"
              d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4867-29"
              d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -366,62 +247,34 @@
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              id="path4873-3"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
              id="use4875-90"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
              id="use4877-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <g
              transform="translate(72.039038,-1799.4476)"
              style="display:none;stroke-width:0.27874291"
-             inkscape:label="guides"
              id="layer2-8">
             <path
-               sodipodi:type="star"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                id="path6032-5"
-               sodipodi:sides="6"
-               sodipodi:cx="335.17407"
-               sodipodi:cy="377.47382"
-               sodipodi:r1="250.86446"
-               sodipodi:r2="217.25499"
-               sodipodi:arg1="1.0471976"
-               sodipodi:arg2="1.5707963"
-               inkscape:flatsided="true"
-               inkscape:rounded="0"
-               inkscape:randomized="0"
                d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
             <path
                d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="1.5707963"
-               sodipodi:arg1="1.0471976"
-               sodipodi:r2="87.32563"
-               sodipodi:r1="100.83495"
-               sodipodi:cy="685.74158"
-               sodipodi:cx="335.17407"
-               sodipodi:sides="6"
                id="path5875-0"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <path
                style="fill:url(#linearGradient2490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                id="path5851-9"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccccccc"
                transform="translate(0,-308.26772)" />
             <rect
                transform="rotate(-30)"
@@ -433,19 +286,8 @@
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.41499999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
             <path
                d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="0.52359878"
-               sodipodi:arg1="0"
-               sodipodi:r2="24.291094"
-               sodipodi:r1="28.048939"
-               sodipodi:cy="878.63831"
-               sodipodi:cx="223.93674"
-               sodipodi:sides="6"
                id="path3428-8"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <use
                height="100%"
@@ -469,20 +311,16 @@
         <g
            transform="translate(-156.33871,933.1905)"
            style="display:inline;opacity:1;stroke-width:0.27874291"
-           inkscape:label="gradient-logo"
            id="layer3-1">
           <path
              style="opacity:1;fill:url(#linearGradient1095);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
              id="path3336-6-1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <use
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="124.43045"
-             inkscape:transform-center-y="151.59082"
              id="use3439-6-5"
              transform="rotate(60,407.11155,-715.78724)"
              width="100%"
@@ -492,8 +330,6 @@
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="-168.20651"
-             inkscape:transform-center-y="75.573958"
              id="use3445-0-9"
              transform="rotate(-60,407.31177,-715.70016)"
              width="100%"
@@ -503,16 +339,12 @@
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="59.669705"
-             inkscape:transform-center-y="-139.94592"
              id="use3449-5-8"
              transform="rotate(180,407.41868,-715.7565)"
              width="100%"
              height="100%"
              style="stroke-width:0.27874291" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4260-0-4"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1097);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.83622915;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -539,9 +371,7 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer9"
-     inkscape:label="NOTES"
      style="display:inline"
      transform="translate(0,127)">
     <flowRoot

--- a/bootloader/grub2-installer/icons/copytoram.svg
+++ b/bootloader/grub2-installer/icons/copytoram.svg
@@ -1,51 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="copytoram.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="false"
-     inkscape:zoom="10.727273"
-     inkscape:cx="-27.5"
-     inkscape:cy="11"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg5" />
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -61,5 +26,5 @@
      d="M 16.999999,-9e-7 V 11.999999 h 2 V 1.9999991 h 8 v 9.9999999 h 2 V -9e-7 h -2 -8 z M 12.585938,13.999999 11,15.632812 l 11.999999,12.367187 12,-12.367187 -1.585937,-1.632813 -10.414063,10.734376 z M 9,27.999999 V 32 h 2 23.999999 2 v -4.000001 h -2 V 30 H 11 v -2.000001 z"
      id="rect4161"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/debug.svg
+++ b/bootloader/grub2-installer/icons/debug.svg
@@ -1,51 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="debug.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="false"
-     inkscape:zoom="10.727273"
-     inkscape:cx="33.885593"
-     inkscape:cy="11.652542"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg5" />
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -61,5 +26,5 @@
      d="M 8.749999,2e-7 7,1.3839289 17.758928,13.714286 7,26.044642 8.749999,27.428571 20.714287,13.714286 Z M 20.714287,29.714286 V 32 h 18.285715 v -2.285714 z"
      class="ColorScheme-Text"
      id="path4867"
-     inkscape:connector-curvature="0" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/hidpi.svg
+++ b/bootloader/grub2-installer/icons/hidpi.svg
@@ -1,61 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg6"
-   sodipodi:docname="hidpi.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   inkscape:export-filename="/Users/samuel/tmp/nixos.wiki/breeze-icons/mine/hand@32.svg.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <metadata
      id="metadata10">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview8"
-     showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="10.913194"
-     inkscape:cy="1.7608475"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg6"
-     showguides="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid8438"
-       color="#0000ff"
-       opacity="0.22352941" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -71,6 +26,5 @@
      d="m 29.253964,0.00770124 c -1.242826,0.07535 -2.09317,0.855632 -2.691414,1.82129896 -0.652708,-2.37307796 -5.278014,-2.52151896 -6.20314,0.842107 -0.726936,-0.782685 -1.65497,-1.324649 -2.824226,-1.241617 h -0.04687 C 15.35015,1.6167372 13.83698,3.497054 14.203148,5.5577692 L 16.027367,16.18006 C 15.336873,15.706184 14.498588,14.893818 13.88283,14.625102 12.455856,14.002222 11.149773,13.924032 10.097664,14.22559 7.993462,14.828422 7.3632822,16.79891 7.3632822,16.79891 L 7,17.821188 7.9101586,18.443954 c 2.0089608,1.321394 4.2230894,4.524584 6.1486314,7.508456 0.962777,1.491864 1.921774,2.902278 3.011726,4.04211 1.089951,1.139978 2.149852,2.015768 3.812332,2.005388 h 0.02734 c 4.666878,-0.0024 9.084315,4.58e-4 13.751193,0 h 0.363284 l 0.04688,-0.323857 c 0,0 0.12846,-3.492925 0.363282,-6.432577 0.23488,-2.939656 0.661057,-6.368414 1.066121,-7.954968 L 38.692352,8.714689 C 39.32366,6.3590964 37.586066,4.0929288 35.09382,4.2730674 c -0.764882,0.042652 -1.440514,0.3706422 -2.007818,0.799022 l 0.04296,-1.2886186 c 0.142744,-2.1521346 -1.66587,-3.91481956 -3.874998,-3.77576956 z m -5.74611,1.41787196 v 0.0039 c 1.161128,-0.07109 2.277964,0.908056 2.324228,2.040639 l 0.55078,9.8193518 c 0.03094,0.555344 0.384618,0.548603 0.410158,0.047 l 0.5,-9.8663532 c 0.04276,-1.0435796 0.980714,-1.9800076 2.050788,-2.0445556 1.237922,-0.0782 2.408106,1.061723 2.32813,2.2678118 l -0.546876,10.794657 c -0.0164,0.324304 0.07826,0.48393 0.17968,0.09008 l 1.871104,-7.242112 c 0.21328,-0.8888912 1.072332,-1.5928662 2.00782,-1.645045 1.382958,-0.099526 2.631574,1.3601466 2.281256,2.667323 l -2.19141,8.57381 c -0.879688,3.445788 -1.323468,13.047795 -1.375004,14.074203 L 21,31.011783 v 0 c -4.233022,-0.0429 -7.591846,-10.516039 -12.5334649,-13.766361 -0.020865,-0.07303 1.9574149,-5.41785 9.3420869,1.997554 0,0 0.0512,-0.237524 0.136718,-0.575766 -0.05341,-0.17302 -0.08645,-0.356176 -0.09375,-0.536598 L 15.664085,5.3345132 c -0.205705,-1.157748 0.759843,-2.38194 1.960943,-2.487151 1.091629,-0.07678 2.218156,0.4861123 2.37497,1.5413509 l 1,9.6112869 c 0.06582,0.385014 1.029626,0.0029 1,-0.500872 L 21.45707,3.693385 C 21.38323,2.5762992 22.360912,1.4933912 23.507854,1.4255732 Z"
      class="ColorScheme-Text"
      id="path4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/installer.svg
+++ b/bootloader/grub2-installer/icons/installer.svg
@@ -1,59 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="installer.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   inkscape:export-filename="/Users/samuel/tmp/nixos.wiki/breeze-icons/mine/special@32.svg.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="true"
-     inkscape:zoom="5.5255665"
-     inkscape:cx="72.816803"
-     inkscape:cy="9.8920973"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg5"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid8418" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -69,6 +26,5 @@
      d="M 33,0.58817499 7,26.351259 12.126292,32 38.479691,5.6487407 Z M 10.020879,0.02599555 8.9601917,1.9600328 7.0259972,3.0206339 8.9601917,4.081235 10.020879,6.0152723 11.081566,4.081235 13.015761,3.0206339 11.081566,1.9600328 Z m 9.982939,0 L 18.943131,1.9600328 17.008937,3.0206339 18.943131,4.081235 20.003818,6.0152723 21.064505,4.081235 22.998701,3.0206339 21.064505,1.9600328 Z M 33,1.6487407 l 4.351918,3.9040225 -7,6.9999998 L 26,8.6487407 Z m -18.985946,6.3629572 -1.060686,1.9340373 -1.934195,1.0606008 1.934195,1.060601 1.060686,1.934038 1.060689,-1.934038 1.934194,-1.060601 -1.934194,-1.0606008 z"
      id="path74"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccc" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/nomodeset.svg
+++ b/bootloader/grub2-installer/icons/nomodeset.svg
@@ -1,55 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg6"
-   sodipodi:docname="nomodeset.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata10">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview8"
-     showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="31.587431"
-     inkscape:cy="15.755656"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg6">
-    <inkscape:grid
-       type="xygrid"
-       id="grid817" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -62,9 +23,8 @@
   </defs>
   <path
      style="color:#4d4d4d;fill:currentColor;fill-opacity:1;stroke:none;stroke-width:1"
-     d="m 7,2 v 22 h 13 v 4 h -5 v 2 H 31 V 28 H 26 V 24 H 39 V 2 Z M 9,4 H 37 V 22 H 9 Z"
+     d="M 9,-4e-7 V 32 h 1.999974 13.999817 V 30 H 10.999974 V 1.9999997 L 34,1.9999976 V 20 h 1.999974 V -2.5e-6 H 34 L 10.999974,-4e-7 Z M 26.636133,16 c -3.323963,0 -5.999922,2.675994 -5.999922,6.000002 0,3.324004 2.675959,5.999998 5.999922,5.999998 1.298766,0 2.492674,-0.417172 3.472609,-1.113281 L 35.221958,32 36.636,30.585938 31.522784,25.472658 c 0.696102,-0.979949 1.113269,-2.173874 1.113269,-3.472656 C 32.636053,18.675994 29.960092,16 26.636133,16 Z m 0,1.999999 c 2.215976,0 3.999946,1.783995 3.999946,4.000003 0,2.216006 -1.78397,3.999998 -3.999946,3.999998 -2.215978,0 -3.999949,-1.783992 -3.999949,-3.999998 0,-2.216008 1.783971,-4.000003 3.999949,-4.000003 z"
      class="ColorScheme-Text"
      id="path4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccccccccccc" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/refind.svg
+++ b/bootloader/grub2-installer/icons/refind.svg
@@ -1,55 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg6"
-   sodipodi:docname="refind.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata10">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview8"
-     showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="31.114585"
-     inkscape:cy="11.660585"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg6">
-    <inkscape:grid
-       type="xygrid"
-       id="grid817" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -65,6 +26,5 @@
      d="M 9,-4e-7 V 32 h 1.999974 13.999817 V 30 H 10.999974 V 1.9999997 L 34,1.9999976 V 20 h 1.999974 V -2.5e-6 H 34 L 10.999974,-4e-7 Z M 26.636133,16 c -3.323963,0 -5.999922,2.675994 -5.999922,6.000002 0,3.324004 2.675959,5.999998 5.999922,5.999998 1.298766,0 2.492674,-0.417172 3.472609,-1.113281 L 35.221958,32 36.636,30.585938 31.522784,25.472658 c 0.696102,-0.979949 1.113269,-2.173874 1.113269,-3.472656 C 32.636053,18.675994 29.960092,16 26.636133,16 Z m 0,1.999999 c 2.215976,0 3.999946,1.783995 3.999946,4.000003 0,2.216006 -1.78397,3.999998 -3.999946,3.999998 -2.215978,0 -3.999949,-1.783992 -3.999949,-3.999998 0,-2.216008 1.783971,-4.000003 3.999949,-4.000003 z"
      class="ColorScheme-Text"
      id="path4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccccsssccccsssssss" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/settings.svg
+++ b/bootloader/grub2-installer/icons/settings.svg
@@ -1,58 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="settings.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   inkscape:export-filename="/Users/samuel/tmp/nixpkgs/nixpkgs/TMP/Breeze-GRUB2/breeze/icons/settings.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="true"
-     inkscape:zoom="10.429825"
-     inkscape:cx="54.180657"
-     inkscape:cy="-3.4899745"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg5">
-    <inkscape:grid
-       type="xygrid"
-       id="grid819" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -68,6 +26,5 @@
      d="M 7,9e-7 V 32 H 39 V 9e-7 Z M 8,7 H 38 V 31 H 8 Z m 3,3 v 18 h 8.000001 V 10 Z m 10,1 v 1.000001 H 35 V 11 Z m 0,7 v 1 h 11 v -1 z m 0,6 v 2 h 6 v -2 z"
      id="path18"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+     />
 </svg>

--- a/bootloader/grub2-installer/icons/shutdown.svg
+++ b/bootloader/grub2-installer/icons/shutdown.svg
@@ -1,55 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 42 32"
    version="1.1"
    id="svg6"
-   sodipodi:docname="shutdown.svg"
    width="42"
    height="32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata10">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview8"
-     showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="18.928284"
-     inkscape:cy="32.726043"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg6">
-    <inkscape:grid
-       type="xygrid"
-       id="grid817" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -65,6 +26,5 @@
      d="M 21.666666,9e-7 V 0.0677079 1.4062492 12.000001 H 24 V 1.4010425 0.0625012 1.2e-6 h -1 z m 3.559667,0.2265627 v 1.3619786 c 6.949858,1.285027 12.435154,7.3438004 12.440333,14.4114588 0,8.100176 -6.56649,14.666666 -14.666666,14.666666 -8.100176,0 -14.6666667,-6.56649 -14.6666667,-14.666666 C 8.3372574,8.931361 13.382511,2.8711445 20.333333,1.5859382 V 0.2421889 C 12.64187,1.5422783 7.0089718,8.1994398 7,16.000001 7.0000006,24.836557 14.163444,32 23,32 31.836555,31.999999 38.999998,24.836556 38.999999,16.000001 38.998645,8.1935327 32.923615,1.5276417 25.226333,0.2265636 Z"
      class="ColorScheme-Text"
      id="path4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccccccsccccscc" />
+     />
 </svg>

--- a/bootloader/isolinux/bios-boot.svg
+++ b/bootloader/isolinux/bios-boot.svg
@@ -2,28 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="800"
    height="600"
    viewBox="0 0 211.66666 158.75"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="bios-boot.svg"
-   inkscape:export-filename="/Users/samuel/Projects/nixos/nixos-artwork/bootloader/bios-boot.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <defs
      id="defs2">
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient5855"
        gradientUnits="userSpaceOnUse"
@@ -33,7 +23,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5960">
       <stop
          style="stop-color:#637ddf;stop-opacity:1"
@@ -50,7 +39,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5562"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5564"
          offset="0"
@@ -66,7 +55,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5053"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5055"
          offset="0"
@@ -81,7 +70,6 @@
          style="stop-color:#5277c3;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient5855-2"
        gradientUnits="userSpaceOnUse"
@@ -92,7 +80,7 @@
        y2="515.97058" />
     <linearGradient
        id="linearGradient5867"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5869"
          offset="0"
@@ -107,7 +95,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5867"
        id="linearGradient5855-8"
        gradientUnits="userSpaceOnUse"
@@ -117,7 +104,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient4544"
        gradientUnits="userSpaceOnUse"
@@ -155,7 +141,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5137"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="506.18814"
        x2="290.08701"
@@ -165,9 +151,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5162"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1927"
        gradientUnits="userSpaceOnUse"
@@ -177,7 +162,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1929"
        gradientUnits="userSpaceOnUse"
@@ -187,7 +171,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient2490"
        gradientUnits="userSpaceOnUse"
@@ -197,7 +180,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient2492"
        gradientUnits="userSpaceOnUse"
@@ -207,7 +189,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient2494"
        gradientUnits="userSpaceOnUse"
@@ -217,99 +198,13 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#e2e8ff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="2.2319302"
-     inkscape:cy="266.27649"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer11"
-     showgrid="false"
-     units="px"
-     inkscape:pagecheckerboard="true"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     inkscape:window-x="0"
-     inkscape:window-y="35"
-     inkscape:window-maximized="1"
-     borderlayer="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <sodipodi:guide
-       position="0,12.170833"
-       orientation="0,1"
-       id="guide1048"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,9.5249999"
-       orientation="0,1"
-       id="guide1050"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,123.853"
-       orientation="0,1"
-       id="guide1052"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,143.941"
-       orientation="0,1"
-       id="guide1054"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="71.966666,0"
-       orientation="1,0"
-       id="guide1068"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="136.78958,0"
-       orientation="1,0"
-       id="guide1070"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="0,79.374999"
-       orientation="0,1"
-       id="guide1084"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="Menu layout"
      style="display:none"
-     sodipodi:insensitive="true">
+     >
     <image
        y="-2.8421709e-14"
        x="-2.5431316e-06"
@@ -321,8 +216,6 @@
        width="211.66667" />
   </g>
   <g
-     inkscape:label="Drawing"
-     inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-138.24998)"
      style="display:inline;opacity:1">
@@ -334,9 +227,7 @@
        x="71.966667"
        y="217.62498" />
     <g
-       inkscape:groupmode="layer"
        id="layer8"
-       inkscape:label="horizontal"
        style="display:inline">
       <g
          id="g954"
@@ -344,7 +235,6 @@
          style="display:inline;stroke-width:5.3869729">
         <g
            style="display:none;stroke-width:5.3869729"
-           inkscape:label="bg"
            id="layer7">
           <rect
              y="-957.77832"
@@ -358,7 +248,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;opacity:0.51599995;stroke-width:5.3869729"
-           inkscape:label="guide"
            id="layer5">
           <rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -368,8 +257,6 @@
              x="132.5822"
              y="-957.77832" />
           <rect
-             inkscape:export-ydpi="17.971878"
-             inkscape:export-xdpi="17.971878"
              y="-933.38721"
              x="155.77646"
              height="435.68069"
@@ -387,12 +274,8 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;stroke-width:5.3869729"
-           inkscape:label="logo-guide"
            id="layer6">
           <rect
-             inkscape:export-ydpi="22.07"
-             inkscape:export-xdpi="22.07"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect5379"
              width="550.41602"
@@ -400,9 +283,6 @@
              x="132.65129"
              y="-958.02759" />
           <rect
-             inkscape:export-ydpi="212.2"
-             inkscape:export-xdpi="212.2"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
              y="-933.02759"
              x="156.12303"
              height="434.30405"
@@ -421,28 +301,20 @@
            transform="translate(-132.5822,958.04022)"
            style="display:inline;stroke-width:5.3869729"
            id="layer1-6"
-           inkscape:label="print-logo">
+           >
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4861"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4863"
              d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4865"
              d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4867"
              d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -450,62 +322,34 @@
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              id="path4873"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
              id="use4875"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
              id="use4877"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <g
              transform="translate(72.039038,-1799.4476)"
              style="display:none;stroke-width:5.3869729"
-             inkscape:label="guides"
              id="layer2">
             <path
-               sodipodi:type="star"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                id="path6032"
-               sodipodi:sides="6"
-               sodipodi:cx="335.17407"
-               sodipodi:cy="377.47382"
-               sodipodi:r1="250.86446"
-               sodipodi:r2="217.25499"
-               sodipodi:arg1="1.0471976"
-               sodipodi:arg2="1.5707963"
-               inkscape:flatsided="true"
-               inkscape:rounded="0"
-               inkscape:randomized="0"
                d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
             <path
                d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="1.5707963"
-               sodipodi:arg1="1.0471976"
-               sodipodi:r2="87.32563"
-               sodipodi:r1="100.83495"
-               sodipodi:cy="685.74158"
-               sodipodi:cx="335.17407"
-               sodipodi:sides="6"
                id="path5875"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <path
                style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                id="path5851"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccccccc"
                transform="translate(0,-308.26772)" />
             <rect
                transform="rotate(-30)"
@@ -517,19 +361,8 @@
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.41499999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
             <path
                d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="0.52359878"
-               sodipodi:arg1="0"
-               sodipodi:r2="24.291094"
-               sodipodi:r1="28.048939"
-               sodipodi:cy="878.63831"
-               sodipodi:cx="223.93674"
-               sodipodi:sides="6"
                id="path3428"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <use
                height="100%"
@@ -553,20 +386,16 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:inline;opacity:1;stroke-width:5.3869729"
-           inkscape:label="gradient-logo"
            id="layer3">
           <path
              style="opacity:1;fill:url(#linearGradient1927);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
              id="path3336-6"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <use
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="124.43045"
-             inkscape:transform-center-y="151.59082"
              id="use3439-6"
              transform="rotate(60,407.11155,-715.78724)"
              width="100%"
@@ -576,8 +405,6 @@
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="-168.20651"
-             inkscape:transform-center-y="75.573958"
              id="use3445-0"
              transform="rotate(-60,407.31177,-715.70016)"
              width="100%"
@@ -587,16 +414,12 @@
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="59.669705"
-             inkscape:transform-center-y="-139.94592"
              id="use3449-5"
              transform="rotate(180,407.41868,-715.7565)"
              width="100%"
              height="100%"
              style="stroke-width:5.3869729" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4260-0"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1929);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -622,7 +445,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            id="g5329"
-           inkscape:label="text-vegur"
            style="display:inline;stroke-width:5.3869729">
           <g
              id="text5407"
@@ -632,17 +454,17 @@
                id="path4683"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
-               inkscape:connector-curvature="0" />
+               />
             <path
                id="path4685"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
-               inkscape:connector-curvature="0" />
+               />
             <path
                id="path4687"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
           <g
              id="text5356"
@@ -653,7 +475,7 @@
                id="path4680"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
           <g
              id="text5364"
@@ -663,15 +485,13 @@
                id="path4677"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
         </g>
       </g>
     </g>
     <g
-       inkscape:groupmode="layer"
        id="layer10"
-       inkscape:label="Vertical"
        style="display:none">
       <g
          id="g1648"
@@ -680,7 +500,6 @@
         <g
            transform="matrix(0.62033955,0,0,1.4127351,-265.36433,1353.3489)"
            style="display:none;opacity:0.51599995;stroke-width:3.06308055"
-           inkscape:label="guide"
            id="layer5-1">
           <rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -690,8 +509,6 @@
              x="259.18103"
              y="-957.77832" />
           <rect
-             inkscape:export-ydpi="17.971878"
-             inkscape:export-xdpi="17.971878"
              y="-939.74158"
              x="298.43094"
              height="477.67935"
@@ -709,7 +526,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;stroke-width:3.06308055"
-           inkscape:label="logo-guide"
            id="layer6-2">
           <g
              id="g2135"
@@ -721,9 +537,7 @@
                width="550.41602"
                id="rect5379-0"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-               inkscape:export-xdpi="22.07"
-               inkscape:export-ydpi="22.07" />
+               />
             <rect
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                id="rect5372-2"
@@ -731,9 +545,7 @@
                height="434.30405"
                x="156.12303"
                y="-933.02759"
-               inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-               inkscape:export-xdpi="212.2"
-               inkscape:export-ydpi="212.2" />
+               />
             <rect
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                id="rect5381-3"
@@ -747,7 +559,6 @@
            id="g1921"
            transform="translate(-15.554748)">
           <g
-             inkscape:label="print-logo"
              id="layer1-7"
              style="display:inline;stroke-width:3.06308055"
              transform="translate(-132.5822,958.04022)">
@@ -756,26 +567,18 @@
                id="g2106"
                transform="translate(12.257989)">
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path4861-5"
                  d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4863-9"
                  d="m 341.92005,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4865-2"
                  d="m 351.29616,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4867-2"
                  d="m 493.55397,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -783,61 +586,34 @@
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path4873-8"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 439.74719,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
                  id="use4875-9"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 449.28257,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
                  id="use4877-7"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
             </g>
             <g
                id="layer2-3"
-               inkscape:label="guides"
                style="display:none;stroke-width:3.06308055"
                transform="translate(72.039038,-1799.4476)">
               <path
                  d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-                 inkscape:randomized="0"
-                 inkscape:rounded="0"
-                 inkscape:flatsided="true"
-                 sodipodi:arg2="1.5707963"
-                 sodipodi:arg1="1.0471976"
-                 sodipodi:r2="217.25499"
-                 sodipodi:r1="250.86446"
-                 sodipodi:cy="377.47382"
-                 sodipodi:cx="335.17407"
-                 sodipodi:sides="6"
                  id="path6032-6"
                  style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                 sodipodi:type="star" />
+                 />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:type="star"
                  style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                  id="path5875-1"
-                 sodipodi:sides="6"
-                 sodipodi:cx="335.17407"
-                 sodipodi:cy="685.74158"
-                 sodipodi:r1="100.83495"
-                 sodipodi:r2="87.32563"
-                 sodipodi:arg1="1.0471976"
-                 sodipodi:arg2="1.5707963"
-                 inkscape:flatsided="true"
-                 inkscape:rounded="0"
-                 inkscape:randomized="0"
                  d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:nodetypes="ccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path5851-2"
                  d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                  style="fill:url(#linearGradient5855-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -851,19 +627,8 @@
                  transform="rotate(-30)" />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:type="star"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="path3428-3"
-                 sodipodi:sides="6"
-                 sodipodi:cx="223.93674"
-                 sodipodi:cy="878.63831"
-                 sodipodi:r1="28.048939"
-                 sodipodi:r2="24.291094"
-                 sodipodi:arg1="0"
-                 sodipodi:arg2="0.52359878"
-                 inkscape:flatsided="true"
-                 inkscape:rounded="0"
-                 inkscape:randomized="0"
                  d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
               <use
                  style="stroke-width:3.06308055"
@@ -886,7 +651,6 @@
           </g>
           <g
              id="layer3-4"
-             inkscape:label="gradient-logo"
              style="display:inline;opacity:1;stroke-width:3.06308055"
              transform="translate(-132.5822,958.04022)">
             <g
@@ -897,15 +661,12 @@
                  style="opacity:1;fill:url(#linearGradient2137);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
                  id="path3336-6-7"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <use
                  style="stroke-width:3.06308055"
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="124.43045"
-                 inkscape:transform-center-y="151.59082"
                  id="use3439-6-8"
                  transform="rotate(60,407.11155,-715.78724)"
                  width="100%"
@@ -915,8 +676,6 @@
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="-168.20651"
-                 inkscape:transform-center-y="75.573958"
                  id="use3445-0-4"
                  transform="rotate(-60,407.31177,-715.70016)"
                  width="100%"
@@ -926,15 +685,11 @@
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="59.669705"
-                 inkscape:transform-center-y="-139.94592"
                  id="use3449-5-5"
                  transform="rotate(180,407.41868,-715.7565)"
                  width="100%"
                  height="100%" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path4260-0-0"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2139);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -962,7 +717,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            id="g5329-1"
-           inkscape:label="text-vegur"
            style="display:inline;stroke-width:3.06308055">
           <g
              transform="matrix(0.73707048,0,0,0.73707048,81.93134,-100.17742)"
@@ -977,17 +731,17 @@
                  d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4683-6"
-                 inkscape:connector-curvature="0" />
+                 />
               <path
                  d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4685-3"
-                 inkscape:connector-curvature="0" />
+                 />
               <path
                  d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4687-2"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
             <g
                aria-label="O"
@@ -998,7 +752,7 @@
                  d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4680-6"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
             <g
                aria-label="S"
@@ -1009,16 +763,14 @@
                  d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4677-5"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
           </g>
         </g>
       </g>
     </g>
     <g
-       inkscape:groupmode="layer"
        id="layer11"
-       inkscape:label="bg"
        style="display:inline;opacity:0.05">
       <g
          style="display:inline;opacity:1;stroke-width:0.6689831"
@@ -1027,7 +779,6 @@
         <g
            transform="translate(-23.75651,-24.84972)"
            style="display:none;stroke-width:0.6689831"
-           inkscape:label="bg"
            id="layer7-7">
           <rect
              y="-957.77832"
@@ -1041,12 +792,8 @@
         <g
            transform="translate(-156.33871,933.1905)"
            style="display:none;stroke-width:0.6689831"
-           inkscape:label="logo-guide"
            id="layer6-7">
           <rect
-             inkscape:export-ydpi="22.07"
-             inkscape:export-xdpi="22.07"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect5379-3"
              width="550.41602"
@@ -1054,9 +801,6 @@
              x="132.65129"
              y="-958.02759" />
           <rect
-             inkscape:export-ydpi="212.2"
-             inkscape:export-xdpi="212.2"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
              y="-933.02759"
              x="156.12303"
              height="434.30405"
@@ -1075,28 +819,20 @@
            transform="translate(-156.33871,933.1905)"
            style="display:inline;stroke-width:0.6689831"
            id="layer1-63"
-           inkscape:label="print-logo">
+           >
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4861-9"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4863-48"
              d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4865-1"
              d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4867-29"
              d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -1104,62 +840,34 @@
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              id="path4873-3"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
              id="use4875-90"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
              id="use4877-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <g
              transform="translate(72.039038,-1799.4476)"
              style="display:none;stroke-width:0.6689831"
-             inkscape:label="guides"
              id="layer2-8">
             <path
-               sodipodi:type="star"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                id="path6032-5"
-               sodipodi:sides="6"
-               sodipodi:cx="335.17407"
-               sodipodi:cy="377.47382"
-               sodipodi:r1="250.86446"
-               sodipodi:r2="217.25499"
-               sodipodi:arg1="1.0471976"
-               sodipodi:arg2="1.5707963"
-               inkscape:flatsided="true"
-               inkscape:rounded="0"
-               inkscape:randomized="0"
                d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
             <path
                d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="1.5707963"
-               sodipodi:arg1="1.0471976"
-               sodipodi:r2="87.32563"
-               sodipodi:r1="100.83495"
-               sodipodi:cy="685.74158"
-               sodipodi:cx="335.17407"
-               sodipodi:sides="6"
                id="path5875-0"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <path
                style="fill:url(#linearGradient2490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                id="path5851-9"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccccccc"
                transform="translate(0,-308.26772)" />
             <rect
                transform="rotate(-30)"
@@ -1171,19 +879,8 @@
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.41499999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
             <path
                d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="0.52359878"
-               sodipodi:arg1="0"
-               sodipodi:r2="24.291094"
-               sodipodi:r1="28.048939"
-               sodipodi:cy="878.63831"
-               sodipodi:cx="223.93674"
-               sodipodi:sides="6"
                id="path3428-8"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <use
                height="100%"
@@ -1207,20 +904,16 @@
         <g
            transform="translate(-156.33871,933.1905)"
            style="display:inline;opacity:1;stroke-width:0.6689831"
-           inkscape:label="gradient-logo"
            id="layer3-1">
           <path
              style="opacity:1;fill:url(#linearGradient2492);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
              id="path3336-6-1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <use
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="124.43045"
-             inkscape:transform-center-y="151.59082"
              id="use3439-6-5"
              transform="rotate(60,407.11155,-715.78724)"
              width="100%"
@@ -1230,8 +923,6 @@
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="-168.20651"
-             inkscape:transform-center-y="75.573958"
              id="use3445-0-9"
              transform="rotate(-60,407.31177,-715.70016)"
              width="100%"
@@ -1241,16 +932,12 @@
              x="0"
              y="0"
              xlink:href="#path3336-6-1"
-             inkscape:transform-center-x="59.669705"
-             inkscape:transform-center-y="-139.94592"
              id="use3449-5-8"
              transform="rotate(180,407.41868,-715.7565)"
              width="100%"
              height="100%"
              style="stroke-width:0.6689831" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4260-0-4"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2494);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00694942;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -1277,11 +964,9 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer9"
-     inkscape:label="NOTES"
      style="display:inline"
-     sodipodi:insensitive="true">
+     >
     <flowRoot
        xml:space="preserve"
        id="flowRoot1086"

--- a/bootloader/refind/efi-banner.svg
+++ b/bootloader/refind/efi-banner.svg
@@ -2,28 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="300"
    height="180"
    viewBox="0 0 79.374998 47.625"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="efi-banner.svg"
-   inkscape:export-filename="/Users/samuel/Projects/nixos/nixos-artwork/bootloader/efi-banner.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <defs
      id="defs2">
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient5855"
        gradientUnits="userSpaceOnUse"
@@ -33,7 +23,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5960">
       <stop
          style="stop-color:#637ddf;stop-opacity:1"
@@ -50,7 +39,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5562"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5564"
          offset="0"
@@ -66,7 +55,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5053"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5055"
          offset="0"
@@ -81,7 +70,6 @@
          style="stop-color:#5277c3;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient5855-2"
        gradientUnits="userSpaceOnUse"
@@ -92,7 +80,7 @@
        y2="515.97058" />
     <linearGradient
        id="linearGradient5867"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5869"
          offset="0"
@@ -107,7 +95,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5867"
        id="linearGradient5855-8"
        gradientUnits="userSpaceOnUse"
@@ -117,7 +104,6 @@
        x2="282.26105"
        y2="515.97058" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient4544"
        gradientUnits="userSpaceOnUse"
@@ -155,7 +141,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5137"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="506.18814"
        x2="290.08701"
@@ -165,9 +151,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5162"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1026"
        gradientUnits="userSpaceOnUse"
@@ -177,7 +162,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1028"
        gradientUnits="userSpaceOnUse"
@@ -187,66 +171,23 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#e2e8ff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-542.76806"
-     inkscape:cy="166.57821"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     units="px"
-     inkscape:pagecheckerboard="true"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     inkscape:window-x="0"
-     inkscape:window-y="35"
-     inkscape:window-maximized="1"
-     borderlayer="true"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
   <metadata
      id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:label="Drawing"
-     inkscape:groupmode="layer"
      id="layer1"
      transform="translate(-64.690623,-225.90689)"
      style="display:inline;opacity:1">
     <g
-       inkscape:groupmode="layer"
        id="layer8"
-       inkscape:label="horizontal"
        style="display:inline"
-       sodipodi:insensitive="true">
+       >
       <g
          id="g954"
          transform="matrix(0.05238976,0,0,0.05238976,63.446024,237.02264)"
          style="display:inline;stroke-width:5.3869729">
         <g
            style="display:none;stroke-width:5.3869729"
-           inkscape:label="bg"
            id="layer7">
           <rect
              y="-957.77832"
@@ -260,7 +201,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;opacity:0.51599995;stroke-width:5.3869729"
-           inkscape:label="guide"
            id="layer5">
           <rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -270,8 +210,6 @@
              x="132.5822"
              y="-957.77832" />
           <rect
-             inkscape:export-ydpi="17.971878"
-             inkscape:export-xdpi="17.971878"
              y="-933.38721"
              x="155.77646"
              height="435.68069"
@@ -289,12 +227,8 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;stroke-width:5.3869729"
-           inkscape:label="logo-guide"
            id="layer6">
           <rect
-             inkscape:export-ydpi="22.07"
-             inkscape:export-xdpi="22.07"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect5379"
              width="550.41602"
@@ -302,9 +236,6 @@
              x="132.65129"
              y="-958.02759" />
           <rect
-             inkscape:export-ydpi="212.2"
-             inkscape:export-xdpi="212.2"
-             inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
              y="-933.02759"
              x="156.12303"
              height="434.30405"
@@ -323,28 +254,20 @@
            transform="translate(-132.5822,958.04022)"
            style="display:inline;stroke-width:5.3869729"
            id="layer1-6"
-           inkscape:label="print-logo">
+           >
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4861"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4863"
              d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4865"
              d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="use4867"
              d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -352,62 +275,34 @@
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              id="path4873"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
              id="use4875"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
              id="use4877"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <g
              transform="translate(72.039038,-1799.4476)"
              style="display:none;stroke-width:5.3869729"
-             inkscape:label="guides"
              id="layer2">
             <path
-               sodipodi:type="star"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                id="path6032"
-               sodipodi:sides="6"
-               sodipodi:cx="335.17407"
-               sodipodi:cy="377.47382"
-               sodipodi:r1="250.86446"
-               sodipodi:r2="217.25499"
-               sodipodi:arg1="1.0471976"
-               sodipodi:arg2="1.5707963"
-               inkscape:flatsided="true"
-               inkscape:rounded="0"
-               inkscape:randomized="0"
                d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
             <path
                d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="1.5707963"
-               sodipodi:arg1="1.0471976"
-               sodipodi:r2="87.32563"
-               sodipodi:r1="100.83495"
-               sodipodi:cy="685.74158"
-               sodipodi:cx="335.17407"
-               sodipodi:sides="6"
                id="path5875"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <path
                style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                id="path5851"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccccccc"
                transform="translate(0,-308.26772)" />
             <rect
                transform="rotate(-30)"
@@ -419,19 +314,8 @@
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.41499999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
             <path
                d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
-               inkscape:randomized="0"
-               inkscape:rounded="0"
-               inkscape:flatsided="true"
-               sodipodi:arg2="0.52359878"
-               sodipodi:arg1="0"
-               sodipodi:r2="24.291094"
-               sodipodi:r1="28.048939"
-               sodipodi:cy="878.63831"
-               sodipodi:cx="223.93674"
-               sodipodi:sides="6"
                id="path3428"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               sodipodi:type="star"
                transform="translate(0,-308.26772)" />
             <use
                height="100%"
@@ -455,20 +339,16 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:inline;opacity:1;stroke-width:5.3869729"
-           inkscape:label="gradient-logo"
            id="layer3">
           <path
              style="opacity:1;fill:url(#linearGradient1026);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
              id="path3336-6"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
+             />
           <use
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="124.43045"
-             inkscape:transform-center-y="151.59082"
              id="use3439-6"
              transform="rotate(60,407.11155,-715.78724)"
              width="100%"
@@ -478,8 +358,6 @@
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="-168.20651"
-             inkscape:transform-center-y="75.573958"
              id="use3445-0"
              transform="rotate(-60,407.31177,-715.70016)"
              width="100%"
@@ -489,16 +367,12 @@
              x="0"
              y="0"
              xlink:href="#path3336-6"
-             inkscape:transform-center-x="59.669705"
-             inkscape:transform-center-y="-139.94592"
              id="use3449-5"
              transform="rotate(180,407.41868,-715.7565)"
              width="100%"
              height="100%"
              style="stroke-width:5.3869729" />
           <path
-             sodipodi:nodetypes="cccccccccc"
-             inkscape:connector-curvature="0"
              id="path4260-0"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1028);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:16.16091919;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -524,7 +398,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            id="g5329"
-           inkscape:label="text-vegur"
            style="display:inline;stroke-width:5.3869729">
           <g
              id="text5407"
@@ -534,17 +407,17 @@
                id="path4683"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
-               inkscape:connector-curvature="0" />
+               />
             <path
                id="path4685"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
-               inkscape:connector-curvature="0" />
+               />
             <path
                id="path4687"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
           <g
              id="text5356"
@@ -555,7 +428,7 @@
                id="path4680"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
           <g
              id="text5364"
@@ -565,17 +438,15 @@
                id="path4677"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:5.3869729px"
                d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
-               inkscape:connector-curvature="0" />
+               />
           </g>
         </g>
       </g>
     </g>
     <g
-       inkscape:groupmode="layer"
        id="layer10"
-       inkscape:label="Vertical"
        style="display:none"
-       sodipodi:insensitive="true">
+       >
       <g
          id="g1648"
          transform="matrix(0.06574718,0,0,0.06574718,87.302111,225.78971)"
@@ -583,7 +454,6 @@
         <g
            transform="matrix(0.62033955,0,0,1.4127351,-265.36433,1353.3489)"
            style="display:none;opacity:0.51599995;stroke-width:3.06308055"
-           inkscape:label="guide"
            id="layer5-1">
           <rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -593,8 +463,6 @@
              x="259.18103"
              y="-957.77832" />
           <rect
-             inkscape:export-ydpi="17.971878"
-             inkscape:export-xdpi="17.971878"
              y="-939.74158"
              x="298.43094"
              height="477.67935"
@@ -612,7 +480,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            style="display:none;stroke-width:3.06308055"
-           inkscape:label="logo-guide"
            id="layer6-2">
           <g
              id="g2135"
@@ -624,9 +491,7 @@
                width="550.41602"
                id="rect5379-0"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-               inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-               inkscape:export-xdpi="22.07"
-               inkscape:export-ydpi="22.07" />
+               />
             <rect
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                id="rect5372-2"
@@ -634,9 +499,7 @@
                height="434.30405"
                x="156.12303"
                y="-933.02759"
-               inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-               inkscape:export-xdpi="212.2"
-               inkscape:export-ydpi="212.2" />
+               />
             <rect
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                id="rect5381-3"
@@ -650,7 +513,6 @@
            id="g1921"
            transform="translate(-15.554748)">
           <g
-             inkscape:label="print-logo"
              id="layer1-7"
              style="display:inline;stroke-width:3.06308055"
              transform="translate(-132.5822,958.04022)">
@@ -659,26 +521,18 @@
                id="g2106"
                transform="translate(12.257989)">
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path4861-5"
                  d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4863-9"
                  d="m 341.92005,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4865-2"
                  d="m 351.29616,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="use4867-2"
                  d="m 493.55397,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -686,61 +540,34 @@
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path4873-8"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 439.74719,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
                  id="use4875-9"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 449.28257,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
                  id="use4877-7"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
             </g>
             <g
                id="layer2-3"
-               inkscape:label="guides"
                style="display:none;stroke-width:3.06308055"
                transform="translate(72.039038,-1799.4476)">
               <path
                  d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-                 inkscape:randomized="0"
-                 inkscape:rounded="0"
-                 inkscape:flatsided="true"
-                 sodipodi:arg2="1.5707963"
-                 sodipodi:arg1="1.0471976"
-                 sodipodi:r2="217.25499"
-                 sodipodi:r1="250.86446"
-                 sodipodi:cy="377.47382"
-                 sodipodi:cx="335.17407"
-                 sodipodi:sides="6"
                  id="path6032-6"
                  style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                 sodipodi:type="star" />
+                 />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:type="star"
                  style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                  id="path5875-1"
-                 sodipodi:sides="6"
-                 sodipodi:cx="335.17407"
-                 sodipodi:cy="685.74158"
-                 sodipodi:r1="100.83495"
-                 sodipodi:r2="87.32563"
-                 sodipodi:arg1="1.0471976"
-                 sodipodi:arg2="1.5707963"
-                 inkscape:flatsided="true"
-                 inkscape:rounded="0"
-                 inkscape:randomized="0"
                  d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:nodetypes="ccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path5851-2"
                  d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                  style="fill:url(#linearGradient5855-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -754,19 +581,8 @@
                  transform="rotate(-30)" />
               <path
                  transform="translate(0,-308.26772)"
-                 sodipodi:type="star"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="path3428-3"
-                 sodipodi:sides="6"
-                 sodipodi:cx="223.93674"
-                 sodipodi:cy="878.63831"
-                 sodipodi:r1="28.048939"
-                 sodipodi:r2="24.291094"
-                 sodipodi:arg1="0"
-                 sodipodi:arg2="0.52359878"
-                 inkscape:flatsided="true"
-                 inkscape:rounded="0"
-                 inkscape:randomized="0"
                  d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
               <use
                  style="stroke-width:3.06308055"
@@ -789,7 +605,6 @@
           </g>
           <g
              id="layer3-4"
-             inkscape:label="gradient-logo"
              style="display:inline;opacity:1;stroke-width:3.06308055"
              transform="translate(-132.5822,958.04022)">
             <g
@@ -800,15 +615,12 @@
                  style="opacity:1;fill:url(#linearGradient2137);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
                  id="path3336-6-7"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
+                 />
               <use
                  style="stroke-width:3.06308055"
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="124.43045"
-                 inkscape:transform-center-y="151.59082"
                  id="use3439-6-8"
                  transform="rotate(60,407.11155,-715.78724)"
                  width="100%"
@@ -818,8 +630,6 @@
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="-168.20651"
-                 inkscape:transform-center-y="75.573958"
                  id="use3445-0-4"
                  transform="rotate(-60,407.31177,-715.70016)"
                  width="100%"
@@ -829,15 +639,11 @@
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
-                 inkscape:transform-center-x="59.669705"
-                 inkscape:transform-center-y="-139.94592"
                  id="use3449-5-5"
                  transform="rotate(180,407.41868,-715.7565)"
                  width="100%"
                  height="100%" />
               <path
-                 sodipodi:nodetypes="cccccccccc"
-                 inkscape:connector-curvature="0"
                  id="path4260-0-0"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2139);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.18924141;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -865,7 +671,6 @@
         <g
            transform="translate(-132.5822,958.04022)"
            id="g5329-1"
-           inkscape:label="text-vegur"
            style="display:inline;stroke-width:3.06308055">
           <g
              transform="matrix(0.73707048,0,0,0.73707048,81.93134,-100.17742)"
@@ -880,17 +685,17 @@
                  d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4683-6"
-                 inkscape:connector-curvature="0" />
+                 />
               <path
                  d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4685-3"
-                 inkscape:connector-curvature="0" />
+                 />
               <path
                  d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4687-2"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
             <g
                aria-label="O"
@@ -901,7 +706,7 @@
                  d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4680-6"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
             <g
                aria-label="S"
@@ -912,7 +717,7 @@
                  d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur;stroke-width:3.06308055px"
                  id="path4677-5"
-                 inkscape:connector-curvature="0" />
+                 />
             </g>
           </g>
         </g>

--- a/bootloader/refind/icons/func_about.svg
+++ b/bootloader/refind/icons/func_about.svg
@@ -1,58 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 32 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="func_about.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    width="32"
    height="32"
-   inkscape:export-filename="/Users/samuel/tmp/nixos.wiki/breeze-icons/mine/help-about@32.svg.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1276"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="14.420963"
-     inkscape:cy="7.6256149"
-     inkscape:window-x="0"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg5">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4770" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -75,13 +33,11 @@
      d="m 15,9 v 2 h 2 V 9 Z m 0,5 v 9 h 2 v -9 z"
      id="path55"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccc" />
+     />
   <path
      id="path816-7"
      class="ColorScheme-Text"
      d="M 16,4 C 9.372583,4 4,9.372583 4,16 4,22.627417 9.372583,28 16,28 22.627417,28 28,22.627417 28,16 28,9.372583 22.627417,4 16,4 Z m 0,1 C 22.075132,5 27,9.924868 27,16 27,22.075132 22.075132,27 16,27 9.924868,27 5,22.075132 5,16 5,9.924868 9.924868,5 16,5 Z"
      style="color:#4d4d4d;fill:currentColor;fill-opacity:1;stroke:none"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ssssssssss" />
+     />
 </svg>

--- a/bootloader/refind/icons/os_nixos.svg
+++ b/bootloader/refind/icons/os_nixos.svg
@@ -2,25 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="128"
    height="128"
    viewBox="0 0 120 119.99999"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="os_nixos.svg">
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5562">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -36,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5053">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -53,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -68,7 +60,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5867">
       <stop
          style="stop-color:#7363df;stop-opacity:1"
@@ -92,7 +83,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="515.97058"
        x2="282.26105"
@@ -102,7 +93,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855-8"
        xlink:href="#linearGradient5867"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="247.58188"
        x2="-702.75317"
@@ -112,7 +103,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient4544"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <clipPath
        id="clipPath4501"
        clipPathUnits="userSpaceOnUse">
@@ -134,7 +125,6 @@
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </clipPath>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5137"
        gradientUnits="userSpaceOnUse"
@@ -144,7 +134,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5147"
        gradientUnits="userSpaceOnUse"
@@ -154,7 +143,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5162"
        gradientUnits="userSpaceOnUse"
@@ -164,7 +152,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5172"
        gradientUnits="userSpaceOnUse"
@@ -174,7 +161,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5182"
        gradientUnits="userSpaceOnUse"
@@ -192,7 +178,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5201"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="937.71399"
        x2="-496.29703"
@@ -202,9 +188,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5205"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient918"
        gradientUnits="userSpaceOnUse"
@@ -214,7 +199,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient920"
        gradientUnits="userSpaceOnUse"
@@ -224,50 +208,11 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="86.586001"
-     inkscape:cy="49.692226"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     units="px">
-    <inkscape:grid
-       type="xygrid"
-       id="grid922" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer7"
-     inkscape:label="bg"
      style="display:none"
      transform="translate(-23.75651,-339.99003)">
     <rect
@@ -280,9 +225,7 @@
        y="-957.77832" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="logo-guide"
      style="display:none"
      transform="translate(-156.33871,618.0502)">
     <rect
@@ -292,9 +235,7 @@
        width="550.41602"
        id="rect5379"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-       inkscape:export-xdpi="22.07"
-       inkscape:export-ydpi="22.07" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5372"
@@ -302,9 +243,7 @@
        height="434.30405"
        x="156.12303"
        y="-933.02759"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-       inkscape:export-xdpi="212.2"
-       inkscape:export-ydpi="212.2" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5381"
@@ -314,8 +253,6 @@
        y="-958.04022" />
   </g>
   <g
-     inkscape:label="print-logo"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:none"
      transform="translate(-156.33871,618.0502)">
@@ -323,84 +260,50 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        id="path4861"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
        id="use4863"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
        id="use4865"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
        id="use4867"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path4873"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4875"
        d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4877"
        d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <g
        id="layer2"
-       inkscape:label="guides"
        style="display:none"
        transform="translate(72.039038,-1799.4476)">
       <path
          d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="1.5707963"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="217.25499"
-         sodipodi:r1="250.86446"
-         sodipodi:cy="377.47382"
-         sodipodi:cx="335.17407"
-         sodipodi:sides="6"
          id="path6032"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="path5875"
-         sodipodi:sides="6"
-         sodipodi:cx="335.17407"
-         sodipodi:cy="685.74158"
-         sodipodi:r1="100.83495"
-         sodipodi:r2="87.32563"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="1.5707963"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
          id="path5851"
          d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
          style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -414,19 +317,8 @@
          transform="rotate(-30)" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="path3428"
-         sodipodi:sides="6"
-         sodipodi:cx="223.93674"
-         sodipodi:cy="878.63831"
-         sodipodi:r1="28.048939"
-         sodipodi:r2="24.291094"
-         sodipodi:arg1="0"
-         sodipodi:arg2="0.52359878"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
@@ -447,9 +339,7 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
      transform="translate(-156.33871,618.0502)">
     <g
@@ -460,14 +350,11 @@
          style="opacity:1;fill:url(#linearGradient918);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:12.54219723;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
          id="path3336-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         />
       <use
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="124.43045"
-         inkscape:transform-center-y="151.59082"
          id="use3439-6"
          transform="rotate(60,407.11155,-715.78724)"
          width="100%"
@@ -477,8 +364,6 @@
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="-168.20651"
-         inkscape:transform-center-y="75.573958"
          id="use3445-0"
          transform="rotate(-60,407.31177,-715.70016)"
          width="100%"
@@ -488,16 +373,12 @@
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="59.669705"
-         inkscape:transform-center-y="-139.94592"
          id="use3449-5"
          transform="rotate(180,407.41868,-715.7565)"
          width="100%"
          height="100%"
          style="stroke-width:4.18073225" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="path4260-0"
          d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient920);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:12.54219723;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />

--- a/bootloader/refind/icons/os_unknown.svg
+++ b/bootloader/refind/icons/os_unknown.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="0 0 128 128">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
   <defs id="defs3051">
     <style type="text/css" id="current-color-scheme">
       .ColorScheme-Text {
@@ -10,7 +10,7 @@
       </style>
     <linearGradient
        id="linearGradient4213"
-       inkscape:collect="always">
+       >
       <stop
          id="stop4215"
          offset="0"
@@ -21,7 +21,6 @@
          style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4213"
        id="linearGradient6632"
        gradientUnits="userSpaceOnUse"

--- a/bootloader/refind/icons/tool_shell.svg
+++ b/bootloader/refind/icons/tool_shell.svg
@@ -1,52 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 32 32"
    version="1.1"
    id="svg5"
-   sodipodi:docname="tool_shell.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   >
   <metadata
      id="metadata9">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     id="namedview7"
-     showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="7.6079746"
-     inkscape:cy="14.120811"
-     inkscape:window-x="0"
-     inkscape:window-y="35"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5">
-    <inkscape:grid
-       type="xygrid"
-       id="grid849" />
-  </sodipodi:namedview>
+    </metadata>
   <defs
      id="defs3051">
     <style
@@ -62,28 +24,22 @@
      d="M 4,4 V 28 H 28 V 4 Z M 5,9 H 27 V 27 H 5 Z"
      id="path18"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccc" />
+     />
   <path
      style="color:#4d4d4d;fill:currentColor;fill-opacity:1;stroke:none;stroke-width:1"
      d="m 11,24 v 1 h 11 v -1 z"
      id="path18-3"
      class="ColorScheme-Text"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     />
   <g
      id="g868"
      transform="translate(26.314425,9.912818)">
     <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
        class="ColorScheme-Text"
        id="path18-3-6"
        d="m -18.314425,14.551284 0.866026,0.5 2,-3.464102 -0.866026,-0.5 z"
        style="color:#4d4d4d;fill:currentColor;fill-opacity:1;stroke:none" />
     <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
        class="ColorScheme-Text"
        id="path18-3-6-7"
        d="m -17.448399,8.1230802 -0.866026,0.5000001 2,3.4641017 0.866026,-0.5 z"

--- a/bootloader/refind/selection_big.svg
+++ b/bootloader/refind/selection_big.svg
@@ -2,23 +2,14 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="144"
    height="144"
    viewBox="0 0 38.099999 38.100001"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="selection_big.svg"
-   inkscape:export-filename="/Users/samuel/Projects/nixos/nixos-artwork/bootloader/selection_big.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <defs
      id="defs2">
     <style
@@ -29,43 +20,10 @@
       }
       </style>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="4.9153742"
-     inkscape:cx="-45.475034"
-     inkscape:cy="41.48689"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     units="px"
-     inkscape:pagecheckerboard="true"
-     borderlayer="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="1276"
-     inkscape:window-height="1401"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-258.89998)">
     <rect

--- a/bootloader/refind/selection_small.svg
+++ b/bootloader/refind/selection_small.svg
@@ -2,23 +2,14 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="42"
    height="42"
    viewBox="0 0 11.1125 11.1125"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="selection_small.svg"
-   inkscape:export-filename="/Users/samuel/Projects/nixos/nixos-artwork/bootloader/selection_small.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
+   >
   <defs
      id="defs2">
     <style
@@ -29,47 +20,10 @@
       }
       </style>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="4"
-     inkscape:cx="-6.903429"
-     inkscape:cy="51.483484"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     units="px"
-     inkscape:pagecheckerboard="true"
-     borderlayer="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="1276"
-     inkscape:window-height="1401"
-     inkscape:window-x="2560"
-     inkscape:window-y="35"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4556" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-285.88748)">
     <rect

--- a/logo/nix-snowflake.svg
+++ b/logo/nix-snowflake.svg
@@ -2,25 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="141.5919mm"
    height="122.80626mm"
    viewBox="0 0 501.70361 435.14028"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.0 r15299"
-   sodipodi:docname="nix-snowflake.svg">
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5562">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -36,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5053">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -53,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -68,7 +60,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5867">
       <stop
          style="stop-color:#7363df;stop-opacity:1"
@@ -92,7 +83,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="515.97058"
        x2="282.26105"
@@ -102,7 +93,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855-8"
        xlink:href="#linearGradient5867"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="247.58188"
        x2="-702.75317"
@@ -112,7 +103,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient4544"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <clipPath
        id="clipPath4501"
        clipPathUnits="userSpaceOnUse">
@@ -134,7 +125,6 @@
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </clipPath>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5137"
        gradientUnits="userSpaceOnUse"
@@ -144,7 +134,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5147"
        gradientUnits="userSpaceOnUse"
@@ -154,7 +143,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5162"
        gradientUnits="userSpaceOnUse"
@@ -164,7 +152,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5172"
        gradientUnits="userSpaceOnUse"
@@ -174,7 +161,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5182"
        gradientUnits="userSpaceOnUse"
@@ -192,7 +178,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5201"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="937.71399"
        x2="-496.29703"
@@ -202,9 +188,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5205"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient4328"
        gradientUnits="userSpaceOnUse"
@@ -214,7 +199,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient4330"
        gradientUnits="userSpaceOnUse"
@@ -224,45 +208,11 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.98318225"
-     inkscape:cx="113.58176"
-     inkscape:cy="-45.193301"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="2560"
-     inkscape:window-height="1577"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer7"
-     inkscape:label="bg"
      style="display:none"
      transform="translate(-23.75651,-24.84972)">
     <rect
@@ -275,9 +225,7 @@
        y="-957.77832" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="logo-guide"
      style="display:none"
      transform="translate(-156.33871,933.1905)">
     <rect
@@ -287,9 +235,7 @@
        width="550.41602"
        id="rect5379"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-       inkscape:export-xdpi="22.07"
-       inkscape:export-ydpi="22.07" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5372"
@@ -297,9 +243,7 @@
        height="434.30405"
        x="156.12303"
        y="-933.02759"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-       inkscape:export-xdpi="212.2"
-       inkscape:export-ydpi="212.2" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5381"
@@ -309,94 +253,58 @@
        y="-958.04022" />
   </g>
   <g
-     inkscape:label="print-logo"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
      transform="translate(-156.33871,933.1905)"
-     sodipodi:insensitive="true">
+     >
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        id="path4861"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
        id="use4863"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
        id="use4865"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
        id="use4867"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path4873"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4875"
        d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4877"
        d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <g
        id="layer2"
-       inkscape:label="guides"
        style="display:none"
        transform="translate(72.039038,-1799.4476)">
       <path
          d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="1.5707963"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="217.25499"
-         sodipodi:r1="250.86446"
-         sodipodi:cy="377.47382"
-         sodipodi:cx="335.17407"
-         sodipodi:sides="6"
          id="path6032"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="path5875"
-         sodipodi:sides="6"
-         sodipodi:cx="335.17407"
-         sodipodi:cy="685.74158"
-         sodipodi:r1="100.83495"
-         sodipodi:r2="87.32563"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="1.5707963"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
          id="path5851"
          d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
          style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -410,19 +318,8 @@
          transform="rotate(-30)" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="path3428"
-         sodipodi:sides="6"
-         sodipodi:cx="223.93674"
-         sodipodi:cy="878.63831"
-         sodipodi:r1="28.048939"
-         sodipodi:r2="24.291094"
-         sodipodi:arg1="0"
-         sodipodi:arg2="0.52359878"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
@@ -443,15 +340,10 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
-     sodipodi:insensitive="true"
      transform="translate(-156.33871,933.1905)">
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path3336-6"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
        style="opacity:1;fill:url(#linearGradient4328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -460,8 +352,6 @@
        width="100%"
        transform="rotate(60,407.11155,-715.78724)"
        id="use3439-6"
-       inkscape:transform-center-y="151.59082"
-       inkscape:transform-center-x="124.43045"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -470,8 +360,6 @@
        width="100%"
        transform="rotate(-60,407.31177,-715.70016)"
        id="use3445-0"
-       inkscape:transform-center-y="75.573958"
-       inkscape:transform-center-x="-168.20651"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -480,8 +368,6 @@
        width="100%"
        transform="rotate(180,407.41868,-715.7565)"
        id="use3449-5"
-       inkscape:transform-center-y="-139.94592"
-       inkscape:transform-center-x="59.669705"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -489,8 +375,7 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4330);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
        id="path4260-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <use
        height="100%"
        width="100%"

--- a/logo/nixos-text-below.svg
+++ b/logo/nixos-text-below.svg
@@ -2,28 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="147mm"
    height="145mm"
    viewBox="-105 0 727 720"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="nixos-text-below.svg"
-   inkscape:export-filename="/Users/wmertens/Desktop/nixos-text-below.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5562">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -39,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5053">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -56,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -79,9 +68,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5384"
        gradientUnits="userSpaceOnUse"
@@ -91,7 +79,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5386"
        gradientUnits="userSpaceOnUse"
@@ -101,48 +88,14 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.84644711"
-     inkscape:cx="273.39215"
-     inkscape:cy="271.31279"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer5"
-     showgrid="false"
-     inkscape:window-width="1651"
-     inkscape:window-height="1005"
-     inkscape:window-x="29"
-     inkscape:window-y="1"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer5"
-     inkscape:label="guide"
      style="display:none;opacity:0.51599995"
      transform="matrix(0.62033955,0,0,1.4127351,-265.36433,1353.3489)"
-     sodipodi:insensitive="true">
+     >
     <rect
        y="-957.77832"
        x="259.18103"
@@ -157,8 +110,7 @@
        height="477.67935"
        x="298.43094"
        y="-939.74158"
-       inkscape:export-xdpi="17.971878"
-       inkscape:export-ydpi="17.971878" />
+       />
     <rect
        y="-943.83441"
        x="452.18167"
@@ -168,18 +120,13 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="logo-guide"
      style="display:none"
      transform="translate(-132.5822,958.04022)"
-     sodipodi:insensitive="true">
+     >
     <g
        id="g2135">
       <rect
-         inkscape:export-ydpi="22.07"
-         inkscape:export-xdpi="22.07"
-         inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="rect5379"
          width="550.41602"
@@ -187,9 +134,6 @@
          x="132.65129"
          y="-958.02759" />
       <rect
-         inkscape:export-ydpi="212.2"
-         inkscape:export-xdpi="212.2"
-         inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
          y="-933.02759"
          x="156.12303"
          height="434.30405"
@@ -206,8 +150,6 @@
     </g>
   </g>
   <g
-     inkscape:label="print-logo"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
      transform="translate(-132.5822,958.04022)">
@@ -215,26 +157,18 @@
        id="g2106"
        transform="translate(12.257989)">
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="path4861"
          d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="use4863"
          d="m 341.92005,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="use4865"
          d="m 351.29616,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="use4867"
          d="m 493.55397,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -242,61 +176,34 @@
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 297.81444,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
          id="path4873"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         />
       <path
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 439.74719,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
          id="use4875"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         />
       <path
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 449.28257,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
          id="use4877"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         />
     </g>
     <g
        id="layer2"
-       inkscape:label="guides"
        style="display:none"
        transform="translate(72.039038,-1799.4476)">
       <path
          d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="1.5707963"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="217.25499"
-         sodipodi:r1="250.86446"
-         sodipodi:cy="377.47382"
-         sodipodi:cx="335.17407"
-         sodipodi:sides="6"
          id="path6032"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="path5875"
-         sodipodi:sides="6"
-         sodipodi:cx="335.17407"
-         sodipodi:cy="685.74158"
-         sodipodi:r1="100.83495"
-         sodipodi:r2="87.32563"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="1.5707963"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
          id="path5851"
          d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
          style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -310,19 +217,8 @@
          transform="rotate(-30)" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="path3428"
-         sodipodi:sides="6"
-         sodipodi:cx="223.93674"
-         sodipodi:cy="878.63831"
-         sodipodi:r1="28.048939"
-         sodipodi:r2="24.291094"
-         sodipodi:arg1="0"
-         sodipodi:arg2="0.52359878"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
@@ -343,9 +239,7 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
      transform="translate(-132.5822,958.04022)">
     <g
@@ -355,14 +249,11 @@
          style="opacity:1;fill:url(#linearGradient2137);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
          id="path3336-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         />
       <use
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="124.43045"
-         inkscape:transform-center-y="151.59082"
          id="use3439-6"
          transform="rotate(60,407.11155,-715.78724)"
          width="100%"
@@ -371,8 +262,6 @@
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="-168.20651"
-         inkscape:transform-center-y="75.573958"
          id="use3445-0"
          transform="rotate(-60,407.31177,-715.70016)"
          width="100%"
@@ -381,15 +270,11 @@
          x="0"
          y="0"
          xlink:href="#path3336-6"
-         inkscape:transform-center-x="59.669705"
-         inkscape:transform-center-y="-139.94592"
          id="use3449-5"
          transform="rotate(180,407.41868,-715.7565)"
          width="100%"
          height="100%" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="path4260-0"
          d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2139);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
@@ -415,11 +300,9 @@
   </g>
   <g
      style="display:inline"
-     inkscape:label="text-vegur"
      id="g5329"
-     inkscape:groupmode="layer"
      transform="translate(-132.5822,958.04022)"
-     sodipodi:insensitive="true">
+     >
     <g
        id="g11451"
        transform="matrix(0.73707048,0,0,0.73707048,81.93134,-100.17742)">
@@ -429,17 +312,14 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          aria-label="Nix">
         <path
-           inkscape:connector-curvature="0"
            id="path4683"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
            d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z" />
         <path
-           inkscape:connector-curvature="0"
            id="path4685"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
            d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z" />
         <path
-           inkscape:connector-curvature="0"
            id="path4687"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
            d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z" />
@@ -450,7 +330,6 @@
          transform="matrix(0.95067318,0,0,1.0518862,-792.12753,362.72047)"
          aria-label="O">
         <path
-           inkscape:connector-curvature="0"
            id="path4680"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
            d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z" />
@@ -461,7 +340,6 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:386.55480957px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          aria-label="S">
         <path
-           inkscape:connector-curvature="0"
            id="path4677"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
            d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z" />

--- a/logo/nixos.svg
+++ b/logo/nixos.svg
@@ -2,25 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="435.58978mm"
    height="136.68491mm"
    viewBox="0 0 1543.4284 484.31659"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.0 r15299"
-   sodipodi:docname="nixos-hex.svg">
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5562">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -36,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5053">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -53,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -76,9 +68,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5384"
        gradientUnits="userSpaceOnUse"
@@ -88,7 +79,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5386"
        gradientUnits="userSpaceOnUse"
@@ -98,45 +88,11 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.34760742"
-     inkscape:cx="803.54996"
-     inkscape:cy="186.45699"
-     inkscape:document-units="px"
-     inkscape:current-layer="g5329"
-     showgrid="false"
-     inkscape:window-width="1366"
-     inkscape:window-height="706"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer7"
-     inkscape:label="bg"
      style="display:none">
     <rect
        transform="translate(-132.5822,958.04022)"
@@ -148,9 +104,7 @@
        y="-957.77832" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer5"
-     inkscape:label="guide"
      style="display:none;opacity:0.51599995"
      transform="translate(-132.5822,958.04022)">
     <rect
@@ -167,8 +121,7 @@
        height="435.68069"
        x="155.77646"
        y="-933.38721"
-       inkscape:export-xdpi="17.971878"
-       inkscape:export-ydpi="17.971878" />
+       />
     <rect
        y="-851.65918"
        x="159.02695"
@@ -178,9 +131,7 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="logo-guide"
      style="display:none"
      transform="translate(-132.5822,958.04022)">
     <rect
@@ -190,9 +141,7 @@
        width="550.41602"
        id="rect5379"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-       inkscape:export-xdpi="22.07"
-       inkscape:export-ydpi="22.07" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5372"
@@ -200,9 +149,7 @@
        height="434.30405"
        x="156.12303"
        y="-933.02759"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-       inkscape:export-xdpi="212.2"
-       inkscape:export-ydpi="212.2" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5381"
@@ -212,94 +159,57 @@
        y="-958.04022" />
   </g>
   <g
-     inkscape:label="print-logo"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
-     sodipodi:insensitive="true"
      transform="translate(-132.5822,958.04022)">
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        id="path4861"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
        id="use4863"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
        id="use4865"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
        id="use4867"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path4873"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4875"
        d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4877"
        d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <g
        id="layer2"
-       inkscape:label="guides"
        style="display:none"
        transform="translate(72.039038,-1799.4476)">
       <path
          d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="1.5707963"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="217.25499"
-         sodipodi:r1="250.86446"
-         sodipodi:cy="377.47382"
-         sodipodi:cx="335.17407"
-         sodipodi:sides="6"
          id="path6032"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="path5875"
-         sodipodi:sides="6"
-         sodipodi:cx="335.17407"
-         sodipodi:cy="685.74158"
-         sodipodi:r1="100.83495"
-         sodipodi:r2="87.32563"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="1.5707963"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
          id="path5851"
          d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
          style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -313,19 +223,8 @@
          transform="matrix(0.8660254,-0.5,0.5,0.8660254,0,0)" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="path3428"
-         sodipodi:sides="6"
-         sodipodi:cx="223.93674"
-         sodipodi:cy="878.63831"
-         sodipodi:r1="28.048939"
-         sodipodi:r2="24.291094"
-         sodipodi:arg1="0"
-         sodipodi:arg2="0.52359878"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
@@ -346,15 +245,10 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
-     sodipodi:insensitive="true"
      transform="translate(-132.5822,958.04022)">
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path3336-6"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
        style="opacity:1;fill:url(#linearGradient5384);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -363,8 +257,6 @@
        width="100%"
        transform="rotate(60,407.11155,-715.78724)"
        id="use3439-6"
-       inkscape:transform-center-y="151.59082"
-       inkscape:transform-center-x="124.43045"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -373,8 +265,6 @@
        width="100%"
        transform="rotate(-60,407.31177,-715.70016)"
        id="use3445-0"
-       inkscape:transform-center-y="75.573958"
-       inkscape:transform-center-x="-168.20651"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -383,8 +273,6 @@
        width="100%"
        transform="rotate(180,407.41868,-715.7565)"
        id="use3449-5"
-       inkscape:transform-center-y="-139.94592"
-       inkscape:transform-center-x="59.669705"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -392,8 +280,7 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5386);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
        id="path4260-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <use
        height="100%"
        width="100%"
@@ -415,9 +302,7 @@
   </g>
   <g
      style="display:inline"
-     inkscape:label="text-vegur"
      id="g5329"
-     inkscape:groupmode="layer"
      transform="translate(-132.5822,958.04022)">
     <g
        aria-label="Nix"

--- a/logo/nixos.text.svg
+++ b/logo/nixos.text.svg
@@ -2,25 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="435.58978mm"
    height="136.68491mm"
    viewBox="0 0 1543.4284 484.31659"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="nixos.text.svg">
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5562">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -36,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5053">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -53,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -76,9 +68,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5384"
        gradientUnits="userSpaceOnUse"
@@ -88,7 +79,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5386"
        gradientUnits="userSpaceOnUse"
@@ -98,51 +88,11 @@
        x2="-496.29703"
        y2="937.71399" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="746.50859"
-     inkscape:cy="165.55189"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:window-width="2556"
-     inkscape:window-height="1401"
-     inkscape:window-x="0"
-     inkscape:window-y="603"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid883" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer7"
-     inkscape:label="bg"
      style="display:none">
     <rect
        transform="translate(-132.5822,958.04022)"
@@ -154,9 +104,7 @@
        y="-957.77832" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer5"
-     inkscape:label="guide"
      style="display:none;opacity:0.51599995"
      transform="translate(-132.5822,958.04022)">
     <rect
@@ -173,8 +121,7 @@
        height="435.68069"
        x="155.77646"
        y="-933.38721"
-       inkscape:export-xdpi="17.971878"
-       inkscape:export-ydpi="17.971878" />
+       />
     <rect
        y="-851.65918"
        x="159.02695"
@@ -184,9 +131,7 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="logo-guide"
      style="display:none"
      transform="translate(-132.5822,958.04022)">
     <rect
@@ -196,9 +141,7 @@
        width="550.41602"
        id="rect5379"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
-       inkscape:export-xdpi="22.07"
-       inkscape:export-ydpi="22.07" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5372"
@@ -206,9 +149,7 @@
        height="434.30405"
        x="156.12303"
        y="-933.02759"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
-       inkscape:export-xdpi="212.2"
-       inkscape:export-ydpi="212.2" />
+       />
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5381"
@@ -218,94 +159,57 @@
        y="-958.04022" />
   </g>
   <g
-     inkscape:label="print-logo"
-     inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
-     sodipodi:insensitive="true"
      transform="translate(-132.5822,958.04022)">
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        id="path4861"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
        id="use4863"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
        id="use4865"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
        id="use4867"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path4873"
        d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4875"
        d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="use4877"
        d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <g
        id="layer2"
-       inkscape:label="guides"
        style="display:none"
        transform="translate(72.039038,-1799.4476)">
       <path
          d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="1.5707963"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="217.25499"
-         sodipodi:r1="250.86446"
-         sodipodi:cy="377.47382"
-         sodipodi:cx="335.17407"
-         sodipodi:sides="6"
          id="path6032"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.23600003;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="path5875"
-         sodipodi:sides="6"
-         sodipodi:cx="335.17407"
-         sodipodi:cy="685.74158"
-         sodipodi:r1="100.83495"
-         sodipodi:r2="87.32563"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="1.5707963"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
          id="path5851"
          d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
          style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -319,19 +223,8 @@
          transform="matrix(0.8660254,-0.5,0.5,0.8660254,0,0)" />
       <path
          transform="translate(0,-308.26772)"
-         sodipodi:type="star"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.50899999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="path3428"
-         sodipodi:sides="6"
-         sodipodi:cx="223.93674"
-         sodipodi:cy="878.63831"
-         sodipodi:r1="28.048939"
-         sodipodi:r2="24.291094"
-         sodipodi:arg1="0"
-         sodipodi:arg2="0.52359878"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
          d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
@@ -352,15 +245,10 @@
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
-     sodipodi:insensitive="true"
      transform="translate(-132.5822,958.04022)">
     <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
        id="path3336-6"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
        style="opacity:1;fill:url(#linearGradient5384);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -369,8 +257,6 @@
        width="100%"
        transform="rotate(60,407.11155,-715.78724)"
        id="use3439-6"
-       inkscape:transform-center-y="151.59082"
-       inkscape:transform-center-x="124.43045"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -379,8 +265,6 @@
        width="100%"
        transform="rotate(-60,407.31177,-715.70016)"
        id="use3445-0"
-       inkscape:transform-center-y="75.573958"
-       inkscape:transform-center-x="-168.20651"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -389,8 +273,6 @@
        width="100%"
        transform="rotate(180,407.41868,-715.7565)"
        id="use3449-5"
-       inkscape:transform-center-y="-139.94592"
-       inkscape:transform-center-x="59.669705"
        xlink:href="#path3336-6"
        y="0"
        x="0" />
@@ -398,8 +280,7 @@
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5386);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
        id="path4260-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+       />
     <use
        height="100%"
        width="100%"
@@ -421,11 +302,9 @@
   </g>
   <g
      style="display:none"
-     inkscape:label="text--baked-in"
      id="g5329"
-     inkscape:groupmode="layer"
      transform="translate(-132.5822,958.04022)"
-     sodipodi:insensitive="true">
+     >
     <g
        aria-label="Nix"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -433,15 +312,15 @@
       <path
          d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
          id="path4683"
-         inkscape:connector-curvature="0" />
+         />
       <path
          d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
          id="path4685"
-         inkscape:connector-curvature="0" />
+         />
       <path
          d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
          id="path4687"
-         inkscape:connector-curvature="0" />
+         />
     </g>
     <g
        aria-label="O"
@@ -451,7 +330,7 @@
       <path
          d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
          id="path4680"
-         inkscape:connector-curvature="0" />
+         />
     </g>
     <g
        aria-label="S"
@@ -460,13 +339,11 @@
       <path
          d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
          id="path4677"
-         inkscape:connector-curvature="0" />
+         />
     </g>
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="text-actually-vegur601"
      style="display:inline">
     <g
        id="g952">
@@ -480,7 +357,7 @@
            y="378.79724"
            x="593.58667"
            id="tspan869"
-           sodipodi:role="line">Nix</tspan></text>
+           >Nix</tspan></text>
       <text
          id="text871-4"
          y="380.13666"
@@ -491,7 +368,7 @@
            y="380.13666"
            x="1365.2794"
            id="tspan869-7"
-           sodipodi:role="line">S</tspan></text>
+           >S</tspan></text>
       <text
          transform="scale(0.95067319,1.0518862)"
          id="text871-4-0"
@@ -503,7 +380,7 @@
            y="362.81711"
            x="1194.63"
            id="tspan869-7-4"
-           sodipodi:role="line">O</tspan></text>
+           >O</tspan></text>
     </g>
   </g>
 </svg>

--- a/weekly/nixos-weekly.svg
+++ b/weekly/nixos-weekly.svg
@@ -2,25 +2,18 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="459"
    height="226"
    viewBox="0 0 430.3125 211.87501"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-  >
+   >
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="light">
       <stop
          style="stop-color:#699ad7;stop-opacity:1"
@@ -36,7 +29,6 @@
          id="stop5568" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="dark">
       <stop
          style="stop-color:#415e9a;stop-opacity:1"
@@ -53,7 +45,7 @@
     </linearGradient>
     <linearGradient
        id="old2"
-       inkscape:collect="always">
+       >
       <stop
          id="stop5962"
          offset="0"
@@ -68,7 +60,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="old1">
       <stop
          style="stop-color:#7363df;stop-opacity:1"
@@ -92,7 +83,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855-8"
        xlink:href="#old1"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="247.58188"
        x2="-702.75317"
@@ -102,7 +93,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient4544"
        xlink:href="#old2"
-       inkscape:collect="always" />
+       />
     <clipPath
        id="clipPath4501"
        clipPathUnits="userSpaceOnUse">
@@ -124,7 +115,6 @@
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </clipPath>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#dark"
        id="linearGradient5137"
        gradientUnits="userSpaceOnUse"
@@ -134,7 +124,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#dark"
        id="linearGradient5147"
        gradientUnits="userSpaceOnUse"
@@ -144,7 +133,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient5162"
        gradientUnits="userSpaceOnUse"
@@ -154,7 +142,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient5172"
        gradientUnits="userSpaceOnUse"
@@ -164,7 +151,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient5182"
        gradientUnits="userSpaceOnUse"
@@ -182,7 +168,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5201"
        xlink:href="#light"
-       inkscape:collect="always" />
+       />
     <linearGradient
        y2="937.71399"
        x2="-496.29703"
@@ -192,9 +178,8 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5205"
        xlink:href="#dark"
-       inkscape:collect="always" />
+       />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient944-3"
        gradientUnits="userSpaceOnUse"
@@ -204,7 +189,6 @@
        x2="290.08701"
        y2="506.18814" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient924-5"
        gradientUnits="userSpaceOnUse"
@@ -214,7 +198,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#light"
        id="linearGradient1034-2"
        gradientUnits="userSpaceOnUse"
@@ -224,7 +207,6 @@
        x2="-496.29703"
        y2="937.71399" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#dark"
        id="linearGradient952-1"
        gradientUnits="userSpaceOnUse"
@@ -234,150 +216,11 @@
        x2="290.08701"
        y2="506.18814" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="537.06095"
-     inkscape:cy="163.98621"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="2560"
-     inkscape:window-height="1405"
-     inkscape:window-x="0"
-     inkscape:window-y="539"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     units="px"
-     borderlayer="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="true">
-    <sodipodi:guide
-       position="4.0978987e-06,3.8298056e-06"
-       orientation="0,1"
-       id="guide1066"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="9.7208094e-14,211.863"
-       orientation="0.8660254,0.5"
-       id="guide1080"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="430.31251,211.863"
-       orientation="0,1"
-       id="guide1091"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="56.451864,211.863"
-       orientation="0.8660254,0.5"
-       id="guide1093"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="155.16164,211.863"
-       orientation="-0.8660254,0.5"
-       id="guide1095"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="304.81603,211.863"
-       orientation="-0.8660254,0.5"
-       id="guide1097"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="182.49688,3.8298056e-06"
-       orientation="0.8660254,0.5"
-       id="guide1155"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="248.55035,211.863"
-       orientation="-0.8660254,0.5"
-       id="guide1235"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="183.28005,211.863"
-       orientation="0.8660254,0.5"
-       id="guide1237"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="217.61718,54.324733"
-       orientation="-0.8660254,0.5"
-       id="guide1239"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="373.85985,211.863"
-       orientation="-0.8660254,0.5"
-       id="guide1241"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="430.31251,211.863"
-       orientation="-0.8660254,0.5"
-       id="guide1243"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="140.9031,187.1974"
-       orientation="0.8660254,0.5"
-       id="guide1247"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-    <sodipodi:guide
-       position="303.85988,3.8298056e-06"
-       orientation="0,1"
-       id="guide1249"
-       inkscape:locked="false"
-       inkscape:label=""
-       inkscape:color="rgb(0,0,255)" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+    </metadata>
   <g
-     inkscape:groupmode="layer"
      id="layer3"
-     inkscape:label="gradient-logo"
      style="display:inline;opacity:1"
      transform="translate(-156.33871,709.92523)">
     <g
@@ -385,20 +228,14 @@
        transform="matrix(0.99984686,0,0,0.99994336,-621.94158,-243.76213)"
        style="stroke-width:1.0001049">
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
          id="path4260-0-3"
          d="M 900.73738,-254.30249 778.39949,-466.17748 H 834.86 l 122.33789,211.87499 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1034-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00031471;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         sodipodi:nodetypes="cccccccc"
-         inkscape:connector-curvature="0"
          id="path4260-0-1"
          d="m 1086.44,-254.30249 122.3379,-211.87499 h -56.4613 l -95.3045,165.05629 -32.649,-56.54419 -28.3131,49.03508 31.3692,54.32781 z"
          style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient924-5);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00031471;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
          id="use3449-5-2"
          d="m 960.92431,-254.30249 122.33789,-211.87499 h -56.2743 l -32.64015,56.52894 -32.64014,-56.52894 h -28.12272 l -14.25179,24.68244 46.70151,80.88157 -33.24745,57.5807 z"
          style="display:inline;opacity:1;fill:url(#linearGradient952-1);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00031471;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />


### PR DESCRIPTION
Done by hand using http://jsfiddle.net/alexanderby/31nmr8f7 as advertised in
https://graphicdesign.stackexchange.com/questions/49626/what-program-makes-clean-plain-svg-files-from-inkscape

I haven't done much with SVGs in years, but I recall that most of this stuff is just noise like remembering editor views etc that don't really constitute source. We should regenerate raster images to to confirm no useful information is lost.