### PR TITLE
logo: Provide an easy path to optimized SVGs and exported PNGs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,4 +28,5 @@
       makeFlags = [ "prefix=$(out)" ];
     }
   ) {};
+  logo = pkgs.callPackage ./logo/package.nix {};
 }

--- a/logo/README.md
+++ b/logo/README.md
@@ -56,6 +56,17 @@ white, keeping the spacing exact.
 This variant is monochrome, with the shadow gradients baked-in as opacity
 changes.
 
+### Optimized version
+
+The SVG files in this directory are the authoring files.
+
+In other words, they are busy with inkscape-specific properties, used when
+editing the files.
+
+If what is needed is a file optimized for size, and for using as an asset,
+the Nix expression in this directory can be used to produce optimized SVGs.
+
+
 License
 -------
 

--- a/logo/default.nix
+++ b/logo/default.nix
@@ -1,0 +1,1 @@
+(import ../. {}).logo

--- a/logo/package.nix
+++ b/logo/package.nix
@@ -1,0 +1,38 @@
+{ runCommand
+, lib
+, inkscape
+, nodePackages
+}:
+
+runCommand "nixos-artwork-logos" {
+  logos = [
+    # The snowflake-only variants
+    "nix-snowflake-colours"
+    "nix-snowflake-white"
+
+    # The horizontal variants
+    "nixos"
+    "nixos-white"
+
+    # The vertical variant
+    "nixos-text-below"
+  ];
+  src = lib.cleanSource ./.;
+  nativeBuildInputs = [
+    inkscape
+    nodePackages.svgo
+  ];
+} ''
+  PS4=" $ "
+  for f in $logos; do
+    mkdir -p $out
+    printf ":: ⇒ %s\n" "$f"
+    (set -x
+    inkscape --export-background-opacity=0 --export-plain-svg --export-filename=$out/$f.svg "$src/$f.svg"
+    inkscape --export-background-opacity=0 --export-filename=$out/$f.png "$src/$f.svg"
+    )
+  done
+  (set -x
+  svgo --pretty --multipass --folder "$out"
+  )
+''


### PR DESCRIPTION
The non-logo files are not part of the build, as they are files made for specific usage, and should not be part of the NixOS assets for general usage.

With the added Nix expression, someone that needs PNGs or optimized SVGs can get them more easily than previously, where they'd need to get into inkscape and export the files.

With future clean-up work, this may be enhanced by exporting different layers. This would allow exporting the flat (for print) and gradient based variants.

It's done directly as a Nix expression, as these assets are not intended to be part of an automated pipeline. This for end-user convenience.

* * *

@Ericson2314 first of all, sorry for the span of years since your initial contribution.

Can you please remind me the rationale behind #37, #38 and #39?

I'm wondering if part of it will be addressed here. I'm thinking mainly about producing "built assets" versions of the SVG files, which drops all inkscape-isms, and then get optimized.

Though I recall (and see) that these also seemed intended to make the files "accessible" to hand editing, though I'm unsure if that was an intention.

Finally, the last thing I understand from what you were doing is you were cleaning up the names and "concepts" in some of the files. Obviously this is not handled here.

(Anyway these changes I think are needed and good, so I'm not blocked by your reply, so take your time. Though I want to understand the needs you had, to handle them.)