### PR TITLE
update README with Matrix room for communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ References to other Linux distributions:
 Communication:
 
 * [Mailing list](https://groups.google.com/forum/#!forum/nix-devel)
+* [Matrix - #nix:nixos.org](https://matrix.to/#/#nix:nixos.org)
 * [IRC - #nixos on libera.chat](irc://irc.libera.chat/#nixos)


### PR DESCRIPTION
Following up on https://github.com/NixOS/nixos-artwork/pull/67#issuecomment-874479944, updating this README to show the Matrix group under communications.