### PR TITLE
Make installed icons square at build time

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
   icons = pkgs.stdenv.mkDerivation {
     name = "nix-icons";
     srcs = lib.cleanSource ./.;
-    buildInputs = [ pkgs.imagemagick ];
+    buildInputs = with pkgs; [ imagemagick xmlstarlet ];
     makeFlags = [ "DESTDIR=$(out)" "prefix=" ];
   };
 }

--- a/icons/Makefile
+++ b/icons/Makefile
@@ -17,21 +17,33 @@ install_dest = $(DESTDIR)$(prefix)/share/icons/$(theme)
 
 all: $(icons)
 
-%/$(category)/nix-snowflake.png: ../logo/nix-snowflake.svg
+%/$(category)/nix-snowflake.png: scalable/$(category)/nix-snowflake.svg
 	@mkdir -p $(@D)
 	convert -background none -resize $* $< $@
 
 scalable/$(category)/nix-snowflake.svg: ../logo/nix-snowflake.svg
 	@mkdir -p $(@D)
-	cp $< $@
+	xmlstarlet ed \
+		-u '/svg:svg/@height' -x 'string(/svg:svg/@width)' \
+		-a '/svg:svg' \
+			-t attr \
+			-n 'preserveAspectRatio' \
+			-v "xMidYMid meet" \
+		< $< > $@
 
-%/$(category)/nix-snowflake-white.png: ../logo/white.svg
+%/$(category)/nix-snowflake-white.png: scalable/$(category)/nix-snowflake-white.svg
 	@mkdir -p $(@D)
 	convert -background none -resize $* $< $@
 
 scalable/$(category)/nix-snowflake-white.svg: ../logo/white.svg
 	@mkdir -p $(@D)
-	cp $< $@
+	xmlstarlet ed \
+		-u '/svg:svg/@height' -x 'string(/svg:svg/@width)' \
+		-a '/svg:svg' \
+			-t attr \
+			-n 'preserveAspectRatio' \
+			-v "xMidYMid meet" \
+		< $< > $@
 
 $(install_dest)/%: %
 	install -D $< $@

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 with import <nixpkgs> {};
 mkShell {
-  nativeBuildInputs = [ grub2_efi inkscape imagemagick ];
+  nativeBuildInputs = [ grub2_efi inkscape imagemagick xmlstarlet ];
   dejavu = dejavu_fonts;
   __strictDeps = true;
 }


### PR DESCRIPTION
Closes #42

- Modify the source SVGs at build time with XMLStarlet to
  - make width == height to cause alignment
  - explicitly set preferred [alignment settings](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio#syntax)
- Make raster icons use square'd vector icons as source

```
↪ find /nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons -type f -exec identify {} \;
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/16x16/apps/nix-snowflake.png PNG 16x16 16x16+0+0 16-bit sRGB 1932B 0.000u 0:00.000
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/16x16/apps/nix-snowflake-white.png PNG 16x16 16x16+0+0 8-bit Grayscale Gray 492B 0.000u 0:00.000
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/24x24/apps/nix-snowflake.png PNG 24x24 24x24+0+0 16-bit sRGB 3595B 0.000u 0:00.000
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/24x24/apps/nix-snowflake-white.png PNG 24x24 24x24+0+0 16-bit Grayscale Gray 1256B 0.000u 0:00.000
[...]
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/1024x1024/apps/nix-snowflake.png PNG 1024x1024 1024x1024+0+0 16-bit sRGB 637151B 0.000u 0:00.000
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/1024x1024/apps/nix-snowflake-white.png PNG 1024x1024 1024x1024+0+0 8-bit Grayscale Gray 62264B 0.000u 0:00.000
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/scalable/apps/nix-snowflake.svg SVG 535x535 535x535+0+0 16-bit sRGB 23361B 0.000u 0:00.708
/nix/store/1pb0h3sqazy97aysa8b3yzx43x8nxpnh-nix-icons/share/icons/hicolor/scalable/apps/nix-snowflake-white.svg SVG 535x535 535x535+0+0 16-bit sRGB 5582B 0.000u 0:00.633
```

An example, with the background filled in to show its *stunning* squareness. :smile:
![squared](https://github.com/NixOS/nixos-artwork/assets/23431373/423b48dd-d678-4c72-a895-c6aa3045adc5)