### PR TITLE
Add KDE Matrix icon + replace template room png with svg

### DIFF
--- a/matrix/icons.src.svg
+++ b/matrix/icons.src.svg
@@ -6,10 +6,11 @@
    version="1.1"
    id="svg8"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   sodipodi:docname="icons.src.svg"
+   sodipodi:docname="icons2.src.svg"
    inkscape:export-filename="channel-nixos.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
+   xml:space="preserve"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -17,53 +18,38 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <defs
-     id="defs2">
-    <linearGradient
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs2"><linearGradient
        id="linearGradient1711"
-       inkscape:collect="always">
-      <stop
+       inkscape:collect="always"><stop
          id="stop1707"
          offset="0"
-         style="stop-color:#81bbe5;stop-opacity:1;" />
-      <stop
+         style="stop-color:#81bbe5;stop-opacity:1;" /><stop
          id="stop1709"
          offset="1"
-         style="stop-color:#81bbe5;stop-opacity:0;" />
-    </linearGradient>
-    <rect
+         style="stop-color:#81bbe5;stop-opacity:0;" /></linearGradient><rect
        id="rect17"
        height="1021.8296"
        width="936.8928"
        y="12.540837"
-       x="-40.173786" />
-    <mask
+       x="-40.173786" /><mask
        id="mask953"
-       maskUnits="userSpaceOnUse">
-      <circle
+       maskUnits="userSpaceOnUse"><circle
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.89135;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
          id="circle955"
          cx="832"
          cy="832"
-         r="167.68814" />
-    </mask>
-    <linearGradient
-       id="main">
-      <stop
+         r="167.68814" /></mask><linearGradient
+       id="main"><stop
          id="stop915"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:0" />
-      <stop
+         style="stop-color:#ffffff;stop-opacity:0" /><stop
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0.23168644"
-         id="stop917" />
-      <stop
+         id="stop917" /><stop
          id="stop919"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
+         style="stop-color:#ffffff;stop-opacity:1" /></linearGradient><linearGradient
        xlink:href="#main"
        id="linearGradient1299"
        gradientUnits="userSpaceOnUse"
@@ -71,8 +57,7 @@
        x1="-584.19934"
        y1="782.33563"
        x2="-414.38654"
-       y2="880.37714" />
-    <linearGradient
+       y2="880.37714" /><linearGradient
        xlink:href="#main"
        id="linearGradient1713"
        gradientUnits="userSpaceOnUse"
@@ -80,8 +65,7 @@
        x1="200.59668"
        y1="351.41116"
        x2="389.57562"
-       y2="460.51822" />
-    <linearGradient
+       y2="460.51822" /><linearGradient
        y2="460.51822"
        x2="389.57562"
        y1="351.41116"
@@ -90,8 +74,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1044"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="880.37714"
        x2="-414.38654"
        y1="782.33563"
@@ -100,56 +83,40 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1046"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        inkscape:collect="always"
-       id="linearGradient5562">
-      <stop
+       id="linearGradient5562"><stop
          style="stop-color:#699ad7;stop-opacity:1"
          offset="0"
-         id="stop5564" />
-      <stop
+         id="stop5564" /><stop
          id="stop5566"
          offset="0.24345198"
-         style="stop-color:#7eb1dd;stop-opacity:1" />
-      <stop
+         style="stop-color:#7eb1dd;stop-opacity:1" /><stop
          style="stop-color:#7ebae4;stop-opacity:1"
          offset="1"
-         id="stop5568" />
-    </linearGradient>
-    <linearGradient
+         id="stop5568" /></linearGradient><linearGradient
        inkscape:collect="always"
-       id="linearGradient5053">
-      <stop
+       id="linearGradient5053"><stop
          style="stop-color:#415e9a;stop-opacity:1"
          offset="0"
-         id="stop5055" />
-      <stop
+         id="stop5055" /><stop
          id="stop5057"
          offset="0.23168644"
-         style="stop-color:#4a6baf;stop-opacity:1" />
-      <stop
+         style="stop-color:#4a6baf;stop-opacity:1" /><stop
          style="stop-color:#5277c3;stop-opacity:1"
          offset="1"
-         id="stop5059" />
-    </linearGradient>
-    <linearGradient
+         id="stop5059" /></linearGradient><linearGradient
        id="linearGradient5960"
-       inkscape:collect="always">
-      <stop
+       inkscape:collect="always"><stop
          id="stop5962"
          offset="0"
-         style="stop-color:#637ddf;stop-opacity:1" />
-      <stop
+         style="stop-color:#637ddf;stop-opacity:1" /><stop
          style="stop-color:#649afa;stop-opacity:1"
          offset="0.23168644"
-         id="stop5964" />
-      <stop
+         id="stop5964" /><stop
          id="stop5966"
          offset="1"
-         style="stop-color:#719efa;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
+         style="stop-color:#719efa;stop-opacity:1" /></linearGradient><linearGradient
        y2="515.97058"
        x2="282.26105"
        y1="338.62445"
@@ -158,8 +125,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient5384"
@@ -168,8 +134,7 @@
        x1="200.59668"
        y1="351.41116"
        x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
+       y2="506.18814" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient5386"
@@ -178,8 +143,7 @@
        x1="-584.19934"
        y1="782.33563"
        x2="-496.29703"
-       y2="937.71399" />
-    <linearGradient
+       y2="937.71399" /><linearGradient
        y2="515.97058"
        x2="282.26105"
        y1="338.62445"
@@ -188,8 +152,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1342"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="506.18814"
        x2="290.08701"
        y1="351.41116"
@@ -198,8 +161,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1344"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="937.71399"
        x2="-496.29703"
        y1="782.33563"
@@ -208,8 +170,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1346"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="460.51822"
        x2="389.57562"
        y1="351.41116"
@@ -218,8 +179,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1348"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="880.37714"
        x2="-414.38654"
        y1="782.33563"
@@ -228,8 +188,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1350"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="460.51822"
        x2="389.57562"
        y1="351.41116"
@@ -238,8 +197,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1352"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="880.37714"
        x2="-414.38654"
        y1="782.33563"
@@ -248,8 +206,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient1354"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient1342-6"
@@ -258,8 +215,7 @@
        x1="213.95642"
        y1="338.62445"
        x2="282.26105"
-       y2="515.97058" />
-    <linearGradient
+       y2="515.97058" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1344-8"
@@ -268,8 +224,7 @@
        x1="200.59668"
        y1="351.41116"
        x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
+       y2="506.18814" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1346-2"
@@ -278,8 +233,7 @@
        x1="-584.19934"
        y1="782.33563"
        x2="-496.29703"
-       y2="937.71399" />
-    <linearGradient
+       y2="937.71399" /><linearGradient
        gradientUnits="userSpaceOnUse"
        y2="502.99289"
        x2="-15.600792"
@@ -287,42 +241,32 @@
        x1="659.58734"
        id="linearGradient1714"
        xlink:href="#linearGradient1711"
-       inkscape:collect="always" />
-    <mask
+       inkscape:collect="always" /><mask
        id="mask1786"
-       maskUnits="userSpaceOnUse">
-      <g
+       maskUnits="userSpaceOnUse"><g
          style="display:inline;stroke:#060606;stroke-opacity:1"
          id="g1792"
-         transform="rotate(4.8040314,1811.2728,-143.34394)">
-        <ellipse
+         transform="rotate(4.8040314,1811.2728,-143.34394)"><ellipse
            ry="266.5979"
            rx="431.36444"
            cy="830.2522"
            cx="659.63055"
            id="ellipse1788"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:#060606;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:#060606;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
            sodipodi:nodetypes="ccc"
            id="path1790"
            d="M 342.29022,657.41174 C 271.32799,575.27519 391.06962,472.79543 461.08753,382.44815 449.39549,459.84454 363.12479,601.33746 497.506,585.54867"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#060606;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </mask>
-    <filter
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#060606;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g></mask><filter
        height="1.1076118"
        y="-0.053805908"
        width="1.1322678"
        x="-0.066133907"
        id="filter2033"
        style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
+       inkscape:collect="always"><feGaussianBlur
          id="feGaussianBlur2035"
          stdDeviation="6.4653894"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
+         inkscape:collect="always" /></filter><linearGradient
        y2="515.97058"
        x2="282.26105"
        y1="338.62445"
@@ -331,8 +275,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2324"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="506.18814"
        x2="290.08701"
        y1="351.41116"
@@ -341,8 +284,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2326"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="937.71399"
        x2="-496.29703"
        y1="782.33563"
@@ -351,8 +293,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2328"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="515.97058"
        x2="282.26105"
        y1="338.62445"
@@ -361,8 +302,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2416"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="506.18814"
        x2="290.08701"
        y1="351.41116"
@@ -371,8 +311,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2418"
        xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="937.71399"
        x2="-496.29703"
        y1="782.33563"
@@ -381,8 +320,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2420"
        xlink:href="#linearGradient5053"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="460.51822"
        x2="389.57562"
        y1="351.41116"
@@ -391,8 +329,7 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2956"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <linearGradient
+       inkscape:collect="always" /><linearGradient
        y2="880.37714"
        x2="-414.38654"
        y1="782.33563"
@@ -401,21 +338,17 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient2958"
        xlink:href="#main"
-       inkscape:collect="always" />
-    <filter
+       inkscape:collect="always" /><filter
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter2033-3"
        x="-0.066133907"
        width="1.1322678"
        y="-0.053805908"
-       height="1.1076118">
-      <feGaussianBlur
+       height="1.1076118"><feGaussianBlur
          inkscape:collect="always"
          stdDeviation="6.4653894"
-         id="feGaussianBlur2035-6" />
-    </filter>
-    <linearGradient
+         id="feGaussianBlur2035-6" /></filter><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient1659"
@@ -424,8 +357,7 @@
        x1="213.95642"
        y1="338.62445"
        x2="282.26105"
-       y2="515.97058" />
-    <linearGradient
+       y2="515.97058" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1661"
@@ -434,8 +366,7 @@
        x1="200.59668"
        y1="351.41116"
        x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
+       y2="506.18814" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1663"
@@ -444,8 +375,7 @@
        x1="-584.19934"
        y1="782.33563"
        x2="-496.29703"
-       y2="937.71399" />
-    <linearGradient
+       y2="937.71399" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5960"
        id="linearGradient1665"
@@ -454,8 +384,7 @@
        x1="213.95642"
        y1="338.62445"
        x2="282.26105"
-       y2="515.97058" />
-    <linearGradient
+       y2="515.97058" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5562"
        id="linearGradient1667"
@@ -464,8 +393,7 @@
        x1="200.59668"
        y1="351.41116"
        x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
+       y2="506.18814" /><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient5053"
        id="linearGradient1669"
@@ -474,42 +402,32 @@
        x1="-584.19934"
        y1="782.33563"
        x2="-496.29703"
-       y2="937.71399" />
-    <mask
+       y2="937.71399" /><mask
        maskUnits="userSpaceOnUse"
-       id="mask2224">
-      <path
+       id="mask2224"><path
          id="path2226"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:0.997315;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z" />
-    </mask>
-    <filter
+         d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z" /></mask><filter
        height="1.1187269"
        y="-0.05936344"
        width="1.1274829"
        x="-0.063741429"
        id="filter1784"
        style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
+       inkscape:collect="always"><feGaussianBlur
          id="feGaussianBlur1786"
          stdDeviation="16.1049"
-         inkscape:collect="always" />
-    </filter>
-    <filter
+         inkscape:collect="always" /></filter><filter
        height="1.0980198"
        y="-0.0490099"
        width="1.1052487"
        x="-0.052624327"
        id="filter2196"
        style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
+       inkscape:collect="always"><feGaussianBlur
          id="feGaussianBlur2198"
          stdDeviation="13.296055"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
+         inkscape:collect="always" /></filter><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4689"
        id="linearGradient1478"
@@ -518,19 +436,14 @@
        x1="26.648937"
        y1="20.603781"
        x2="135.66525"
-       y2="114.39767" />
-    <linearGradient
-       id="linearGradient4689">
-      <stop
+       y2="114.39767" /><linearGradient
+       id="linearGradient4689"><stop
          style="stop-color:#5a9fd4;stop-opacity:1;"
          offset="0"
-         id="stop4691" />
-      <stop
+         id="stop4691" /><stop
          style="stop-color:#306998;stop-opacity:1;"
          offset="1"
-         id="stop4693" />
-    </linearGradient>
-    <linearGradient
+         id="stop4693" /></linearGradient><linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4671"
        id="linearGradient1475"
@@ -539,19 +452,14 @@
        x1="150.96111"
        y1="192.35176"
        x2="112.03144"
-       y2="137.27299" />
-    <linearGradient
-       id="linearGradient4671">
-      <stop
+       y2="137.27299" /><linearGradient
+       id="linearGradient4671"><stop
          style="stop-color:#ffd43b;stop-opacity:1;"
          offset="0"
-         id="stop4673" />
-      <stop
+         id="stop4673" /><stop
          style="stop-color:#ffe873;stop-opacity:1"
          offset="1"
-         id="stop4675" />
-    </linearGradient>
-    <radialGradient
+         id="stop4675" /></linearGradient><radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient2795"
        id="radialGradient1480"
@@ -561,20 +469,14 @@
        cy="132.28575"
        fx="61.518883"
        fy="132.28575"
-       r="29.036913" />
-    <linearGradient
-       id="linearGradient2795">
-      <stop
+       r="29.036913" /><linearGradient
+       id="linearGradient2795"><stop
          style="stop-color:#b8b8b8;stop-opacity:0.49803922;"
          offset="0"
-         id="stop2797" />
-      <stop
+         id="stop2797" /><stop
          style="stop-color:#7f7f7f;stop-opacity:0;"
          offset="1"
-         id="stop2799" />
-    </linearGradient>
-  </defs>
-  <sodipodi:namedview
+         id="stop2799" /></linearGradient></defs><sodipodi:namedview
      inkscape:snap-global="false"
      inkscape:guide-bbox="true"
      showguides="true"
@@ -584,11 +486,11 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.39801078"
-     inkscape:cx="734.90473"
-     inkscape:cy="782.64213"
+     inkscape:zoom="0.22206233"
+     inkscape:cx="123.8391"
+     inkscape:cy="45.032401"
      inkscape:document-units="px"
-     inkscape:current-layer="layer22"
+     inkscape:current-layer="layer6"
      inkscape:document-rotation="0"
      showgrid="false"
      units="px"
@@ -596,68 +498,59 @@
      borderlayer="false"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1050"
-     inkscape:window-x="1920"
-     inkscape:window-y="30"
-     inkscape:window-maximized="0"
-     inkscape:deskcolor="#d1d1d1">
-    <sodipodi:guide
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:deskcolor="#d1d1d1"><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide859"
        orientation="0,1"
-       position="1024,0" />
-    <sodipodi:guide
+       position="1024,0" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide861"
        orientation="0,1"
-       position="0,1024" />
-    <sodipodi:guide
+       position="0,1024" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide863"
        orientation="-1,0"
-       position="0,1024" />
-    <sodipodi:guide
+       position="0,1024" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide865"
        orientation="-1,0"
-       position="1024,0" />
-    <sodipodi:guide
+       position="1024,0" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1004"
        orientation="-1,0"
-       position="51,512" />
-    <sodipodi:guide
+       position="51,512" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1006"
        orientation="-1,0"
-       position="973,512" />
-    <sodipodi:guide
+       position="973,512" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1008"
        orientation="0,1"
-       position="512,51.2" />
-    <sodipodi:guide
+       position="512,51.2" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1010"
        orientation="0,1"
-       position="512,973" />
-    <inkscape:grid
+       position="512,973" /><inkscape:grid
        id="grid1012"
        type="xygrid"
        originx="0"
@@ -665,109 +558,78 @@
        spacingy="1"
        spacingx="1"
        units="px"
-       visible="false" />
-    <sodipodi:guide
+       visible="false" /><sodipodi:guide
        inkscape:color="rgb(186,189,182)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1424"
        orientation="-1,0"
-       position="640,384" />
-    <sodipodi:guide
+       position="640,384" /><sodipodi:guide
        inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
        inkscape:label=""
        id="guide1426"
        orientation="0,1"
-       position="640,384" />
-    <sodipodi:guide
+       position="640,384" /><sodipodi:guide
        id="guide3117"
        orientation="0,-1"
        position="0,512"
-       inkscape:locked="false" />
-    <sodipodi:guide
+       inkscape:locked="false" /><sodipodi:guide
        position="832,192"
        orientation="0,1"
        id="guide1374"
        inkscape:label=""
        inkscape:locked="false"
-       inkscape:color="rgb(237,212,0)" />
-    <sodipodi:guide
+       inkscape:color="rgb(237,212,0)" /><sodipodi:guide
        position="832,192"
        orientation="-1,0"
        id="guide1376"
        inkscape:label=""
        inkscape:locked="false"
-       inkscape:color="rgb(237,212,0)" />
-    <sodipodi:guide
+       inkscape:color="rgb(237,212,0)" /><sodipodi:guide
        position="512,512"
        orientation="-1,0"
        id="guide1587"
        inkscape:label=""
        inkscape:locked="false"
-       inkscape:color="rgb(245,121,0)" />
-    <sodipodi:guide
+       inkscape:color="rgb(245,121,0)" /><sodipodi:guide
        position="51,576"
        orientation="0,-1"
        id="guide2110"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-      </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#Notice" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#Attribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-        <cc:requires
-           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <g
+       inkscape:locked="false" /></sodipodi:namedview><metadata
+     id="metadata5"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" /></cc:Work><cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/"><cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" /><cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" /><cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" /><cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" /><cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" /><cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" /></cc:License></rdf:RDF></metadata><g
      inkscape:groupmode="layer"
      id="g2695"
      inkscape:label="Channel"
-     style="display:inline">
-    <g
+     style="display:inline"><g
        sodipodi:insensitive="true"
        inkscape:groupmode="layer"
        id="g2651"
        inkscape:label="$BACKGROUND"
-       style="display:inline;opacity:1">
-      <rect
+       style="display:inline;opacity:1"><rect
          y="0"
          x="0"
          height="1024"
          width="1024"
          id="rect3052"
-         style="color:#000000;overflow:visible;opacity:0.99;fill:#6586c8;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
+         style="color:#000000;overflow:visible;opacity:0.99;fill:#6586c8;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><rect
          width="835.00354"
          y="640"
          x="0"
          height="384"
          id="rect1014-1"
-         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#27385d;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-      <g
-         id="g2995">
-        <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#27385d;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><g
+         id="g2995"><rect
            ry="0"
            rx="0"
            style="color:#000000;overflow:visible;opacity:1;fill:#6586c8;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -775,78 +637,59 @@
            width="832"
            height="64"
            x="0"
-           y="576" />
-        <rect
+           y="576" /><rect
            style="color:#000000;overflow:visible;fill:#00ffff;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
            id="rect545"
            width="384"
            height="384"
            x="640"
-           y="640" />
-        <circle
+           y="640" /><circle
            style="color:#000000;overflow:visible;opacity:1;fill:#6586c8;fill-opacity:1;stroke:none;stroke-width:32.0001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path2982"
            cx="832"
            cy="832"
-           r="256" />
-      </g>
-      <g
+           r="256" /></g><g
          transform="matrix(0.60254176,0,0,0.60265672,705.46623,705.52274)"
          id="g3096"
-         style="fill:#fbfbfb;fill-opacity:1;stroke:#c2c2c2;stroke-width:22.2732;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-        <path
+         style="fill:#fbfbfb;fill-opacity:1;stroke:#c2c2c2;stroke-width:22.2732;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"><path
            style="fill:#fbfbfb;fill-opacity:1;stroke:#c2c2c2;stroke-width:22.2732;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            stroke-width="54.2384"
            d="m 209,15 a 195,195 0 1 0 2,0 z"
-           id="path3082" />
-        <path
+           id="path3082" /><path
            style="fill:#fbfbfb;fill-opacity:1;stroke:#c2c2c2;stroke-width:22.2732;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            stroke-width="37.5496"
            d="M 210,15 V 405 M 405,210 H 15 M 59,90 a 260,260 0 0 0 302,0 m 0,240 A 260,260 0 0 0 59,330 M 195,20 a 250,250 0 0 0 0,382 m 30,0 a 250,250 0 0 0 0,-382"
-           id="path3084" />
-      </g>
-      <g
+           id="path3084" /></g><g
          style="display:inline;opacity:0.998;stroke-width:1.26477"
          transform="matrix(0.84336725,0,0,0.84336725,148.26116,648.96693)"
-         id="g1040-4">
-        <g
+         id="g1040-4"><g
            id="g1018-9"
            transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
-           style="display:none;stroke-width:1.26477">
-          <rect
+           style="display:none;stroke-width:1.26477"><rect
              style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:13.1036"
              id="rect1016-2"
              width="7947.0356"
              height="7145.4614"
              x="-1045.6049"
-             y="-2102.4253" />
-        </g>
-        <g
+             y="-2102.4253" /></g><g
            id="g1038-0"
            style="display:inline;opacity:1;stroke-width:1.26477"
-           transform="translate(-156.48372,537.56136)">
-          <g
+           transform="translate(-156.48372,537.56136)"><g
              id="g1036-6"
              transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
-             style="stroke-width:13.9773">
-            <g
+             style="stroke-width:13.9773"><g
                style="stroke-width:13.9773"
                id="g1034-8"
-               transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)">
-              <g
+               transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"><g
                  style="stroke-width:13.9773"
                  id="g1022-9"
-                 transform="rotate(-60,226.35754,-449.37199)">
-                <path
+                 transform="rotate(-60,226.35754,-449.37199)"><path
                    style="opacity:1;fill:url(#linearGradient2956);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:41.9314;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                    d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                   id="path1020-2" />
-              </g>
-              <path
+                   id="path1020-2" /></g><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2958);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:41.9314;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                 id="path1024-6" />
-              <use
+                 id="path1024-6" /><use
                  style="stroke-width:13.9773"
                  height="100%"
                  width="100%"
@@ -854,8 +697,7 @@
                  id="use1026-6"
                  xlink:href="#path3336-6"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:13.9773"
                  height="100%"
                  width="100%"
@@ -863,8 +705,7 @@
                  id="use1028-4"
                  xlink:href="#path3336-6"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(120,407.33916,-716.08356)"
@@ -872,8 +713,7 @@
                  xlink:href="#path4260-0"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:13.9773" />
-              <use
+                 style="display:inline;stroke-width:13.9773" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(-120,407.28823,-715.86995)"
@@ -881,40 +721,29 @@
                  xlink:href="#path4260-0"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:13.9773" />
-            </g>
-          </g>
-        </g>
-      </g>
-      <rect
+                 style="display:inline;stroke-width:13.9773" /></g></g></g></g><rect
          style="color:#000000;overflow:visible;opacity:1;fill:#00ffff;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
          id="rect1370"
          width="384"
          height="384"
          x="640"
-         y="640" />
-    </g>
-    <g
+         y="640" /></g><g
        inkscape:label="doom-emacs"
        id="g868"
        inkscape:groupmode="layer"
-       style="display:none">
-      <path
+       style="display:none"><path
          d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z"
-         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#dfdfdf;fill-opacity:0.99215686;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#dfdfdf;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
          id="path858"
-         inkscape:label="doom bg" />
-      <path
+         inkscape:label="doom bg" /><path
          id="path862"
          style="color:#000000;overflow:visible;fill:#c57bdb;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
-         inkscape:label="accent" />
-      <g
+         inkscape:label="accent" /><g
          id="g22662"
          transform="matrix(1.0735511,0,0,1.0735511,239.40192,28.368943)"
          inkscape:label="emacs icon"
-         style="display:inline">
-        <path
+         style="display:inline"><path
            transform="matrix(0.98685,0,0,0.98685,1.833,1.934)"
            d="m 491.67,257.76 c 0,131.794 -105.76,238.634 -236.222,238.634 -130.462,0 -236.222,-106.84 -236.222,-238.635 0,-131.794 105.76,-238.635 236.222,-238.635 130.461,0 236.221,106.84 236.221,238.635 z"
            opacity="0.405"
@@ -924,32 +753,25 @@
            stroke-width="8.533"
            filter="url(#c)"
            id="path22638"
-           style="display:inline;fill:#211f46;fill-opacity:1;stroke:#0a0b1b;stroke-opacity:0.65974069;opacity:1;stroke-width:30.20481024;paint-order:stroke markers fill" />
-        <path
+           style="display:inline;opacity:1;fill:#211f46;fill-opacity:1;stroke:#0a0b1b;stroke-width:30.2048;stroke-opacity:0.659741;paint-order:stroke markers fill" /><path
            d="m 487.037,256.303 c 0,130.061 -104.37,235.497 -233.115,235.497 -128.746,0 -233.116,-105.436 -233.116,-235.497 0,-130.061 104.37,-235.497 233.116,-235.497 128.745,0 233.115,105.436 233.115,235.497 z"
            fill="url(#d)"
            stroke="url(#e)"
            stroke-width="13.338"
            id="path22640"
-           style="fill:url(#d);stroke:url(#e)" />
-        <path
+           style="fill:url(#d);stroke:url(#e)" /><path
            d="m 173.799,421.719 c 0,0 19.738,1.396 45.131,-0.842 10.283,-0.906 49.327,-4.74 78.517,-11.142 0,0 35.59,-7.617 54.63,-14.634 19.923,-7.341 30.764,-13.573 35.643,-22.401 -0.212,-1.81 1.503,-8.225 -7.685,-12.078 -23.488,-9.852 -50.73,-8.07 -104.633,-9.213 -59.778,-2.054 -79.663,-12.06 -90.256,-20.118 -10.158,-8.176 -5.05,-30.793 38.474,-50.715 21.925,-10.61 107.87,-30.187 107.87,-30.187 -28.944,-14.308 -82.918,-39.46 -94.013,-44.89 -9.73,-4.764 -25.303,-11.936 -28.678,-20.614 -3.827,-8.331 9.038,-15.507 16.225,-17.563 23.144,-6.676 55.818,-10.825 85.554,-11.29 14.948,-0.235 17.374,-1.197 17.374,-1.197 20.624,-3.42 34.201,-17.531 28.544,-39.878 -5.078,-22.81 -31.861,-36.214 -57.313,-31.574 -23.969,4.37 -81.738,21.15 -81.738,21.15 71.407,-0.618 83.359,0.574 88.697,8.037 3.152,4.407 -1.433,10.45 -20.477,13.56 -20.733,3.387 -63.831,7.465 -63.831,7.465 -41.345,2.455 -70.468,2.62 -79.203,21.113 -5.706,12.082 6.085,22.763 11.254,29.45 21.84,24.288 53.388,37.388 73.695,47.035 7.64,3.63 30.058,10.484 30.058,10.484 -65.878,-3.624 -113.4,16.605 -141.276,39.896 -31.529,29.163 -17.582,63.924 47.012,85.327 38.152,12.641 57.073,18.587 113.982,13.462 33.52,-1.807 38.804,-0.731 39.138,2.02 0.47,3.871 -37.231,13.49 -47.524,16.46 -26.185,7.553 -94.828,22.804 -95.171,22.878 z"
            fill="#ffffff"
            fill-rule="evenodd"
-           id="path22642" />
-      </g>
-    </g>
-    <g
+           id="path22642" /></g></g><g
        style="display:none"
        inkscape:groupmode="layer"
        id="g2693"
        inkscape:label="arm"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          id="rect1467"
          style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" />
-      <image
+         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" /><image
          y="208.29634"
          x="122.6337"
          width="778.7326"
@@ -957,184 +779,129 @@
          preserveAspectRatio="none"
          xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAB4AAAAJPCAYAAACdJMkAAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJzs3XmcXWV9+PHPc+7MZGFJJmELAWRRQCiogBuQ4GQBxAUsNlZbbdEiKmSjVLS2OrZYF2Bm7p0A xo1F/RVHUVmMhNxFQsCFIBUFFxSXikELIexZZs7z+yOoCAlkmZnnLp/36zUvIcw95zMmucv5nvMc kCRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJ0jALqQMkSZIkSUri/KU7UGibSGFoPLTt /KdfD/l4YMyf/j0Pnc94bIwbKPDoxn/OIrDmz/9x8GHybAiAdh7i/tWP0D1n/Yj8DJIkSZIkPY0D YKnVdA90MGmPCQwOTaAQJwATiXkGYSIZbcSwEzF2kLHDnx6TsyPQvsntZfFxCOue8r2PEcJ6Yv44 kUcp8Cgxe5BC/ggxf5Q4+CjzTnp4hH9KSZIktZrF145n7ZipxMIUQtgL8j2IYTdC7IQwEfjjV+dT /nnT73FHxjrgYeAR4EEiDwG/J3A/Id5Pnt1Pxn3kQ3+gLftf7n9glUNjSdKwizFwyYqJDD0+kZhN JIaJ5EygECYSQwfEjMCEp3z/Dht//WkCjxAYfPKb1pBnT5DljwNriOFxsmw1sfAAq6sP0N2dj9JP J6kV/PEkzrY4gRgmQphIzHciZH9+7iLfkRA2vtePoYMYd3jGdgJPEFi78XtihGwNMX+cjLX88bks hMcgPMCYR1dzxuseH40fTxouDoClRvfxFTsxbu3exGwKsDvkuxLDLmTsToy7EcMuBHYFJgA7A+PS Bv/JA8AfnvxaRYx/AH5PCKsI4Q+E8HvY8DvmHv+7tJmSJEmqGz3XT6Kt7VByDiTL9ifG/YEDgP2B yYnrhluEeB+RewncS+TXhPBzMn5OPvRzxk76FWcctSF1pCSpTvTcMg7WTaVtaAox25uYT4GwFxlT ydmTwFQinX8x3B09q4EHIPwe4m8h/I4Q/5cYfkcIv6F9/T28+4Q/JOiSVC8uWbobG9qnAHsRmQpx Twh7QZxCjLuRhYlEJrLxGPdonsT5VE+w8Zj2aiL3E/gdMa4iy35Lzr2EuIrBwf9l74d+x5w5Q4ka pT9xACzVs+7ujJ1eOZX29icPbsX9CDyPmO0JcSqwF7BT6swRtha4B7iHGO8hcA8h3MNguAfG3sPZ Rz+ROlCSJEnDrLvWxsShQ8iyo4jxxcAhwKHAHonL6skg8GsId0P80cav7EcMjb3L98iS1KRiDBTL e0M4CMJBhPhCyA4kcBAx7p06bzs9AvEXxHAPIfwc8rsg+xFjH/uxV91JTeD8pTswJjuQPBxIyA6E eDCR5xGYCkzhqbdfaXwbCPyayD3AL+DJ49nkP2HMxLs9iVOjxQGwVA96l0+hbcMLiRxEHg9+8kVw f2Bf4JnL7Ogp4ipi+DGBHxLjD4E7GPfEnX44kCRJaiA9lakU4jQIRxM4isiLqZ+VaxrNEHAPxDuI fB+4lVi4lYVda57rgZKkOrL42vGsHf9iiC+FcBQbT4Q6CBifuGy05cAvN57oFG4nxtuIHbexcPqq 1GGSNmFR5XkMhoPJOIiYHwTZgRAPBPbGeRTABuCnwF2EeCdwF4OF/2Hhq35BCDFxm5qMf+Gk0XRB bRfa44uIHA7xcAKHEDko0fI7zWyIjWdX3QHhDvJ842B4wcxf+kIqSZJUB/qW7QNhNhnTidk0iPul TmpyEbgb+B4h3Eqef5s1hdvp7hpMHSZJAroHOpg46UVk4ShiPOrJge8hQFvqtDr2O+A2YvwOhBXk 4251BQxplC2qPI88HEnMj4JwJHAkzXdbltEReYjA94HbCHyfLN7GmTPv9li2tocDYGmk9C/dj6G2 o4AjCeFFEA8H9kyd1eJWA7dAuIWQr2Bw/Eo/HEiSJI2CnlvGka2dTognACcCL0ydJB4hsgJYTmA5 Yyfc6nJ0kjRKFq9sZ/3DLyPmM4lhJvBymmv50xTWAyuJ8WZC9i3awnLO7Ho0dZTUNC5cujdtTx7r JhwJ8Shgl9RZTe5+ArdAWEHgFuLalcw7aV3qKDUOB8DScLiotgcb4ssI+VGQvdQXwIaxAeJtkN1C 4GYK4RbO7LovdZQkSVJTWLxsAmsLr4H8ryG8mtZbsrLRPAbcDHEpWWEJc7t+kjpIkppGjIH+2uHE fCaEmcB0YMfUWU1uA/AdQiwTQ5kHs++58oW0FXpr+5LlXUAXMAOYmrhIsBbCSogVYl5mXOd3PYFT z8YBsLS1Ygz0V15IHo4hi8cSwzHAAamzNGx+AWEFMS/TXig7EJYkSdoKF9V2ZHDoVAhzgJl4NVMj +xXwTQLfZN1glX854bHUQZLUUC6q7chgPAniG9j4mrhr6qQW9yCR6wnxGvLC9SzsWpM6SKor/Tfs yVA2g0AXZF3eoqUhPAosJ4YyISxjftePUgepvjgAlp5Ld3fGhOMOJxuaAeFVwNF4L4NWEYEfElhG HpYxIdzIaV1rU0dJkiTVlYGBAvdNnknkrcAbgB1SJ2nYrYNYhnAVQxuu5uwTV6cOkqS61HP9JNra X0/kr4HZwNjUSdqkQeAmQvg6g/Eqzp55b+ogadRdfFMn69fP2jjwpQs4OHWSttuvCFwHXAvrbnS5 aDkAljalVD6E+McXv/AqHPhqo8eePPB1HW3ZdV4dLEmSWtqFS/emrXA6hLfjknCtZANQg3AVoe1r zJv+f6mDJCmp/hv2JBZOJoa/hvgqoC11krZKDtxMZIDYfhULp69KHSSNmP7aweT5a4HXAsfg81Uz e5TIDRC/Rrb+Guad9HDqII0+B8ASQGnJzjB2FjG+GjgR2Ct1kupeDtxGjF+H7CoWzPhp6iBJkqQR 192d0Xns8cC7ILwWKKROUlJDEGpEPs+GDVe5TLSkltFzyzgKT7yREN5OjNOBLHWShkUO1IDLWT/4 VV/X1PBiDPRVXkGWvZEQX0/k+amTlMRaAjeQxy87DG4tDoDVuvqXHUbMToJwIjEeA7SnTlJD+yEh foWh+GUWzv5x6hhJkqRhtfja8Tyxwz+SxYUeONJmPArhKsgv58EVN9LdnacOkqRh1187ijx/O5G3 EJiQOkcj6hEiV5GFy5jbtZwQYuogaYt0d2dMnv5KhuIbycKpxLh36iTVlbUQlxKyK2DtN1wmurk5 AFbrGBgocN8uxxLjycDJwP6pk9SkAncSwxeJQ19kwezfpM6RJEnaZhfUdqE9PxM4E9g1dY4axq+J fJ6YfZaFXb9KHSNJ26Xn+km0dfw9Mb4deFHqHCVxNzEupo3LOGvWA6ljpE3qKx9OFt5G5G/x9iza Mqsh/DchXsG8md9LHaPh5wBYze3S2lgejicQ4ykEXgvskjpJLSUnhOXEeAVh3VUuryFJkhpG7/Ip ZBvOBU4HxqfOUcPKgW9AvJgHV9zgVcGSGkp/9RjyeBbwBmBM6hzVhbWEOMAQn2ThrG+njpHoqUyl LbyFGN8KHJY6Rw3tx8Dn2JBdxjld96eO0fBwAKzm0z3QwaTJJxCZA7we2Dl1kgQ8AeGr5EOfYcGs G106SJIk1aW+8u6EcC7wLmBc6hw1kcDPyeMnyQcv5ewTV6fOkaRN6u7OmDT9FIjnEHll6hzVsRhX EriQBwtfobtrMHWOWsjile088fDryfLTiWE23oNcw2sdhK8Qhz7JgtkrUsdo+zgAVnPorrXROTSL GN5E4BRgYuok6Vn8jBA+Q/uGy3n3CX9IHdPwipWbgaNTZyihsY/vwBmvezx1hppYsfIT4KDUGUrm cebP3CF1xIjruX4SWdv7COE9QPP/vErpCQj/jyxcwNyun6SO0VNsPAHkvtQZSijEpcybdWLqjCR6 bhlH2xP/CJztve61lX5DjCWy9Z925TeNqFLlACL/BPwjsEfiGrWGHxG4mHWDV/AvJzyWOkZbzwGw Gltp2UvIs7cReDOwe+ocaSutB75OiIuYN+um1DENywGwHABrpBUrPwUOTJ2hZJp7ANw90EHnpLMg /BvQmTpHLSUncA1D8RMuo1knHACrFQfApeW7EjecCbwH73Wv7fMwISxifeh1+VQNm+7ujM7prwPO gjgT5zlKYzXExWT5IuYe/7vUMdpyPmGo8fTfsCex7e+I8W3AX6XOkYbJ7QRKsO6/mXfSutQxDcUB sBwAa6Q5AG51zTkAjjHQXzmVGD4GHJA6Ry3vJkL4OHO7lnirlIQcAKuVBsB9y/YhZO9j45V03vJA w+lR4JPEeAELZv0+dYwa1OJlE1gb3gHhTGD/1DnSk9YDXyLkvcybfXvqGD03B8BqDN21NiYMvZYs nA6cABRSJ0kjIvIHQlxMW+Fizuzy4MuWcAAsB8AaaQ6AW13zDYB7qodS4JMQj02dIj3NjyB+hAdX DNDdnaeOaTkOgNUKA+CeylQK4f0QTwc6UueoqT1BZDFjBj/q7b+0xYo3vACyBRDeBuyYOkfarMg3 CZzH/Jm3pE7R5jkAVn3rX7ofeds7gNOAPVPnSKNoHTFcRh4u4Oyun6eOqWsOgOUAWCOtWPkZ8ILU GUqmeQbAl9bG8nD+b8B7gfbUOdKz+CHwIebN+LpXBI8iB8Bq5gHwJUt3Y13b+wm8CxibOkct5VFi 6CFbe6H3CNZm9VaOoMD7iJwKZKlzpC0WqRLiecyfVUudomdyAKz6MzBQ4N5JryML7wZm4YueWtsQ IXwFhj7u0hqb4QBYDoA10hwAt7rmGAD3V2aQ80n8s6xGEvg+hA8yb8Y3Uqe0BAfAasYB8OJrx7N2 /ELgXGCn1DlqafdD/Cg7Fy7mtK61qWNUJ4rlLgjvA45PnSJtl8jNFPggc2dWU6fozxysqX5cUNuF UuVcVk3+BVn4Ghtf+PwzqlZXIMY3EbPvU6x+k97yK1MHSZKkBnJBbReK1cvIKePwV40mcgQxXkex /G1K5VmpcyQ1kO7ujGLlNNaO/ylwHg5/ld4uEC7k4XgXpfIbU8cosb7qCRTL34ZQxeGvmkHgGHIq FCs30Fd+aeocbdSWOkCit3IEGWdB/maiy/BImxdPJAsnUqwsIcs+xNyulamLJKklBAIuQKpGVKy+ BfIisEvqFGn7hFcQWUaxsoQ8P4eFs3+cukhSHSuVpxEpAS9OnSI9U9yPGL5MsXIjIV/oam8tpr8y gyH+gxCPcXFWNanZhDCLYvmr5PHffd+elgNgpdHdnTFp2muInANMT50jNZiTyPNXUyxfQ8g+xLwZ P0gdJEmS6khvbSIhvxjim1OnSMPsJLLseIrVxWwI3ZzTdX/qIEl1pKcylQKfIPJmnKyo/h1HzFZS rHyODdn7fU1rcn2V6QT+g5zjfHZSCwgQTiULp9BX/QxjNnyQd5/wh9RRrcjldTW6Lq2Npa9yOp3T 7iRyDQ5/pW0VIJxMjLdTrHyJ3vL+qYMkqWlFP6KrgZSqx5HlPyDg8FfNqg3imbTnd1OsnEP3QEfq IEmJLV7ZTqlyLgV+ArwFh79qHBnwT7TnP6FUfTsx+me32fRUD6VY+QaBG4HjUudIo6xAiGewru1n lKr/QmnJmNRBrcYBsEbHxTd1Uqr8Gw/nvyLwKeDg1ElSkwjAHLLwY4qVHnqun5Q6SJIkJdA90EGx 8lFirAL7pM6RRsFE4Hw6J99F/w17po6RlEip9grWPnQbkY8BO6bOkbbRZGL8LKXqjfRUD00do2HQ u3wKpcqnKMQfACelzpGSCkwgxk8Qx9xJqfrXqXNaiUtAa2RdsnQ31rctZMP69wA7p86RmlgHsJBC +z9SrPwXYV0/805alzpKkiSNgv7aweT5F4AjU6dICWzgrNmrmJs6Q9Ko+viKnRi37r+I+XvwAhc1 j2kU4u30VT7Omgf+k+4561MHaSudv3QHOtrOgQ3nED0pRXqaA4jxKoqVZTB0JvOPvzt1ULPzDZJG Rv8Ne9JX6WV92y+B9+HwVxotncD5xDE/8YwqSRo2LsWm+tVXOZ08vw2Hv2pVkR5CiKkzJI2iYvUk xq2/k8hZeGxTzaedwL/ROXklxarv7xpJX/lNdLT9BOjGFQmkZzMbCndQrHzIZaFHllcAa3iVansR 838l5+0E/MsrpbPvk2dU3UAM81gw46epgyRJ0jBafO141u5wMcR/SJ0iJRP5AxOyz6fOkDRKSkt2 Jo7tgfgOPO1Dze8wiN+hVP0ErP0PV3mrYz3VQynEfqArdYrUQMYC3cQxb6FUPpN5s8qpg5qRZ8lp ePSVd6dY6SPmdwPvBoe/Up04nhDvoK/yMc5fukPqGElqTMErgFVfemrPZ+34Wxz+quVl8SJO61qb OkPSKOivzCCOuQPiO1KnSKOojRj/lTjmVvqXHZY6Rk9TWrIzxeqFFOLtOPyVttWBxLCMYuVz9NYm po5pNg6AtX16rp9EsfJRQvgFMJ+NZ25Iqi8dBM6lo+0nlMpvTB0jSZK2Q7F6Mlm+EnhR6hQpscdZ X7g4dYSkEXZpbSx95SI5ZeB5qXOkRA4jz75HsTKXGD05tR6Uqn9N7PgJxLOB9tQ5UhM4jSz/EaXq a1KHNBOXgNa2OX/pDoxpW0jOOcCE1DmStshexPBlSpVrGOQ9nD3z3tRBkiRpCw0MFPjd5I9AfC/B +1JLwBWc03V/6ghJI6i/djAP51cSgic9SRsvuilRqp7IJUtP490n/CF1UEu6qLYHg0OLiPFUfEsu DbepxHgdpfIVtI1ZwHumPZg6qNF5BbC2Tnetjb7K6XQU7ibynwSHv1LDibyejDsplc/wzFFJ2hI+ VyqxvvLurJq8jMC5eKRJAshhqCd1hKQR1Fd+B7krXkibcBLr2+6gWJ2ZOqSlxBgoVd/OYH4XhFNT 50hNLYa3sWH9j+grz06d0ugcAGvLlSqvozP/AYFPQZiSOkfSdghMIIZPUqrWKN7wgtQ5kiRpM3pr LybLbsX7ikl/FriG+cffnTpD0gj4+IqdKFWvJITPADukzpHq1O4Ql1KsfMAT+0fBosrzKNVuIMbP Ap2pc6QWsSchLKVUuYDSkjGpYxqVA2A9t2L1SIqVbxG5BjgkdY6kYXUcFH5AX3WhHxokSaozveVT yPIVxLh36hSpruT5hakTJI2AnuqhjF13KzG+KXWK1AAKwHmUqtfRc/2k1DFNq1j+B4a4A+Ks1ClS CwpE/pnY8R16l70wdUwjcgCszbtk6W4UK5+G+D3guNQ5kkbMOELsoVgtc+FSDzBL0jN5goxGX6ly Llm4Cq9+kp7uuyyYvSJ1hKRhVqy+hUL8LnBQ6hSpwZxEof379FaOSB3SVC6o7UKx/BUIlwE7p86R Wlt4MVm2kr7K6alLGo0DYD3T4pXt9FUXsq7tZ8A/4Z8TqTUEZtDWdgfF6ltSp0iS1LJKS8ZQrF5G 5GP4Plx6pohX/0rNpHugg1KlH+IX8aQnaVs9j4yb6Ct79fxw6K+8mvahO7zXr1RXxhP4FMXKFSy+ dnzqmEbhAQX9pVLleNY+dAch9hCYkDpH0qibCPGLlKpXcvFN3tdEkjbyCmCNjtLyXYljyxD/IXWK VKfuYc8Hvpo6QtIwKS3flc7JZSJnpU6RmsB4Qvhv+ir/6S2+tlFpyRiKlRI534AwJXWOpE16K2vH f5e+qiuGbAEHwNqopzKVUmWAyFLg4NQ5khKL8U0MbvgBxcrRqVMkSWoJPdVDiYPfhXhs6hSpjvUx Z85Q6ghJw6CvfDhxw/eAaalTpCYSCPwbpepVXFTbMXVMQ+kt70/esQKYiycAS/XurwjxVlc9eG4O gFtdd3dGsfpOCtxF5G9S50iqIzHuDdxIsdJNd7evF5JaVwgeANDI6i2/kkK8EeJ+qVOkOvYgbdml qSMkDYNi9SRCuAnYN3WK1KTewGB+Cz2VqalDGkKxejJZWEkIR6VOkbTFdiKEK+krFxkYKKSOqVce 0G9lpcrL6Jy2EuJivJm9pE1rAz5E57HXsKg8OXWMJElNp696KlmoAr7OSs8qfpIzux5NXSFpO5Uq 50K8Fo9DSSPtMArhJvprrvS4Od0DHfSVixC/DngbNKkRhTCPVZOuZvEyb2e6CQ6AW9FFtR0pVfqJ fBt4SeocSY0gvIY8u53+6jGpSyRJahp91fcQ4gAwNnWKVOfWkXf0p46QtB0GBgoUK5cQ+Rgej5RG SdyPPL/ZYzmb0H/DnnROXk4I81KnSNpe4TWszb5N8YYXpC6pN77hajWlyvEM5j8kchb+/kvaGjHu TR6/Ranqm2NJkrZHjIFi5TxCvAjfk0vPLfLfLJy+KnWGpG10/tIdWDX5a8C7UqdILWgSeSxTrLwh dUjdKFaOJs9WAi9PnSJp2LwQCt+lWJ2ZOqSeeLChVSxeNoFieTGR6/EeK5K2XRsxFilWvkjPLeNS x0jSqIjRewBr+AwMFChVPgl8IHWK1Dhib+oCSdtoUXkyHW03AK9LnSK1sLHAlylWTksdklyx8lag AmFK6hRJw64T4vX0VU5PHVIvHAC3gr7q61mb3QXhnYAHMCUNh7dQeOJb9FSmpg6RJKlhLL52PKsm Xf3k+3JJWyRcz4JZd6SukLQN+pfux1D4LnB06hRJFIDP0Fd9T+qQJBavbKdYuRi4Am+/IjWzNgKL KVY84RoHwM1t8bIJFKuXEeLVwJ6pcyQ1nZdRiLdSrPhhXlKz8wQ6bb/FyybwxPgbILwmdYrUUEJ+ YeoESdugVD6EvO0m4IDUKZL+JCPEi+irvC91yKjquX4Sax9aBrw7dYqkURGA8yiWF9Nda0sdk5ID 4GbVX5nB2uwOiP+QOkVSMwtTgJrLCEmS9Cx6rp/E2mwZgWNSp0iNJf4P82aVU1dI2kr9taOI4UbA FaOkehT4KH3VD6fOGBX9S/ej0H4zcFzqFEmjLbyTzvyrrXwbQwfAzebS2lj6Kh8jZxmwT+ocSS2h A/gcfeUi3d2+rkhqRl4BrG13ydLdKLRXgZemTpEaTsSrf6VG01eZTp5XgF1Sp0h6FiF+kFL5g6kz RlSp8jLytm8DB6dOkZTM6yg8cT2lJTunDknBA/XNpLdyBA/ntxM4F39vJY22EObROe1yugc6UqdI klQXepdPYX1bDXhR6hSpAf2WcRO/lDpC0lboK88mcD3QkgdZpYYTw4eb9j6ZveVTiNSA3VOnSEpu OnHMMnqun5Q6ZLQ5JGwGMQb6qgvJuAXPaJKU1t8zaZelXHxTZ+oQSZKSunDp3mQbbgQOSZ0iNaQQ Spxx1IbUGZK2UKlyPCFcDbTsMotSgzqPUuXc1BHDqliZSxa+AoxPnSKpbryMQvu3uKi2R+qQ0eQA uNGVlu9KqXodIfYAY1LnSBIxvooN61fQW9s3dYokSUn0lvenrW058ILUKVKDeoQxQ59KHSFpC/VV TyDi8FdqVJGPUazMTZ0xLIqVDwEloJA6RVLdOYzBfDk9lampQ0aLA+BGVirPIq7/AXBS6hRJeppD yIZuoX/ZYalDJGn7Re8BrC3XU3s+WbgR2Dd1itTAPsMZsx9KHSFpCxTLJxLi14GxqVMkbZc+SuW/ Sx2xzWIM9FV6ge7UKZLq2gsoUKP/hj1Th4wGB8CNaGCgQLFyHjEshTAldY4kbVqYQp59i77qy1OX SJI0Knpr+1LIK8BeqVOkBjZIgWLqCElboK88G4LDX6k5ZMRwKcVq411oNDBQoFj9HIEFqVMkNYQX kBeq9C5v+tmaA+BGc0FtF1ZNXgJ8AH//JNW/SYRYoVQ5PnWIJG274BXAem49lalkeRnYJ3WK1OAG OGvmr1NHSHoOpdorCOGreDsyqZm0Q/wKpfK01CFbrHugg1WTryTwj6lTJDWUg8g2fKvZh8AOEBtJ 37Jjac//B3CQIqmR7EDkaorVk1OHSJI0IvrKu1OgAhyQOkVqeFnWmzpB0nPorRxBnl8P7Jg6RdKw G0cMV9NfOzh1yHO6tDaWzl2uBt6YOkVSQzqQwoZlXFDbJXXISHEA3CiK1XcSsgrQMjeoltRUxkK8 imLltNQhkrQNvAJYm9dbm0gI3wQOSp0iNYEac7tWpo6Q9CwWlQ8kYwmBCalTJI2YTvK4hL7y7qlD Nqt7oIOH8wGIJ6ZOkdTAIofSni/h4yt2Sp0yEhwA17vzl+5AqTIAcTHQkTpHkrZDAfgMfeV3pA6R JGlY9NYmPnnP35ekTpGaQow9qRMkPYv+pfsxFKpA/Q6FJA2TuB9Z+Bo9t4xLXfIM3QMddE6+Cnhd 6hRJTeGljF33NUpLmu62Fg6A69mFS/emo+1GIn+TOkWShklGCJ+mVD4jdYgkbbHoFcDahPOX7kCW X0PkiNQpUpP4KWtWLEkdIWkzFpUnk7ctwZXppNYReSWFJ66gu7t+ZgiLV7bTOWkAeG3qFElNZSax 40t019pShwyn+nny1l/qr8ygre124MjUKZI0zAIxXEyx/A+pQyRpiwRi6gTVme6BDjrargampU6R mkbkQrq789QZkjZh8bXjGeI6oP7vCSppuL2Rzmn/kToC2Dj8XffQAISTU6dIakbhZDrzS1JXDCcH wPWoWJ5PzlJgcuoUSRohGYTPUay8NXWIJD0nrwDWU8UY6Jx8KTAzdYrURH7PhOzzqSMkbcLAQIG1 46+E8IrUKZKS+Vf6qqcmLejuzlj70BeInJK0Q1Kz+yeKlQ+kjhguDoDrSfdAB8XyZyH0AU11qbkk bUIGXEqp/HepQyRJ2mKl6ieAt6TOkJpLuIjTutamrpC0CasmXYz32ZRaXSDEyyjW/ipZQee0i4A5 yfYvqZX8J8Xy36aOGA4OgOtFz/WT6Jx8PYS3p06RpFFUIIbL6at4r3NJ9St4BbCeVKosAM5JnSE1 mcfZEJpqqTWpafSV/xXCO1NnSKoLOxLyr3HxTZ2jvudi5TzgXaO+X0mtKkC4lP7qMalDtpcD4HrQ U3s+hfZbgK7UKZKUQIHAF+grz04dIknSZvWV30TkwtQZUhO6nHO67k8dIelp+qqnEsJ/ps6QVEci z2f9+i/S3T16M4WNJ2A2zXKskhrGWPL4dXpqz08dsj0cAKdWrBxNlt8XIz4JAAAgAElEQVQMHJQ6 RZIS6iCEr1OsHJ06RJI2wSuAW12pehwhXI6fn6ThlsNQb+oISU9TWvYSQvR1T9IzBV7NxGPfNyr7 KpX/zhMwJSW0C4X8OhYvm5A6ZFv5Ri6ljfe9rBLYLXWKJNWB8cA19C57YeoQSZKeooM8Xg2MSR0i NZ3ANcw//u7UGZKeov+GPYnZtcAOqVMk1akQPkypPG1E99FXPYEYLsP5haS0DmJddsWornwwjBoy uikUy/OJ4Qo8kCRJTzWZLFtGb23f1CGS9BReAdza2gg07Bm/Ul2LnJ86QdJTxDCOvPBVYGrqFEl1 rY0Y/psLaruMyNZL5UMI8UqgbUS2L0lbI/J6Oqd9MHXGtnAAPNq6uzP6Kr0Q+vD/f0nalKlk+TdH 7IOEJG29mDpAkppP/A7zZ96SukLSX5gOvDx1hKSGMJW2/ApiHN6TZfvKuxPDEmDisG5XkrbPBylW T04dsbUcQI6m0pIxdE77IoEFqVMkqc4dTHt+NZfWxqYOkSS8AliShl/wnn6SJDW0wKsp1obvOHfP LeMI4WrgecO2TUkaHgHiFfTXDk4dsjUcAI+W0pKdyccsAf42dYokNYijeTi/dNjPJpUkSVJq97DH 6q+ljpAkSdspxP+ip3rodm8nxkDbE5fjKgSS6tfO5PkAPbeMSx2ypRwAj4YLaruQd1QIzEidIkkN 5m8pVv8jdYSklueJKJI0vPqYM2codYQkSdpuYynEz9M90LFdW+mvnUfkb4apSZJGymG0PVFMHbGl HACPtItqe9CeVwnhqNQpktSQAh+gr/q21BmSWpoDYEkaPg/Sll2aOkKSJA2bl9A5qXubH91bPoUY 3z98OZI0giKnU6y8NXXGlnAAPJL6l+7HYL4COCx1iiQ1sECIn6avMj11iKSWFVMHSFLTCOESzux6 NHWGJEkaTuG99FeP2eqH9VQPJQufx5NuJTWWi1hUPjB1xHNxADxS+msHk7ctBw5InSJJTaCDwFcp 3vCC1CGSWpIHIyRpeKxjqG1R6ghJkjTsCuTxs1xaG7vFj1i8bAKF+FVgx5HLkqQRsRND4crtXv5+ hDkAHgl95cMZym8E9kqdIklNZDIUvs7HV+yUOkSSJEnb5P+xcPqq1BGSJGlEHMQj8d+36Du7uzPW Zp8H6v4KOknajJfQOfnDqSOejQPg4VaqvogQKgR2S50iSU3oEMatu4IYvRpP0mjyOUeStl8kxr7U EZIkaQTF+F56K0c85/d1Tvt34HUjHyRJI+q9lKrHpY7YHAfAw6lUfRExloFdUqdIUtOKnEJ/9b2p MyRJkrQ1wlIWzLojdYUkSRpRbWR8iu5a22a/o1g+Efjg6CVJ0ojJiPFz9bpipQPg4dJbezExVnD4 K0kjL/IR+sqzU2dIkiRpi12QOkCSJI2KI+nMF2zyv1xU24MYLse5hKTmsT9j19blSkc+0Q6H3tqL yfJlwOTUKZLUIgqEcCW95f1Th0hqAdEloCVpO93BvK5q6ghJkjRqPsyiyvP+4le6uzMG8yu8daKk 5hPeTqlSd8vaOwDeXsXaXz05/PXKX0kaXZPIwleAcalDJEmS9CxiPJ8QYuoMSZI0asYzxCf+4lcm Tnsv4GpukppTZFG9LQXtAHh79NSeD0M34PBXklJ5yZNfkjRyglcAS9J2uJc1qwdSR0iSpFE3h77q CQD0lV9K4MOJeyRpJO3D2HUfSR3xVA6At9WFS/emkC+DMCV1iiRJkiRJdaqP7jnrU0dIkqQEQixx ydLdCNmXgI7UOZI0ws6kb9mxqSP+yAHwtuipTKWtrQbsmzpFkiRJkqQ69TBj80+njpAkSckcyIb2 lRD3Sx0iSaMgI2SLKS0ZkzoEHABvvdLyXSlQBg5InSJJkiRJUv0Kn+GM2Q+lrpAkSQnFuHfqBEka RYcQx5yTOgIcAG+dxdeOhw1XAwenTpEkSdKo8T2zJG29QeJQMXWEJEmSJI2yD9Bb2zd1hAezttTi le2sG/dVIq9MnSJJkiRJUp0bYMHs36SOkCRJkqRRNo5s6ILUEQ6At0SMgXVrPkMMJ6ROkSRJkiSp 7gW8+leSJElSiwqn0l95dcoCB8BboljtIYa3pc6QJElSEiF1gCQ1mBrzZn4vdYQkSZIkJZNTpLRk TKrdOwB+LsXq+wksSJ0hSZKkZGLqAElqKDH2pE6QJEmSpMReAGPenWrnDoCfTbE6B+JHUmdIkiQp Ka8AlqQt91PWrFiSOkKSJEmSkot8gNKSnVPs2gHw5vQtOxbi5XjAT5IkqdX5flCStlSM59PdnafO kCRJkqQ6sAtxzNkpduwAeFNKlQMI2VeBsalTJEmSJElqCJE/MKHwxdQZkiRJklRH/pm+8u6jvVMH wE+3qDyZyBJg19QpkiRJqgteASxJWyKjn9O61qbOkCRJkqQ6siMhvH+0d+oA+KlKS8YwGK4GDkyd IkmSpLoRUwdIUgN4nPXZJ1NHSJIkSVIdehe9tX1Hc4cOgJ8qjllE4JjUGZIkSaorXgEsSc8pXMo5 XfenrpAkSZKkOjSGLHaP5g4dAP9RqbIA+KfUGZIkSao7DoAl6dnlDIW+1BGSJEmSVL/iWylVXzRa e3MADFAqzyJyfuoMSZIk1SWXgJakZ3c1Z3f9PHWEJEmSJNWxjJj/++jtrNX1L92PGP4baEudIkmS pLrkFcCS9OwuSB0gSZIkSfUvvIGe6qGjsafWHgB/fMVO5G3XAbukTpEkSZIkqfHE7zB/5i2pKyRJ kiSpAWS05e8dnR21qhgD49Z9FjgkdYokSZLqmlcAS9LmxMyrfyVJkiRpS8XwZvqX7jfSu2ndAXCp +s9E/iZ1hiRJkuqeA2BJ2qTwS/a8/+upKyRJkiSpgbSTF84Z6Z205gC4WDka+K/UGZIkSZIkNa78 QubMGUpdIUmSJEmNJbyDvvLuI7mH1hsAX1TbA/gy0J46RZIkSZKkBrWatsLlqSMkSZIkqQGNIQun j+QOWmsA3F1rYzAfAPZMnSJJkqSG4RLQkvR0kYs5s+vR1BmSJEmS1JBy5nJpbexIbb61BsATh/4L mJY6Q5IkSZKkBraO2H5x6ghJkiRJaliB3XgozhmpzbfOALhYPpEQ/jl1hiRJkiRJjS18gYXTV6Wu kCRJkqSGFuI5I7Xp1hgA9y6fQgyX0yo/ryRJkiRJIyMyRG/qCEmSJElqAofRV5k+Ehtu/oFod3dG NngFgd1Sp0iSJKkheQ9gSfqzb3L2jDtTR0iSJElSUwjhnSOx2eYfAE+a9q8QZ6XOkCRJUsNyACxJ f5RxYeoESZIkSWoe8Y2Ulu863Ftt7gFwsXI0kQ+lzpAkSVJDi6kDJKlO3M7cmdXUEZIkSZLURMYQ 1791uDfavAPg85fuAFwGtCUukSRJUmPzCmBJAgjRq38lSZIkadiFdxLjsB5/at4BcEehBLwgdYYk SZIangNgSYLfMmbiQOoISZIkSWpCB9Ffmz6cG2zOAXCxejKEt6fOkCRJUlNwCWhJgiJnHLUhdYQk SZIkNaXI6cO5ueYbAJeW7wpxceoMSZIkNQ2vAJbU6h5hbP7p1BGSJEmS1LziG/j4ip2Ga2vNNwCO Gz4H7J46Q5IkSZKk5hA+zRmzH0pdIUmSJElNbDxj1r9huDbWXAPgUvXtwGtTZ0iSJKmpeAWwpFY2 SBwqpo6QJEmSpKYX4t8P16aaZwDcu3wKMV6QOkOSJElNxwGwpBYWvsSC2b9JXSFJkiRJLWAmpdpe w7Gh5hkAFzZcDHSmzpAkSZIkqWnksSd1giRJkiS1iIyY/+1wbKhtODaSXKn8d0ROSZ0htYDHCfwS wv8R8weAjV+RBwhhNTE8AEOrCYUnyMJjDA6t/9Mj23mIbEz+zC0OFigM7QxALGQU4gSyEBga6iRk nYS8kzx0EkInIXYS6YSwB8S9gD2BjlH5ySVJkqTWU2PhzO+njpCkFrAGiBDWQIx//uUQIE4ECsDO idokaTg9+LT/fdKfnu/agJ1GuUmqN38PbPeKx40/AO4r704M3o9IGh4R+CXwCwK/IoZfQv5LYvZL yH/Fglm/H6H93r9Nj4ox0HfTHoT1exHCXoSwN8R9iBxI4IVE9mPjhyRJkiRJWyuEC1MnSFKD+w0h /pgYfkaM9xG4l5jdRwj3Egq/Z+60+wkhPvdmnnTxTZ2sG5wA+SQKYQp5vgch25MQ9ybnAALPB/ai mVZ9lNQIIvBr4C5i/Dkhu4/IvWTxPgbDveTh95zTteXHf2MMXLJiIkOPTyRvn0TMpxDCHoS4JzHb h8ABwAHEuBfesknN6UWUyocwb9Zd27ORxh8Ah7AImJw6Q2pAa4nxR2ThdmL8AVn2PzzecQfnHvtI 6rAttvFD0qonv259xn8vLRlD3nEQITuYkB8M2SHEeDhwEH4YkiRJkp7NXcztWsK81BmS1BA2QLwN wreJ8U7IfkS29sfMO+nhZ33U1j7Hvmfag2y8au5Xm/2e0pIxDI17ISEeToiHQXgxxJfhFcSShsd6 IreS8R3gR+TxTtoLP+bMrkeHbQ8bj/n+8fnul5v9vktrY1mTH0KBw4nhMIgvAV4K7DhsLVIqMTsV 2K4BcGOfHVGqvI7INakzpAbxY2JYDvkK8ux2Hg4/pbtrMHVUEqUlOxM7jiRkRxHjy9j4xuB5qbMk baOxj+/AGa97PHWGmlSMgVL1mbcwkKTmdzrzZ34mdYRGUV95d0K4L3WG1CAeI8QVxOxm8qGbGL/2 e3X9mWRgoMDvJh1KCEcDxwGzgF0SV0lqDI8ANxHjzWTcxE6FWzmta23qqM0aGChwX+fhxHA0hFcB M4BJiaukbRD/h/mzXrI9W2jcAfBFtR0ZzO8E9kmdItWhCNxJ4FvkLIe4fASXb24OlyzdjQ1tLyfS xcY3BofTyM+RUitxAKyR5ABYUmv6PTtn+9b1wT0NPwfA0nP5LXAdGdewY1Zr6OfI7u6MzukvIeYn AG8ghCPxGIikP/sVgevI4zWsWX0j3XPWpw7aZgMDBe6bfCTEE4m8YeOqCFKDyOMBLJx1z7Y+vHFf 2IvVCyGenTpDqiMPEOI3gGvJqHHWrAdSBzW0C2q70DH0KmKYwcaB8EGpkyRthgNgjaTu7ozOaUOp MyRtVgTWENlA4I/Lzg2y8UoFgBzCQ09+65P3WAx/+Tk4xB2I7MTGpTF3BiaOdHTdC/w782aelzpD o8wBsLQp9xDDF4jxahbMuH2r7tfbSPqW7QOFUwnxNOCw1DmSkvgZhC8Q86tZMOuO1DEjpre8P4Xs VGJ8O3Bw6hzpOfwL82desK0PbswBcGnZS4jZ92iGexhL2+ce4Gry/BqmPngTc+Z4gHqklGp7EfPX EuIpxNAFdKROkvQkB8AaSQ6ApRTWs/Hehr+CsAriKkJYReQ+Qr6KnIcgrmEcD3HG7IdGpKC0ZGcY tzN5nEqW7w1hL3KeR4h7Q9ibjStR7TEi+07vcQpxH08obUEOgKU/egT4CpHLmD/jpqYd+m5OqfYK 4tDpEN4E7JA6R9KIWkMMXyLml7Nw1rdTx4y6UnkaMZwOvBEYlzpHeqb4HebPeuW2PrrxBsADAwVW Tf42G+/ZKbWiHwFXkuXXMHf2D1PHtKTSkp2JY08kxlMIvBqvEpHScgCskeQAWBpJ/wfhB8AdxPwu AvcQ4y9Yc/Nv6e6u/6XXFy+bwOPhELJwKJFDCRwJHEHDHyyPFzN/1pmpK5SAA2Dpe8Aixj5+lZ8v ePJkqI43Q3gnkSNS50gaTmEF5Bexc+HrDb2c/XDprU0k5H9P4J24CoLqS2SIvTl75r3b8uDGGwD3 Vc4i0J86Qxpl9xPj/yNkVzB/xm2pY/QUi1e288SaVxHCm4FT2bhsoKTR5ABYI2njyYeDqTOkJrCG yLfJuAX4HoXsDs7sar5B08BAgVW7vhDylxKZTgjHQdwvddZWyBnKDuLsrp+nDlECDoDVmoYgfp0s 62XujJtTx9StYvlECN3Ay1OnSNpmG4h8BWIvC2bdmjqmLsUYKNVeD/FDwEtS50gbxbOYP+uibXlk Yw2AS8t3JW74KdCZOkUaBeuBb0C4nLE7L+GMozakDtJzWHzteNbucAox/j2B44FC6iSpJTgA1khy ACxtqzUElkGsEAs38+CNdzXEVb0joW/ZPoTsOGA2cCKwa+KizYt8lQUzT02doUQcAKu1PEbk0xQG S8w94ZepYxpGsXrSk4ORl6VOkbTFHoFwCYMbFvHPJ/xv6piGEGOgr3IyGR+C8OLUOWpxkW+yYOZJ 2/LQBhsAVz5F5PTUGdIIu4cYFtGWX+F9txpY7/IpZOvfDOFtwItS50hNzQGwRpIDYGlLRYg/AL5J 4JusLnyb7i7/7jxdd3fGpONeRsxfC/E1dXhA6Rjmz7wldYQScQCs1rCOGBfTXvhoU65EMVpK1dcQ 40fweIdUzx4nxosYLHyCc7ruTx3TkGIMlKqnAB8BXpg6Ry3rCYbGTebso5/Y2gc2zgC4t3IEGbcC WeoUaYTcRgwl1oT/58GyJlOsHgn5OyG8FRiXOkdqOg6ANZK6a2105q7CIW3eXcCXYeiLzD/+7tQx Dae3ti/Z0MnE8DcEjklc8z3mz3Rpz1bmAFjNbQNwJXnsZuGse1LHNIXuWhudQ2dC+E9gp9Q5kv5k A8RLyfIPM/f436WOaQqLV7azds17IJwH7Jg6Ry0ohhNZMGPp1j6sMQbAMQb6qzcTeWXqFGmYrQe+ RE4fC2d+P3WMRlhfeXdC9k6IZwBTU+dITcMBsEaSA2BpU35D5ArycCVnz7gzdUzT6KkeSiH/O+Af IUwZ9f3H8EYWzLhq1Per+uEAWE0rXs1Q4Rzvbz5CLly6N+1tJSKnpE6RWl4IXyKL53LWzF+nTmlK veX9ybKLIJ6YOkUtJsYSC2bN39qHNcYAuFj+BwiXpc6QhtEjhNDPUNsiFk5flTpGo2zxynaeeOgU AnOBaalzpIbnAFgjafHKdtY+tD51hlQHIiHeQMwuYcr91zFnzlDqoKbVXWtjYjyJEP8JeDXQNgp7 /QVTHjjI39cW5wBYzeenxDB/W66Y0Tboq76ejEXEuHfqFKkF/ZA8n8fC2d9KHdISitU5EIvAHqlT 1DJ+xvyZB23tg+p/AHxRbUcG87vxL5Oaw6PAIgrxAu/vKwD6lh1LKHzAM8ek7eAAWCPJAbBaXeQh QvgsDH7SJZ4T6L9hT4bazoD4LgK7jdh+InNZMHPRiG1fjcEBsJrHIxDP48HVfXTP8X3caOq5fhKF 9suA1yUukVrFGkL4EKvDxd5ScJRtXOnxCxBnpU5Riwg8n3kzf7F1D6l3xfJ/QPj31BnSdnocuJjQ /gnmTf+/1DGqQ/21o4j5B4icTCM8N0v1xAGwRpIDYLWu1RD6yEM/C7vWpI5peZfWxvJIfAsxLgAO G+atr2b94D78ywmPDfN21WgcAKsZRL5Jlr2TeV2/TZ3SsmIMFCtnE8JHgfbUOVIT+xoxvpsFs36f OqRldXdndE7/AMQPAYXUOWpy23DSbn0PGXoqUynwM2B86hRpGz1BZDHEj/lirC3Sv+wwhrL3E5iD bxykLeMAWCOpe6CDzsnrUmdIo+j/IPSytmMR5x77SOoYbUKpPIs8vJ/AjGHa4keYP/PfhmlbamQO gNXYHgb+mXkzPksIMXWMgFLtFcT8SuB5qVOkJrOaEOcxb9YXU4foSb3LXkWWfRHYM3WKmln8BvNn vXZrHpGNVMqwyDgPh79qTJEQvsTg4EEsmLnQ4a+22NzZP2TBzLcQ4uHAtalzJElSy3gMwgdZP7gf 82d81OFvHZs3q8yCmTOJ+TRg2XZubR1tmUs/S2pwoUzMD2P+zM84/K0j87q+w9CGI4AbU6dITeQ6 8va/cvhbZxbO/hYxHgF8N3WKmlmYxsDAVl0wVr9XAPfWXkyW30a9D6mlZ4j/QwzzWTBzeeoSNYFS 9ThiPB94aeoUqW55BbBGklcAq/lF4IsM8T7Onnlv6hhtg2LlaEL8IDGcsPUPjp9j/qx3DH+UGpJX AKvxrIf4XubNLDn4rWOlJWOIY64A5qROkRrYWgjzmT/jU6lD9CzOX7oDHW1XAlt1laa0xbLspczt WrnF3z6SLdslyz9BPfdJz7Qa4gKmrD7K4a+GzbwZNzJvxsuJzAG26ibvkqRhMGnH+j1hUtp+t5KF acyf+VaHvw1s/sxbmDfrREL2SiI3b8UjI0NZz4h1SdJICuF/yeOrmD+r6PC3zs07aR3zZvwtkY+n TpEa1N3k2Ssd/jaAfznhMaY8cArwydQpalJDQ8dtzbfX54C1WD4RmJ06Q9pCg0CRPDuA+bOKzJkz lDpITSaEyIKZX+bBBw4hhrOJPJQ6SZIkNbSHCfFdzJvxcubO2JqBoerZvK7vMH/GNP4/e3cer/dZ 1/n/fd0naVIrhQIq28w47rgviIgVPFkoFqsOMxMVVwbHypKTBRAY/Q3HhVGsshSBX3XGio4CdRcF C7QBCkUFBMsuS2Xf2rSka5Jz39f8kdAmzXZyzn2f676/3+fzDx9tE895PR7WK00+9+e6Un8syYeX 8b/xquze9O5JZwFMwCuydOBbs2vLm1uHsEyH/lzj6Ul9cg7dPgIsR8mfpux/UHbNv6N1Csu0bdsw OzY/PqU+s3UKHVTKjA+Aay0p5VmtM2CZrknKQ7Jj887smr+xdQwdt7jtQHZuem7q+gemlJe3zgHo hbudaQOYbin18tTRN2VhyyU2pjqolJodW16WG65/YGrZnWTvCX/uIL+9dmEAYzFKzTOysOmHsvuR Jz7fmF47tjwntTwphsBwKktJFrKweVsWzt/XOoYVWNjyK0l9WusMOud7s7i47Lnu9A2An3/lf0nN t7fOgFNYSs2zU/Y/ODs2va11DD2z62GfysKmH03qpiTva50DAMyAms8n5cJs3/z92bn1o61zmLAv fHBwePCrU+vFSUZ3+Rn/kidt2tMiDWCFbsmo/ufs3PwbPsA043ZuelFSd7XOgCl2U0r54ezY/ILW IazSji2/meSXW2fQKffI3R/+zcv9ydM1AL7ssrkU/w/BlCv559T6Hdm5+elZOH9/6xx6bMeWPRme +e1JnpXkQOscAGBqvT6jfEN2bPpdf2jeM7sfuTc7t+xIHT08yTV3/PNSL/LvAjBDPpFRHpZdW/6q dQhjsmPL812PCsdTrs2wfHcWNv1d6xLGZMfmxdR6UesMOmRu9H3L/anTNQD+9L1+MskDW2fACexP rb+YvYPvys4t15z6p8Ma2P3Q27Jj8y9lNPrW1HjDD2DcbtjgCmhm2Sil/K/c9/rN2b35E61jaGjn 1jfmhsF3HL4W+j3ZcI/LWicBLNPbM8x3Zdfmf24dwpgtbPmV1Dy7dQZMjZI354yDD8nuTe9uncKY 7dj8tKS+qHUGnbHsd4CnZwC8eNkZqfHJL6bV+zIYfWd2bvlfWZxfah0Dx9i19b253/UPT8r/iG1g ACC5LqmPysKmX8y2bcPWMUyBxfml7Nz03Nww+JZc+KCDrXMAluGKrBs8zIeYOmzHpmck8aEkSP42 dxtsyuPP+2zrECaglJr77l1Iqs1uVq/m3NS6rGWF6RkA3+PeP5vky1tnwLHKS3Jg6UHZvvWdrUvg pLZtG2bHpl9PGT0kJT4tCAD9dXWWlr49O7b8fesQppAPtAKzoORvcvbgB/LE+ZtbpzBBpdRsvPWx KbHhTZ+9LBvv/ug8dv721iFM0LZtw5QDj0nyntYpzLx757mv+8rl/MTpGABf8tb1KfUXWmfAXdyW lAuzY9PP5Knn3dI6BpZtYevbc7fBgw5fpTRqnQMw08663hXQzJjyktxw/XyefN7HWpcAwAq9LBvu /l8MQ3riwgtuTRlekMSmN/1T6h/mhsFPup2lJxbO35fB0g8kua51CjNurj54OT9tOgbA+2/8b0n+ Q+sMOMI7Mxh8e3Zs+t3WIbAij52/PTs3Pz2DbE0p/gAYALqvJuV/ZmH+sVnc5jkIAGZU/d3ccNWP G4b0zPZHfDJl8F+S7G+dAmunPCfbN/+M21l6Zvt512aQH0ni/+6sXK3fuZyf1n4AfMlb16eWp7fO gCP87wzP/K5sn39f6xBYte2br8yB8u1JXt06BWAm7TvDBjCzYH9SfiI7Nv1qSqmtYwBgZervZ2Hz z2dx0U1WfbQw/w8p8WfE9MXzs2PTk/23e09t33xlUn6ldQYzrGRGNoBv//xPx9u/TIdhSp6eHZv/ e3Y/9LbWMTA2T5m/LgubHnn4N1J+Iw0A3bI3pZyXHZv+pHUIAKxYzV/khrkLDUN6bvum5yf171pn wGSVl+SGq3a3rqCxG97wrJTyutYZzKxvzyVvXX+qn9R2ALy4Z12SZzRtgENuSKmPzMLmZ7cOgYko pWZh87NTyg8muaF1DgAwDvVTGY3OzcKm17cuAYBVeEXOvPuPugaVlFKzbu5nU/PZ1ikwEaW8PPe9 7nFuOiCLi6MM6s8kubF1CjNpY279/Ded6ie1HQCfM/zxJF/RtAGS92euPiQLW17bOgQmbmHT32VU H5Tk7a1TAGbCF7kCmqn18WT08Oza+t7WIQCwClfk7ME2b/5yhyfOfzqpj0tiG5yueUU2nP2T2bZt 2DqEKfGkzR9J6uNbZzCj5k79DnC7AXCtJSm/0Oz7wyGvzmjwkDxpy7+2DoE1s2vLhzM883uS/FHr FABgRT6SUX14djziA61DAGAV3pWy/9F57PztrUOYMju3/G1K9WcWdMlbsvHWH/VhF46xY8vLkvxl 6wxmUD31O8DtBsAvuPIHknx9s+8PJb+TGwaPyq551yzQP7sfelsWNv10kl+OT9UCwCz5UOby8Oza 8uHWIQCwCp/OXH4gC+fvax3CtDrjKUn2tq6AMfho1g1+MBdecGvrEKbU0tKOJDe1zmDWlCkeAFfb v7RU/mcWNm/3vgy9VkrNjs2LSX1skgOtcwCm0s3rXQHN9Cj5YCPtqZgAACAASURBVMrg+w5dFQYA M+vWlPyQX884qYWHfS7J01pnwCrty2D0A4euNocTePJ5H0stz2ydwcx5YC7ds/FkP6HNAPjiKx6c 1HObfG/6rqaW3dmx6Vdbh8DU2LHlJRnk+5PYhge4qzP3GQAzLT6XOjw/C/Mfbx0CAKtQk/q4LGz+ p9YhzICFTf8npbyudQas0DC1/ni2b31n6xBmwP2uuzjJ21tnMFPmctPSA0/2E1ptAD+j0fel3w6m 5Mezc9NzW4fA1Nm++cqU+j1JfAIbAKbPvowGj/DmLwCzr/7a4fcO4dRKqclwd5JR6xQ4ffV/ZOeW v21dwYzYtm2YOlponcGMGc1908l+eO0HwM+78mtT84Nr/n3pu1szyA9lYfNLW4fA1FrY8p6sGzwk qe9onQIA3GF/BvlP2TXv12cAZt0Vue/eX24dwYxZ2Pr2pPjzPGZLyd9kYfNFrTOYMTu3vjElf9M6 g1ky+saT/WiLDeBdjb4v/XVjBuUR2b75Va1DYOo9cf7TWb9hUxLXcQFAezWlPi7bN1/ZOgQAVumT OWPpMdm2bdg6hBk0Kr+UZH/rDFiecm3WnfEzhzbY4XTVZyTxayXLUwZTtAH8oqvOSak/sabfk77b l1oeme2b3tQ6BGbGE773hqwbbE6yp3UKQHMb1nsDmIbqb2Rhyx+3rgCAVVpKqT+ax5/32dYhzKhd 8/+Wmhe3zoBl2J/kv+YJ33tD6xBm1MKW9yTlD1pnMCvqFA2ADx54XJKz1vR70mc3Z1DOz85N/9g6 BGbOE+dvzoGlC2IIDACtvCI3vPGXWkcAwBgsZmHLVa0jmHFLg2cluaV1BpxUKb+QHZve1jqDGVfK YpIDrTOYCffPc/7+nif6wbUbAF922VySJ67Z96Pvbs1odIHNX1iFp553S4ZnPiopf986BQB6peTd Kft/IouLo9YpALBKb8sNg2e3jqADnjJ/XWp+r3UGnMRV2fuG32kdQQcszH88KX/UOoMZMVh/wneA 124A/Kl7/WCSL1+z70ef3Z5afzi7tr6udQjMvN0PvS3l9h9Oyd+0TgFo4tZ1roBmrd2UQX10Fs7f 1zoEAFbpQGr9b1mcX2odQkcMl54TW3FMp1uT4eN8gJOxmRv9ZhL/PnFq5cTXQK/lFdA71vB70V8H UrItO7e8pnUIdMbC+fuz9/r/mppXtU4BWHMbDIBZY7U+IU/a8q+tMwBg9cqvZeeWa1pX0CFPPu9j Sf64dQYco+QXs+MRH2idQYcc+j3hX7TOYBaUxhvAz3vtNyd5+Jp8L/pslFoek4XNr2gdAp2zuO1A 1g+2JfUfWqcAQIe9ODu3/N/WEQAwBv+SjWf/RusIOmg0uihJbZ0BR7g6e6+6uHUEHVTrb7ZOYCZ8 w4l+YG0GwCUXrsn3od9K2ZWdm/68dQZ01hPnb85w6VFJ3tU6BQA6p+SfU/bvap0BAGNwMGX02Fz4 oIOtQ+igXVvfm5o9rTPgsNszGLj6mcnYueUtSf6pdQbTrn7ViX5k8gPgiy4/K7X8+MS/D3333Cxs 8kkrmLTdj9ybwfC8pFzbOgUAOuS2DEc/kYXz97cOAYAx+O0sbH176wi6rLyodQEc9mvZPv++1hF0 WMmLWycw7cp98sI9X3y8H5n8AHj93I+m5O4T/z702Sty3+uf2joCemP7Iz6ZUrcm9VOtUwAm7vZb vAHM5JXy9Oza+t7WGQAwBp9L2f/rrSPouBvLXyf5eOsMeu/j2Xjrc1tH0HFLZ748yfWtM5hqJcP6 lcf7gckPgEv5uYl/D/rs6gzP/JFs2zZsHQK9srD5Q6l5ZJJ9rVMAYMZdke3zL2gdAQBjUfLMLJzv 94lM1uL8Ukr9vdYZ9Fytz8iFF9zaOoOO2/3Q25Jc2jqDKTfKca+BnuwA+OLXfFuSB0/0e9BnH8jB wQ8dPgSBtbZzyzVJ+bEkPoABACuzL0tLj00ptXUIAIzB+7J3YCjH2hjlkiSez6CVt+XGN/5J6wh6 YjR4Yfz5KyczOP47wJMdANeB7V8m5cZk+Kg8Zf661iHQazs2vTKpv9A6A2BizljnCmgmp5Zn5Mnn fax1BgCMRckvZHF+qXUGPbFzy2eS8rLWGfTUaPSULC6OWmfQE7vm/y01f906gylW13oD+JJXfFGS x0zs69Nno5TyE9nxiA+0DgGS7NjynKT+fusMAJgxV+fGN/z/rSMAYCxKeV0WNr+idQY9U4bPb51A L70iu7a+rnUEveO848RKWeMB8G1nPjrJ2RP7+vRXqb+chU1/1zoDOMINex+f5KrWGQBjd/ucDWAm 4UCG5edsDQDQETU1T2kdQQ8tbH17kje0zqBXljIYuAmPtbdz8xuSvL11BlOqrvUV0KX8zMS+Nv1V 8jfZvvlXW2cAd7G47UAODh6dlGtbpwDADLgouze9u3UEAIxFySuyY9PbWmfQV/XFrQvok/LybJ9/ X+sKeqrGeceJ3P/wrcxHmcwA+Hmv+fdJ5ifytemz92fD6KdSSm0dAhzHU+avyzAXJLm5dQoATLGP 58DSr7eOAICxqXl26wR6bN3c3ya5rXUGvVBTR7/ZOoIeW1f/IslS6wymUsntX/wVd/2HkxkADwY/ NbGvTV/dlFIfnQu3fr51CHASh7aZntA6A2BsznAFNONWnpannndL6woAGJOrsmPz1a0j6LEnzt+c mle1zqAXXpWdW65pHUGPPWnL9Un2tM5gWtWvvOs/Gf+QttaS5KfH/nXpufKzWdjyntYVwDLs2PxH SS5tnQEAU+jqLMy/tHUEAIxNKbZ/aW+QP2udQA+47YCpUJx3nMDoAXf9J+MfAD//td+TmuM+OAwr U38/OzZd1roCOA0bb31SSrxtCMy+9bfZAGZcamrd6TkTADrkmmyff2XrCMhtG/42ye2tM+i0q7Nz 8xtaR0DKur9MMmydwVS6/13/wfgHwKX85Ni/Jn32ody+cWfrCOA0XXjBrVkqP5Lk1tYpADAVSv4s O7e8pXUGAIxPebYPNjEVnnbuTUm9vHUGHVbyG60TIEmy8LDPpeb1rTOYQmXSA+BL3ro+KY8e69ek zw6m5DGH/iMOmDm7N707pWxvnQEAU2Apo/L/tY4AgDH6SG4obmtjelTXQDMx7832TX/bOgLu4Np7 jmdUJnwF9P59j0hy77F+TXqsPDMLm/+pdQWwCgubfj/JH7XOAFix/XOugGb1Si7Nzk3vb50BAONT /k8W55daV8Ad1uVVSUatM+igkt912wFTZRDPL3CskgkPgGv9kbF+Pfrs9bnvdb/ZOgIYg7L/SUk+ 2joDABo5kINLv9o6AgDGaJilg3/QOgKO8qQt1yf5l9YZdM7+HBj839YRcJQnbf5ISj7YOoOpM8Er oJ9z9ZlJfnhsX48+uzF19FPZts1j5tAFC+fvS60/m8SnJQHon5KX5Mnnfax1BgCMTc2r/drGVKr1 ta0T6Jy/zlPmr2sdAceocd5xV2flRVedc+Q/GN8AeN2tj0pyt7F9Pfqr1qdk51bbgtAlO7e8JiX/ u3UGwGlb7wpoVmUpybNbRwDAWA2K39sxpQZXtC6gY2p13jGdSnXecayDS0dtAY9vAFzzo2P7WvRX zZXZsfn3W2cAk7D/KXEVNAD98rIsbP5Q6wgAGJuaz2bD2a9onQHHtf+Mq5O4UZBx+bfc+EZDNqbT KFe1TmAK1TqBAfBFl5+VlO8fy9eiz27NaHBhSnFNLHTRwvn7UvLf4ypoYJYcsAHMitWU+uutIwBg rEr+MBc+6GDrDDiup517U5JrWmfQEaVemsXFUesMOK6dWz7jHWCONXrAkX83ngHwhvXnJfmisXwt +quUxeyed2hBly1sfnWS/9M6AwAmrubvs7DlPa0zAGCsBgO/n2PKlatbF9AJoxwcXto6Ak6uOu84 2iAT2ACuefRYvg599rbsLc9tHQGsgY2jpyT5eOsMAJis6r9tAeiaa7J9/n2tI+CkSn1T6wQ6oObN efJ5H2udASdVB847jjYa3O/Iv139AHjxsjOS+qhVfx36bCmjwc9mcX6pdQiwBi7c+vnU7G6dAbAs 6253BTQr8a7s2Pza1hEAMFal/nnrBDilYf3H1gl0QXHeMf1KnHccrYzufeTfrn4AfM49NyW5x6q/ Dj1WnpNd8+9oXQGsoZ2b/zQ1V7bOAIAJeX5K8eY9AF3zZ60D4JR2br42yY2tM5hpNRkaADP9Npz9 niT7W2cwRcrgXkf+7eoHwKW4/pnV+EzK7c9qHQE0MKjbkxxsnQFwUgfnbABzemo+nwNLL22dAQBj 9n5v2zMTDn0I7+2tM5hp/5SdWz/aOgJO6cIHHUyt72ydwRSpdYwD4MXFQWp+cFVfg34reXoWzt/X OgNoYGHLe1LzwtYZADBWpf5xnnreLa0zAGCsav60dQIsW8k/t05gltW/aF0Ay+a84yh1jFdA3/Ph D07yZav6GvRXyT9n71V/2DoDaGiw/5lJ/VTrDIATWjewAczpKfV/t04AgLEbFNc/M0OqDWBWrnj/ l1lSnHccodwrtd7x51irGwDX4fmr7qGvamq2Z3Fx1DoEaGjh/H1J+cXWGQAwJv+Yha1+Aw5At5R8 MAub/qV1BixbnfPvKyv19ixs/lDrCFi2UXXecaQz8oJX3e0Lf7O6AXApj1p1Dn310uzYfHXrCGAK 3HDVS5L8Y+sMABiDP24dAABjV/N3rRPgtNzwuX9NstQ6gxnkvGPWfFF9T+sEpkyZu+Md4JUPgJ/7 hvum5tvGEkTf3JY6ekbrCGBKLC6OUkdPaZ0BcFwHD7gCmuUaZTB0XRwA3VPKa1onwGlZ3HYgyQdb ZzCTnHfMlgu3fj7JJ1pnME3OGMMAeHDwUUn8gRinr5aLsnPrR1tnAFNk59Y3JuXvW2cAwCrsyfZH fLJ1BACM2YHMlde3joDTV9/duoCZc3NuvP4fWkfACjjvuNNoeO8v/OVqroD2/i8rcX0Gt/926whg Kv1Skto6AgBW6GWtAwBgAv4hT5y/uXUErIBrUTlN9fWHt8dhtlTnHUcoWeUG8OJlZyTZMq4e+qT+ ZhbO39e6AphCOza9Lal/0ToDAFbgQIYH/RoGQAeV17YugBUyEOH0FOcdM8t5x51qVrkBfPdzHprk buPqoTc+nY23/U7rCGCK1cEvJllqnQFwh7mBJ09Yjsuz+5F7W0cAwNjVvLp1AqxIzYdaJzBrqvOO 2TTnvOMoq9wAHgxs/7IS/ysXXnBr6whgiu3c9P6k/HHrDAA4LaW+vHUCAEzAjbnfdW9tHQErcsaG D7ZOYKZ8Mts3v7d1BKzIcOS84wjlHl/4q5W+AWwAzOn6aMr+320dAcyAwcFfTuLNFWA6rLMBzCnd lts2/k3rCAAYu5LXZdu2YesMWJEnfO8NSdzQwnJdkVJq6whYkRvf9PEk+1tnMDW++At/cfoD4Bdd dU6SB42zhl741Syc7xACTm37edemlktbZwDAMl2Rp517U+sIABi/cnXrAlgl16KyXM47Ztfi4ijJ ta0zmBpnfeEvTn8AvHRwPsncOGvovA/lhsEftI4AZsio/FYSnzQHYAbUv29dAAATMRq+uXUCrJIB MMszGvxD6wRYneq847C6igFwra5/5nT9Vhbnl1pHADNk9/wHk/pXrTMActAV0JzCcO7y1gkAMAEH Mzrrba0jYFVK+XDrBGbCzbn/597ZOgJWpfrAC19QVnEFdMnWsbbQbTWfzfDMl7TOAGZQzbNbJwDA SZV88NCHlgCgc96R3Q+9rXUErErNR1onMANq/sl753TAR1sHMCXqSjeAL97zgNR81diD6K5BXuA3 DMCK7NzyliRvaJ0B9Ny6AzaAORnXPwPQTbW6/pnZN6gfa53ADChx3jH7ysB5xyGlrPQK6OHDx91C p92SQX1x6whghtV6UesEADihUXX9MwDdNCjew2T2jQxEWIZanXfMvtHIeccXrHAAPBp879hT6K6a 38uTtlzfOgOYYTs2/11K3t06A+ixpTkbwJzIgayfe13rCACYiOHARhyz7/b1roDmVGoGZ/xj6whY tVpcAc0XrPAN4FINgFmupazL81pHADOulJqa326dAQDHcVWeOH9z6wgAmIDPZdf8v7WOgFV72rk3 JdnXOoNpVv4tCw/7XOsKWLUHXP/pJEutM5gKK9gAvvgNX5LkgZOooYvKy/OkzT5lB6xe2f8nqfls 6wwAOErJa1onAMCEXNM6AMbIVhwnVuq/tE6Asdi2bZjkE60zmAobcslb1yenMwCuB89N4go8lqeO nt86AeiIhfP3J/UlrTMA4Gj16tYFADARNe9snQBjU6qBCCdWq/OOLnHeccitN52VnNYAOA+bWAwd U9+RnVve0roC6JBBuSRJbZ0B9NBc8QFIjudgNtz2ttYRADARxQYwHVIHn26dwBRz3tElNc47Dqmj 0xwAp547qRa6prywdQHQMQubP5Tkda0zAOCwd+TCC25tHQEAEzEY2IijSz7TOoApNnLe0SHFecdh g/LFyXIHwM+5+syU8i0TDaIbaj6fA0svbZ0BdFDJ77VOAHpoaWADmONx/TMAXTXMwQ3vbh0BY2Mj jhO7Lfe77oOtI2BsSnXecUgpp/EG8LpbH5Rk/SR76IhB/ihPPe+W1hlAB+29/s+TfK51BgCk1je3 TgCACflAdj/0ttYRMDY24jixd2XbtmHrCBgj5x2HjLIuWe4AuJbvmmgM3VEHl7ROADpqcduBlPxh 6wygZ+YO2gDmOAyAAeioEteh0jUGIpxAdd7RLUPnHYetO50BcMmDJxpDV1yVHfPvah0BdNio/F6S 2joDgF77ZHZu/WjrCACYiBrXP9MtQ1dAc0LOO7plbs55xyH1dAbAKQ+ZZAsdUartX2Cydm56f5I3 ts4AoM9s/wLQYaV6D5NuGRUbcRxfHTjv6JZywHnHIaOlZQ6AX/Dq+6XWfzfxIGbdLdk//KvWEUAP 1PKy1glAj8wNXAHNXZS3ty4AgMkpH2hdAGN18+v3Jhm1zmAK1aHzjm6pw+tbJzAlBnNzyXIGwHWd 7V9OrdQ/z1PPu6V1BtADGw7+WZKl1hkA9FXx5AkA3bV00EYc3bK4OEpyY+sMps4wcwc/3DoCxmr7 99+U5GDrDKbAaVwB/R0TTqETyh+3LgB64vHnfTYpr2udAUBPDQ5e0zoBACbk+ux+5N7WETB2Jf69 5q4+loXz97eOgLEqpSbOO3IaA+BR/baJxzDbaj6bvYMrW2cAfVJf3roA6IklV0BzlFty/Zs/0joC ACajug6VbqoGIhzDeUdXOe9ISpZ5BXSJATCn8idZnHcdK7B21p/x50kOtM4AoHfedfgaQQDooOL6 Z7qpxruY3JXzjo4qzjuWuQH8vNd+WZL7rEUPM2xu4PpnYG094XtvSOprWmcAPTBXbABzpHe2DgCA iSk2gOmoUmzEcbRanHd0U6nOO5LBcgbAtn85tfdn+/xbW0cAfVRcAw3AGqvval0AABP0odYBMBkG IhzDeUc3jVwBTZb7BvDAAJhTeWnrAKCnyv6/TnJ76wwAemRQbAAD0F2j8rHWCTAhrkTlaIOh845u GjjvSJJlbQBXA2BOrta/bJ0A9NTC+fuSXNk6A4AeGQze0zoBACam1o+3ToCJqGVf6wSmzQbnHR1V nXcscwO45lvWJIYZVa7Nzi3XtK4A+qy+snUB0HFLS94A5gtuzRO+7zOtIwBgQmrmDnyidQRMxshA hCPdnu3fe13rCJgMH3ghyaAOkpMNgC/dszHJV65VD7Oo/lXrAqDnBkMDYADWyodTSm0dAQAT8tks nL+/dQRMRBnc1DqBKVLycf9dT2eNqvOOpKYkJxsA37T0wCRza9XDDCrlr1snAD23/bxrk7yvdQbQ YXPFBjCHlHy4dQIATEyt3sOkuwYGIhyhxnlHd/nAC0c48QB4VL5hDTuYPddnb3lT6wiApNgCBmDy RgbAAHTYoHgPkw5zJSpHcd7RYa68504nHgAXA2BOouYVWZxfap0BkDJ6VesEoMOWBjaAOWRQrm2d AAATZCBChw0NRDhCdd7RYT7wwp1OPABODIA5sZK/aZ0AkCTZu/cNSVxvAsCEVQNgALprlE+0ToCJ KQMDEY7kvKPDnHfc6SQD4PKNa5fBjLk9B5Ze3ToCIEmyuO1ASq5onQFAxy0VV0AD0F2DfLp1AkzM gYM+NM6d6sB5R3fNjZx33OH4A+CLLj8rqf9hjVuYFTVX56nn3dI6A+AOo3gHGIDJOusWG8AAdFj5 XOsCmJiz7m0gwhGq847u8oEXjnD8AfCGwdec8MeglNe2TgA4ymiwp3UC0FFzxRvAJMkNufCCW1tH AMDEjEafbZ0AE3Phgw4mWWqdwZSYGzjv6K5zNvh9K3c4/pC3zn31GncwS+rIABiYLrvnP5jkk60z AOisT7UOAICJWlcMROi621oHMCUO7nfe0V0/8337k4xaZzAdjj8ALvVr1riD2XFj7rf3n1tHAByj 5E2tE4AOGizZACap3kUEoOPW3+pKVLrOVhxJspR9/3Bj6wiYmFJqkttbZzAdTnDNc7UBzPHVXJlt 24atMwCOUXNV6wQAOqoUG8AAdNmtnjqgB2wAkyTXZXHRdiRd57wjyQkHwMUAmBMoV7QuADiu0cAA GBi/oTeASVKqDWAAusx1qPSBgQhJ4rYD+sB5R5ITvgEcA2COb533f4Ep9fnXX5PENT4AjN+o2gAG oMsMgOkDW+4kzjv6wXlHkuMNgJ+75x5J7r32KUy9Uj6WJ23519YZAMd16Aqfq1tnANBJn2kdAACT U/a2LoA1YCBCUuK8oweq844kxxsAl6HtX46v1je1TgA4ufLG1gUAdFAZ2AAGoMOqm5ToA1eikrg5 jj4oxXlHkuNeAV2+fI0bmBWlvLl1AsBJ1aF3gIHxGgy8AUwyKte3TgCACTIQoQeqgQjJyAde6IGR D7xwyHE2gPMfGnQwE+o/tC4AOKm7r3trkoOtMwDomPWjG1onAMDE1Hy+dQJMXBnc3jqBKVCK847u K3HekcQAmOW7PXuvf0frCICTeuz87Une2zoD6JBhsQFMcssGb4UB0GU24ui+mqXWCUwDG8D0QHHe ccixA+CaL1/7DKZfeWsWtx1oXQFwSqX6sAoA4zTML3zPza0jAGBiigEwfVD9uSbOO/qhxnlHkuO+ AWwDmOOoI+//AjOivL11AdAhc0s2gLkxpdTWEQAwMcUV0PRB9VwUych5Rw9Uz+NxyPE2gP99gw6m 3WDg/V9gRhgAAzBGJd7/BaDbbMTRCwMDEeIKaHph4AMvHHL0APi5e+6Rkrs3amGalSUDYGA2DMu/ JLGpBcB4jPwhEQBdV/a1LoDJcwU0ifOOXqjFeUeSuw6Ay9D2L8fziWx/xCdbRwAsy675G5Nc2zoD gI4oAwNgALptqdzSOgEmr9iIIxk47+gF5x1J7joAniv3b9TBNKu5pnUCwOmproEGxmM48AZw39Vq SwCAbiv1ttYJMHmuRCVJGTrv6L7qvOOQowfAw3q/Rh1Ms1Le2ToB4LSU8o7WCUBHDIoBcN+V3No6 AQAmy0CEXjAQIZk703lH9xVXQHPIXa6ALvdp1MFUq+9qXQBweooNYADGpBoAA9BtG0a3t06AyTMQ Icntc847esAGMIccPQBOuW+bDKZaKa6ABmbLcPTe1gkAdIV3wgDouINDAxF6wECE1Oz6bucd3VcH zjuSHDMAdgU0xziYvdcZpACz5f57P5LEp3uB1XMFNDUGwAB0294z3XZB99VaWyfQ3P6U4t8Duq84 7zjkrgNgG8Dc1fuzuM0QBZgt27YNk1zbOgOADijFH4oD0GXDLM4vtY6AyRuMWhfQnPd/6YdSnXck cQU0p+b6Z2BWfaB1AAAdUGwAA9BpBiL0w8BGHNX1z/RDHTjvSHLMADhf1qSC6VXru1snAKxM+dfW BQB0QK02gAHoMgNg+qFm2DqB1orzjn6oI+cdSY4cAD/7jXdLsrFdCtNp8P7WBQArUuoHWycAHTAc egOY/a0DAGCCDETohxobcX1XnHf0RLEBzCF3DoC/6JZ7N+xgWg1igALMqOoKaGD1BsUAuPfqwdYF ADBBrkSlJ4o3MfuuOu/oCW8Ac9idA+DhnAEwx7rtjA+3TgBYkUExAAZg9crgQOsEAJggG3H0g4EI roCmN3zghUPuHADPFQNg7uozedq5N7WOAFiR6676WPxhBgCrZgMYgE6zEUc/lOpKVJx39EN13nHI nQPgWu/ZsINpVGL7F5hdi4sj5xgAq1YNgAHosGIjjp6oZdg6gdaq845+cN5x2J0D4JQvaZfBVKre /wVm3CgfbZ0AzLiRN4B7b1BcAQ1Ad40MROgJG3G4JY6+GDjvOMQGMCfzodYBAKtSyidbJwAw42wA A9BlxZWo9ETxJmbvleq8oyecdxxyxAZw7tWsgulUqwEwMONGBsAArNKcATAA3VUNgIGecN4BPXPE AHhw93YZTKVSvJ0JzDgbwMAqDVwBzcinpwHosv2tAwDWRnHeAb1yxAC4nt0ug6k0l0+0TgBYnfKp 1gXAjBsODYD7buT9JAA6rJRh6wSANVHjvAN65cgroA2AOVLNWYPPtI4AWJXqCmgAVqkMbAAD0F2l +nUO6AfvQAM9c+cAuORuDTuYPjfksfPeRQBm28gV0ACskg1gALpsZCAC9IUPvAD9YgOY4ytxbSow +x5w/acTV/wAq+ANYOZGBsAAdJcNYKA3fOAF6Jc7B8AjA2COUPPp1gkAq7Zt2zCpn22dAcAMG64z AAagu4oPzAJ9MXLeAb1y5BXQBsAcyQYw0BGugQZgFeZcAQ1Ah41sAAN9YQMY6JdDA+BL3ro+yca2 KUwZG8BAV3ymdQAAM2zkCmgAOqwUv84B/VDjvAN65dAAeP9nz2zcwbSpNuaAzrixdQAww7wBTJmz KQBAhxVXogL94Mp7oGcODYDXz9n+5WiDkTczga74fOsARX3sHQAAIABJREFUAACAqVQ8dQD0hvMO 6JVDA+DhOhvA3MXAxhzQFQbAwMoNhzaA+64MbQAD0F3VBjDQF94ABvrl0AB4qdgA5i5G+1oXAIxF NQAGYBWGNqMA6LJqIAL0hPMO6JfB4f9pAMzRRgYmQEcUbwADq+ANYNatMwAGoLuKjTigL5x3QL8c GgCPDIC5izpnAxjohuIDLQCsgg1gALqs+nUO6IliAxjol0MD4Dr0BjB3ZWMO6IZaDIABAACOxxvA QF/UOO+AXjk0AC5zGxp3MF1q7v+5m1pHAIxH9YEWAACA47ERB/SG8w7ol8NvANczGncwXW7Otm0+ EQV0w9AGMLAKI28AAwBd5k1MoCe8eQ70zOEroMugcQfTxbAE6I51BsAAAADHZyMO6AsDYKBfDl8B nbnGHUwX1z8D3bG0/9bWCcAMG9gABgAAAGC2HBoAj6oBMEc62DoAYGwOfrEzDQAAAACA3jh89XN1 BTRHMiwBuuPMfQdaJwAzbDi0AQwAAADATDl8BfTABjBHqAbAQHfs/SdnGgAAAAAAvXFoAFxHNoA5 wmCpdQHA2CwujpKMWmcAAAAAAMBaOLwBHBvAHMEGMNA5zjVgZQbFFdAAAAAAzBSbvxyPQQnQNd4B BgAAAACgF76wAezKX45gAxjoHL/OAStjAxgAAACAGXP4DeCBgR9HMigBuqW62QAAAAAAgH44NAAe jVyNyZ1qGbZOABir4gpoAAAAAAD6wRXQHKvUudYJAGPm1zlgZUaugAYAAABgthwaAA+KzSiOUNa3 LgAYs1HrAAAAAAAAWAuH3wCu3kbkSOtaBwCM2RmtA4AZVUY2gAEAAACYKQbAHI8NYKBrnGsAAAAA APTCoQFw5gyAOYIroIHOsQEMAAAAAEAv2ADmOKoBMNA1zjVgZUZxBTQAAAAAM+XQAHjdyACYOxWD EqBzbAADAAAAANALh6+AXmcAzJ2qATDQOetaBwAAAAAAwFo4fAW0DWCOsqF1AMDYLO5Zlzs+8AQA AAAAAN126A/ERwbAHOXurQMAxubsDW41AFZuULwBDAAAAMBMObwRVfa3zWDKGAAD3bHuRgNgAAAA AAB64/AG8Bfta9zBdNmYi1/pGmigGw6ceUbrBAAAAAAAWCuHBsC7H3pbElvA3Gn9nC1goBvmhme3 TgBm2MgV0AAAAADMlsEdf1Xz+YYdTJvh3D1aJwCMR3GeAStXRgbAAAAAAMyUOwfAxQCYIyx5Bxjo iHUxAAYAAAAAoDcGR/z1jc0qmD4DA2CgI6oNYAAAAAAA+uOIAXCxAcyRDEyAbhiNzmmdAMywgTeA AQAAAJgtRwyAqw1gjnSv1gEA4zE4u3UBAAAAAACsFRvAHF8t922dADAWxQYwsAojG8AAAAAAzJYj 3wA2AOYI1QAY6AhvAAMAAAAA0B93DoDLyACYI5T7tS4AGBMDYAAAAAAAeuOIDeCBN4A5kg1goCsM gIGVK3EFNAAAAAAz5c4BcLUBzJGqDWCgI+qXtC4AAAAAAIC1YgOYEyhfmssum2tdAbB65QGtCwAA AAAAYK0c8QZwDIA50lw+cZ8vbR0BsCqHPshyn9YZAAAAAACwVu4cAI/y6YYdTKPBkmuggdn2mXt8 WZJ1rTOAGTYaeQMYAAAAgJly5wB4fflEww6mURn9x9YJAKtS51z/DKzOoBgAAwAAADBT7hwAP3H+ 5iQ3tUth6ozKV7VOAFiVmvu3TgAAAAAAgLU0uMvff6pJBdOp5CtbJwCsigEwAAAAAAA9c/QAuJRP NupgOn116wCAVSkGwMAqjVwBDQAAAMBsOXoAXKsBMEdyBTQw67wBDAAAAABAr9z1CmgDYI50v1x0 +VmtIwBWwQYwAAAAAAC9cpcBcPUGMEcq2Tj4itYRAKvwH1sHADOuxBXQAAAAAMwUG8Cc3GjgGmhg Nl26Z2OSf9c6AwAAAAAA1tLRA+AysAHM0Wq+tnUCwIrsy1clmWudAQAAAAAAa+noAXBdsgHMXX1z 6wCAFSnDr2udAHTAaOQKaAAAAABmytED4I37P9Gog2k1MAAGZlQtbjAAAAAAAKB3jh4AX3jBrUn2 tUlhKtV87eF3NAFmS6lf0zoB6IBBsQEMAAAAwEwZHOeffXzNK5hm63Lj6OtbRwCcNhvAAAAAAAD0 0PEGwB9e8wqm25xroIGZZAMYAAAAAIDeOd4A+ANrXsF0qwbAwIx58eVfmuSc1hlABxRXQAMAAAAw W44dANfywQYdTLOab2mdAHBa9q/7utYJAAAAAADQwrED4EE1AOZoxQYwMGMG5VtbJwAAAAAAQAvH DoCHBsAc4955zp6vah0BsGy1Pqh1AtARo7gCGgAAAICZcuwA+P57P5LkwNqnMNUG9aGtEwBOgwEw AAAAAAC9dOwAeNu2YZJ/W/MSplup3906AWBZXrjni5N8TesMoCMGIxvAAAAAAMyUYwfASZL6gbXN YAbYAAZmw8Glb00y1zoDAAAAAABaOMEAuHgHmLv6xlzymru3jgA4pcHA9c8AAAAAAPTW8QfANQbA 3NUgt5UHt44AOKWa72idAHTIqLgCGgAAAICZcvwBcKkGwByrFNdAA7PAABgAAAAAgN46wQC4eAOY Y5X63a0TAE7qosvPSvI1rTMAAAAAAKCV4w+A73P9vyU5sKYlTL9azs3iZWe0zgA4oQ1z351krnUG 0CHFFdAAAAAAzJbjD4C3bRsm+fDapjADzso97vWQ1hEAJ1TzsNYJAAAAAADQ0vEHwIdcs2YVzI5S t7ROADix8n2tC4COqSMbwAAAAADMlBMPgGv9lzXsYHZsbR0AcFzPufrMJA9unQEAAAAAAC2deAA8 GBgAcxzlO/Oiq85pXQFwjLnbH5pkQ+sMAAAAAABo6SRXQBcDYI5nLgcPfF/rCIBjjR7eugDooBJX QAMAAAAwU048AF6Y/3iS69YuhRniGmhgChUDYAAAAAAAeu8kG8BJkneuSQWzpRgAA1Pm0j0b4/1f YBJKsQEMAAAAwEw5+QC4xjXQHKvmq/K8K7+2dQbAHfYNvzvJxtYZAAAAAADQ2skHwAMDYE5gUH+4 dQLAHWq+v3UCAAAAAABMg1NcAT0yAOb4qgEwMEVKuaB1AtBR1RXQAAAAAMyWkw+A997w7iQH1iaF 2VK+KxfveUDrCoBcfMVXJvm61hkAAAAAADANTj4AXtx2IMn71yaFGVOSkY07oL1R+cHWCUCHlZEN YAAAAABmyimugE4S7wBzAjWugQbaK9WHUQAAAAAA4DADYFZjPi+66pzWEUCPXfKauyc5t3UGAAAA AABMi1MPgEejt65BB7NpfZb2n986Auix28v3J1nfOgMAAAAAAKbFqQfAS6O3JDk4+RRmUi0/0joB 6LHq/V9gwkbxBjAAAAAAM+XUA+CnnndLkmsmn8KMemR+a8+9W0cAPXTJW9en5LzWGQAAAAAAME2W 8wZwUuubJtzB7Fqf9UNbwMDa2//5Rya5Z+sMoONKsQEMAAAAwExZ3gC45M0T7mC2/UTrAKCHah7T OgEAAAAAAKbNcjeAr55wBzOtPCTPu/JrW1cAPXLR5WcluaB1BtAD1QYwAAAAALNleQPgnVs/muTj k01hppX6Y60TgB45Y92jk5zVOgMAAAAAAKbN8gbAh9gC5mR+OrXakAHWRqk/3joBAAAAAACm0WkM gF0DzUl9eX5nz0NbRwA98LzXfllq2dw6AwAAAAAAptHyB8ClvHmCHXRBHf1c6wSgBwaDH0myrnUG 0BNl5IYTAAAAAGbK8gfAG+7+9iS3TS6FmVfLtvzWnnu3zgA6rtbHtE4AAAAAAIBptfwB8IUPOpjk LZNLoQM25oz62NYRQIc958pvSPJdrTOAHinFBjAAAAAAM+U03gBOkngHmJOr9eezuHi6/14BLM9c fVLrBAAAAAAAmGanN6ir9U0T6qA7viLnnPuI1hFAB138yrOT/HjrDAAAAAAAmGanNwDev/H1SQ5O JoXOKOXxrROADhpt+Kkkd2udAfRMjSugAQAAAJgppzcAftq5NyXlHyfUQlfU/ECeu+fLW2cAHVNy YesEAAAAAACYdit5q/XVY6+gawYpo59vHQF0yPOueFiSb2ydAQAAAAAA0+70B8ClvGYCHXRNyePz 3D33aJ0BdMSgPKF1AtBTpbgCGgAAAICZcvoD4Pt87i1Jbhx/Ch1zdgbDn2sdAXTAC/fcJ7X+p9YZ AAAAAAAwC05/ALxt2zA1V06ghc4pu3Ppno2tK4AZtzRcSHJG6wygp0YjG8AAAAAAzJSVvAGclLgG muX4suwb/UTrCGCGXfzKs5Py+NYZAAAAAAAwK1Y2AB4sXT7mDrrrqVlcXNm/ZwB14xOTeE8caMcb wAAAAADMmJUN5rafd22SD483hY76mtzzYT/cOgKYQZfu2ZiMtrfOAAAAAACAWbKazcxXj62Cbqv1 6a0TgBm0b/i4pNy3dQYAAAAAAMySlQ+AS/EOMMv1nbn4igtaRwAzZHHPuqQ8pXUGQGpcAQ0AAADA TFn5AHhYrkwyHF8KnVbzLG8BA8t2j/qYJF/eOgMAAAAAAGbNygdyu+ZvTOpbxthCt31Tzjl3W+sI YAZcdtlcSn1a6wwAAAAAAJhFq9vIrHnFmDrohfIrh651BTiJT97zZ5J8fesMgCRJKa6ABgAAAGCm rHIAXP9yTB30w1fnnvWnWkcAU+zSPRszGDyzdQYAAAAAAMyq1Q2Ad219b5L3jSeFXqj1mbn4lRta ZwBT6qbRjtT671pnANyhjGwAAwAAADBTVjcATpLYAua0/Ptk44WtI4Ap9KKrzkmNt38BAAAAAGAV Vj8ArjEA5vTUupjfee29WmcAU+bA/mckOad1BgAAAAAAzLLVD4B3bH5rSvnYGFroj3MyLN74BO70 nCvun1Ke2DoD4Bi1uAIaAAAAgJmy+gFwKTWpfz2GFvrl8XnOld/QOgKYEnP51SRf1DoDAAAAAABm 3RjeAE5SXAPNaVuXQb24dQQwBV6w50FJfrp1BgAAAAAAdMF4BsBfdv3rk1w3lq9Ff5RsynNf+8Ot M4CGFhcHGY1emHH9egQwbiWugAYAAABgpoznD9y3bRsm5e/G8rXol0H57Vy6Z2PrDKCRezzs55M8 uHUGAAAAAAB0xTg3rlwDzUp8RT4/3N06AmjgxZd/aUr9tdYZAAAAAADQJeMbAA83vjrJLWP7evRH Kf8zL9jzda0zgDV2YP1vJjmndQbASY2KK6ABAAAAmCnjGwDvfuhtSf37sX09+mRDan1xavUHrNAX z3vNuUn9qdYZAAAAAADQNeO8Ajqp5eVj/Xr0R63fl4v3/PfWGcAauOSt61MGL0ziQx8AAAAAADBm 4x0A333wiiQ3jvVr0iP1oly85wGtK4AJu23fLyX55tYZAMtSRj6sAgAAAMBMGe8A+LHzt6fkT8f6 NemTs1NHL24dAUzQxa/5tpT6jNYZAAAAAADQVeMdACdJ6h+N/2vSIz+Q5135n1tHABNw8Ss3pA7+ MMn61ikAy1aLDWAAAAAAZsr4B8DbN78xKdeO/evSH6X+Ti5+w5e0zgDGbcOzknxj6woAAAAAAOiy 8Q+AS6nJ6P+O/evSJ/fJ6OBLUquNG+iKF1z5PanZ2ToD4LSV+O8RAAAAAGbKBK6ATjKc+8MkdSJf m34o+f684Mqfb50BjMFFl5+VWv8gyVzrFAAAAAAA6LrJDIB3z38wqf84ka9Nf9T8di5+7de3zgBW 6Yz1z0/NV7XOAAAAAACAPpjMAPgQ10CzWmemlpfn0j0bW4cAK3TxFT+W1Me1zgBYsVJcAQ0AAADA TJncAHi49NIk+yf29emLb8y++qzWEcAKPO/Kr03NJa0zAAAAAACgTyY3AN79yL0pedXEvj49Unfl 4ise0boCOA0v3PPFKfUvk9ytdQoAAAAAAPTJJK+ATkbFNdCMQ0nNS/OCy/9j6xBgmZZGL0rywNYZ AKtWR66ABgAAAGCmTHYAPLj9b5Psnej3oC/umeHcZd4Dhhnw/Ct+PslPts4A4P+1d+dRfpeFvcc/ z28CAZUl4IL2uhVtxdqqCNTrBXQW4AqC141rq9bS9pqqMDNBLXrsreOpWrFKMgPYC6VXrbe2Ymtd scBMpgVEUVzqWltQERcQYsAFssz8nvsH1KqVJSEzz+83v9frnDnJyZnk+84fSc6ZT57nCwAAAMAg WtoBePzYrUnesaTPYHCUcki+331r6wzgTkxvfEKS9a0zAAAAAABgUC3tAJwki523Juku+XMYFCdl Zu7FrSOAn2P9JQ9Myd8ncVIfWDlKcQU0AAAAAH1l6QfgU4evSjK35M9hcNRMZ2b2iNYZwE844/I9 09n+vtT64NYpAAAAAAAwyJZ+AE6SbnVtL7vSbqnlr3P2/AGtQ4AkU1OdrLr1XUkOa50CAAAAAACD bnkG4F/43geTXLMsz2JQ/EIWuh/Kn15479YhMPDWHHF6av5H6wyAJdF1BTQAAAAA/WV5BuATT1xM yXnL8iwGyROy+9C7MzW/qnUIDKzpuZOSvLx1BsCSKV0DMAAAAAB9ZXkG4CQZ6pyXZNuyPY8BUY7L mrqhdQUMpOmNo0nOaZ0BsKRqp7ZOAAAAAIAdsXwD8EuHr0vy3mV7HgOkvjQbZl/WugIGyszcYUn9 +yS7tU4BWFJOAAMAAADQZ5ZvAE6SUt+6rM9jcJTyp5mZfV7rDBgI0/OPSc0FSfZqnQKw5GoMwAAA AAD0leUdgMfHLk3y+WV9JoOipJbzsuHiw1uHwIp2xvwjksWLkuzfOgUAAAAAAPjPlncATpKSP1v2 ZzIo9kg6H8qG2UNbh8CKdMbcL2SoXpSUB7ZOAQAAAAAAfr7lH4CHOu9M8v1lfy6DoWSflHJR1s8d 3DoFVpQ3z983Q7koqQ9vnQKwrEpxBTQAAAAAfWX5B+CXDv8wyTuW/bkMkn1T8pGsv/ig1iGwIsxc cr/stnhxkke3TgEAAAAAAO7c8g/ASdJZWJ9kocmzGQwl90+nM58z5x/VOgX62tnzB6Run0vK41qn ADThBDAAAAAAfabNAHzKMV9L8t4mz2aQPCC1XpQzL3RlLeyMs+YemsXupUl+tXUKAAAAAABw97QZ gJOk5C3Nns3gqPXB6a6aNQLDDtqw8ZfTLZem5hGtUwAAAAAAgLuv3QA8PvqJJJc0ez6D5BfTXXV5 zrzYKUa4O2ZmH51SN6bWB7dOAWiudl0BDQAAAEBfaTcAJ0nJm5s+n0FyQLqd+WyYPbR1CPS0mfkn ppZLkzyodQoAAAAAALDj2g7A37v0w0m+3LSBQbJ/SpnL9Oxw6xDoSTOzz07tbkyyX+sUAAAAAABg 57QdgKemuqnljU0bGDR7JeUjmdn4zNYh0FOmZydSy7uT7Nk6BaCnlOIKaAAAAAD6StsBOEluKu9K 8tXWGQyU1an13ZmefWHrEGhuan5VZubOTcqG9MK/CQAAAAAAwD3S/ov9U8MLKfVNrTMYOKuS8vZs mJ3O1FT7PwfQwumX7ZU13fen5n+1TgHoWd04AQwAAABAX+mR4Wvb25N8q3UFA6iU8aw5/Pyc88F7 tU6BZbV+9hezx9bLkxzbOgWgp3VSWycAAAAAwI7ojQF4/NitqeUtrTMYVOVZ2XKvy7Ph4oe0LoFl sWH2aemUK5M8pnUKQM9zAhgAAACAPtMbA3CS7Pmjc1Lz3dYZDKzHpnQ+lumNT2gdAkvm/POHMj33 JynlA0nWtM4BAAAAAAB2vd4ZgNcef0viXcA09aCkXpINs/+zdQjschtmH5Dv7H9xklcmTrMB3G2l +DsTAAAAgL7SOwNwkuwzdHa8C5i27pVS/ibTc3+ZMy7fs3UM7BIbZg9NKVckGW6dAgAAAAAALK3e GoBPGt6SUpwCphe8IEO3XpqZuQNbh8BOu+3K51enlI8meWjrHAAAAAAAYOn11gCcJHuVc5N8s3UG JHlCaj7tSmj60pkXPjzf2X8+yeuS7NY6B6Bv1a4roAEAAADoK703AJ80vCW1/EnrDLjd3rddCT17 TmYuWN06Bu6WDRt/K91Vn0tyROsUgL7nHcAAAAAA9JneG4CT5KYbz0vy9dYZ8B/Ki5LVl2d6/jGt S+AOnT1/QKZnP5RS35HkPq1zAFaEWmvrBAAAAADYEb05AE+duC3JH7XOgJ9Sc3DSvTLTG1+VqflV rXPgp8zM/UYWup9PynGtUwBWFCeAAQAAAOgzvTkAJ8nmS/8qyWdaZ8DPWJ3UN2RN98qsn39c6xjI zNyBmZn9h9S8K8l9W+cArDglBmAAAAAA+krvDsBTU92k/GHrDLgDj02n+4lMz03l/POHWscwgM65 crfMzJ2Wmi+klmNa5wAAAAAAAL2hdwfgJJkYuSCl/GPrDLgDuyV5Tb6z32XZMPtrrWMYIGfOjWTL zZ9PzRuT7NE6BwAAAAAA6B29PQAnSTevTFJbZ8AdK09MKZ/K9NxM1s/v27qGFWzDxQ/J9NxfpZu5 JL/cOgcAAAAAAOg9vT8AT45ckeTvWmfAXViV5JSU7leyYfZ3MzXV+3+26B/r5/fNhrk3pnS+kuQ3 W+cADJRavAMYAAAAgL7SHyNVZ+EPkmxpnQF3qeT+KeW87HfEJ7N+9r+2zqHPnXPlbpne+KKU7ldS clpc9wyw/ErXAAwAAABAX+mPAfiUY76WlJnWGXC31RycTrks0xvPy8z8f2mdQ5+ptWRm9tnZevOX knpOSu7fOglgYNWOV5EAAAAA0Ff6YwBOki27vy7Jda0zYAd0kvq7qd2rMz17Ts6eP6B1ED2u1pKZ ueMzs/GK1PKe1DyidRLAwHMCGAAAAIA+0z8D8GmH/yApr2mdATth96S8KAvdq7Jh7o1566VrWgfR Y6amOpmZOz5nbrwyNR9IcmjrJABu5x3AAAAAAPSZ/hmAk2TzJeel5NOtM2An3Tslp2X7tmuyYe6N mblg79ZBNDY11cmGuedkzRFfTM0HUnNw6yQAAAAAAKC/9dcAPDXVTa0vb50B99BeKTktdfVV2bDx tfmzC73fddCsn983Gzauy5ojr0rJ+Uke1ToJAAAAAABYGfprAE6SibH5lPLu1hmwC9wvpf5Rtq26 NtNzf5kzNv5K6yCW2Fmzv5QNs9PpdK9NqWck9eGtkwC4S66ABgAAAKCvrGodsFOGymQW6lOTuEKX lWD3JC/IUH1+pjfOpdSZnDLyoZRSW4exC0xNdbLf4SOpZSKLOS7FkAAAAAAAACyd/jsBnCQvHb4u pbyudQbsYiWpY6n5QGY2fiozcy/O+vl9W0exk86Yf0Q2bHxt1hxxdWq5OMnT4hQZAAAAAACwxPrz BHCSfK+sz5r6giS/2joFlsDjU/PWdLrrMzP3gSTvzAGbLsiJJy62DuNOnHPxPrl16OkpeUHSHY3B FwAAAAAAWGb9OwBPDS9keuO6pM62ToEltDo1z0nynHznvl/LzOzb061vz+RR32gdxu1mLlidrD46 yQuyJcen1D1aJwEAAAAAAIOrfwfgJJkYmcv03LuS/GbrFFh69eGp5bUp5TWZnrssqe/NUHlfTh69 pnXZwJm5YO/U3Y9NyjNS89Qke7VOAmCJ1FJSausKAAAAALjb+nsATpLtnYns1j06yX1bp8Ay6SQ5 MilHZjEbMj33pSTvScoHMzHyqdZxK9ZZs/tnoXNcSn1Oao5Ksrp1EgDLoHSLG/0BAAAA6Cf9PwC/ fPjGzGw8LbX+ResUaOTRSV6T1Ndkeu7LSX1fkouz99DHctLwltZxfetPL7x3dh86IimjSUazmMem 1E7rLACWWe1UJ4ABAAAA6Cf9PwAnySnDb8vMxucnGW6dAo0dlJSDkrwq3+9uyYa5y1OyMcl8Nnc+ kanhhdaBPWvq/N2z75rDUjq3Db7JryfZvXEVAK05AQwAAABAn1kZA3ApNWfN/n4Wyz8n2aN1DvSI PVIykmQkSbKm+8NMz12S1H9Kp1yZhc6ns274praJjdRacvbcI7OQw1LKYUkOS/L4GHwBAAAAAIA+ tzIG4CQ5eexfMzP3+tT8cesU6FH3SXJsUo5NN0mnm0zPXZ2STyf5VLr101mVT+fksU2NO3etcz54 r2y590Gp3YNS8uiUHJyZjYclZY0DXQDcpVqKfy8AAAAA6CcrZwBOktX7nJ4tNz8zt53kA+7agak5 MMlzUkqymGR67htJ/i2pV6d0rkpydbrdq7LnrVdl7fG3tM29A2+b3yPf3/7gdIYenFoelloPSvLo pByULfVhSS0pt3/13mscAQAAAACAFWxlDcBrD9memY0npdZPxFWusLMecttHGU29fS0tJdlyr2R6 7ttJ+WpSv52UG5J6Y1JvSDo3pLv43dShG9Lp3pibhjbd4/cNn37ZXrn31v2yvbMmq7r7ZbGsSep+ 6WS/1DwwyUNS64NTyoPz/e4DkqGkm/z0wmvtBQAAAAAABsvKGoCTZHzknzM994YkU61TYAV6UFIf dNt3/31cLbd9v9O5/cdKsqabTM8lybYkP7r9825Kak3JranZcvtPvnf+4z9r7JX/+Dtpn2RrJ4u5 7arqbpJSf/qxSX58qhcAlooLoAEAAADoMytvAE6SzZ3XZ033+CRPaJ0CA273/HjgrWtu+6ZdDADs sFLKj2/EAAAAAIA+0GkdsCSmhhdS6+/kttOHAAAAAAAAAANhZQ7ASTI59rmkvK51BgAAAAAAAMBy WbkDcJJsLn+Sko+1zgAAoE/VrncAAwAAANBXVvYAPDW8kMX6/CQ/aJ0CAAAAAAAAsNRW9gCcJOvG vprk1NYZAAAAAAAAAEtt5Q/ASTIxel6Sv22dAQBAvymugAYAAACgrwzGAJwkZbeXJLmudQYAAAAA AADAUhmcAXj8yBuS+ptJFlunAADQJ2qcAAYAAACgrwzOAJwkE2PzSX1T6wwAAAAAAACApTBYA3CS bB76o9R8tHUGAAAAAAAAwK42eAPw1PBCOp3nJtlmki9CAAAP9UlEQVTUOgUAgB5XiiugAQAAAOgr gzcAJ8n48DdTyguT1NYpAAAAAAAAALvKYA7ASTI+8uEkG1pnAAAAAAAAAOwqgzsAJ8nmzh8kuaR1 BgAAPap2XQENAAAAQF8Z7AF4anghtZ6Y5NutUwAAAAAAAADuqcEegJNkcuz6dOuzk2xrnQIAQI8p xQlgAAAAAPqKAThJ1o19LKmvap0BAAAAAAAAcE8YgP/d+Oj6JOe3zgAAAAAAAADYWQbgf1dKzeKe v51ar2ydAgBAjyhxBTQAAAAAfcUA/JNOfdKtSX1War7bOgUAAAAAAABgRxmAf9bkUd9IyTOSbG2d AgAAAAAAALAjDMA/z8To5Sn5/dYZAAA0VosroAEAAADoKwbgOzI++vaUnNU6AwAAAAAAAODuMgDf mQM2TabkA60zAABopToBDAAAAEBfMQDfmRNPXMytq5+f1M+2TgEAAAAAAAC4Kwbgu3La4T9Ip3tc Srm2dQoAAAAAAADAnTEA3x2nHP3tZPHpSX7YOgUAgGVU4wpoAAAAAPqKAfjuGj/qMynluUkWWqcA AAAAAAAA/DwG4B0xPvLh1HpSkto6BQAAAAAAAOBnGYB31OTY/0utf9g6AwCAZVBcAQ0AAABAfzEA 74zJsTekZkPrDAAAAAAAAICfZADeWRMjpyZ5Z+sMAACWUK1OAAMAAADQVwzAO6uUms2bfi8ps61T AABYIqXU1gkAAAAAsCMMwPfE1InbssePnp7kktYpAAAsASeAAQAAAOgzBuB7au3xt6RsPT61Xtk6 BQCAXawUAzAAAAAAfcUAvCuMH/v9LAw9NckXWqcAAAAAAAAAg8sAvKu8fPjG7L4wmuRfWqcAAAAA AAAAg8kAvCu9+JjvpnaPScrXWqcADJBu6wAAAAAAAOgVBuBdbfKob2Rh+5OTXN06BWDFK+XdSf1E 6wxgBSvxDmAAAAAA+ooBeCm87Jhrs7AwHCMwwNIp5R+TLS9MihPAwNKpxQAMAAAAQF8xAC8VIzDA UvpCFsszMn7s1tYhAAAAAADQSwzAS8kIDLAUvpmFhWOzbvim1iEAAAAAANBrDMBL7WXHXJvSeUqS f2lcArASbEqnc1Redsy1rUMAAAAAAKAXGYCXw/jwN7P7wpOT+tnWKQB97JZ06/E5Zdh/qAGWUdc7 gAEAAADoKwbg5fLiY76b7tBwaj7aOgWgD21LynOybuxjrUOAQVMMwAAAAAD0FQPwclo3fFP2vOXo JBe1TgHoI4upeX4mRi5oHQIAAAAAAL3OALzc1h5/S8rWE1LyvtYpAH1gMSUvyOToe1qHAAAAAABA PzAAtzB+7NYcsOnZSf5P6xSAHlaT8pKMj/516xBgoLkCGgAAAIC+YgBu5cQTFzMx+uKUvLJ1CkBP qvUVmRg5t3UGAAAAAAD0EwNwa+Ojp6fmRUkWW6cA9I56WibH3tK6AgAAAAAA+o0BuBdMjv55Sp6R 5JbWKQDN1frqTIy9qXUGQJKkFldAAwAAANBXDMC9Ynz0g6llJMn1rVMAGqlJxjM59obWIQAAAAAA 0K8MwL1kcuSKLOYJST7TOgVgmdXUjGdi9MzWIQA/pXSdAAYAAACgrxiAe82po9/Kqs6RST7UOgVg mXRTyu9lcvSs1iEAAAAAANDvDMC96KXDP8zmzjOScnbrFIAltpjktzM+8n9bhwAAAAAAwEpgAO5V U8MLmRg5OaknJ9neOgdgCWxJtz47E6PvbB0CAAAAAAArhQG4102MnZ3aHUlyfesUgF3oh6n1hKwb e1/rEIA7VYp3AAMAAADQVwzA/WDyqMtSOock+WTrFIBd4PqU7pGZHLu4dQgAAAAAAKw0BuB+MT78 zezdOTI1b2+dArDzyteSxSMyftRnWpcA3C01TgADAAAA0FcMwP3kpOEtmRw9KbW+PMlC6xyAHVM/ m1XlSZk4+t9alwAAAAAAwEplAO5Hk2NvSe0OJ/lW6xSAu+mi7FGfkpcOX9c6BGDHeAcwAAAAAP3F ANyvJo+6LNs7j0upF7ZOAbhz9dxs7hyXtUfd3LoEAAAAAABWulWtA7gHXj58Y2p9as7c+AepeX2S odZJAD9hMSWvzvjY6a1DAAAAAABgUDgB3O9KqRkfPT21PjXJ9a1zAG73g6SckPFR4y8AAAAAACwj A/BKMTl2cWp9bGo+0joFGHjXpNbDMzFyQesQgHuu6x3AAAAAAPQVA/BKMjl2fSZGjkvK2iS3tM4B BtIlqfXXMzn2udYhAAAAAAAwiAzAK00pNRMj52axHJbEAAMso3pu9thnLJNjrqMHVpDiBDAAAAAA fcUAvFKdOvLFLO75xKS+NUltnQOsaLck5XmZGFubtYdsbx0DAAAAAACDzAC8kp36pFszMfbSlHp0 km+0zgFWoFKuTafz5EyMvKt1CsCSqHECGAAAAIC+YgAeBONjs9mj+2tJ3tY6BVhBSj6QhW2PyynD V7ZOAVgyxU0qAAAAAPQXA/CgWHvUzZkY/Z2kPjXJt1rnAH1tIclr871Ln5FT//v3WscALCkngAEA AADoM6taB7DMJsb+IWfNPjbdnJFafqt1DtB3vppan5vJsU+2DgEAAAAAAP4zJ4AH0cljmzI+9sKU 8pQk/9o6B+gbf5/ddj/E+AsMlFKcAAYAAACgrxiAB9n4yD9lj1sen5Qzkiy2zgF61g+TsjYTo8/M S47Y3DoGAAAAAAC4YwbgQbf2+FsyMfKydDpPTOpnW+cAPabkY1nsPD4TI+e2TgEAAAAAAO6aAZjb nDJ8ZTYPHZrUydTc3DoHaG4hNadn9T5PzqnDV7WOAWimdF0BDQAAAEBfWdU6gB4yNbyQZDpnz787 C903JXl+El/0hMHz5aS8IJMjn2odAtBc9Q5gAAAAAPqLE8D8Zy8dvi4To7+V2j0yyeda5wDL5rZT v4t7PiETxl+AJEmptXUCAAAAAOwIAzB3bPKoy7K584TUnJJkU+scYEl9JqV7WCZHX5lTn3Rr6xiA nuEEMAAAAAB9xgDMnZsaXsjk6Fnpdh6RmtOTbG2dBOxSW5K8Nps3PTHjR32mdQxADzIAAwAAANBX vAOYu2fd8E1JXpkz5s9Lp3t6Sp7ZOgm4x+az2HlRTh2+qnUIAAAAAACwaxiA2TG3DUXPyoa5I1Py 5iSHtk4CdlT9TkpekVNG35VSvNsSAAAAAABWEFdAs3MmRy/JxOhhKfWoJP/cOge4WxZS60zKtkdl fOyvjL8Ad4d3AAMAAADQXwzA3DPjY7PZfOnBqTkxydWtc4A7dEk63YMzOTaR8WO/3zoGAAAAAABY GgZg7rmpqW4mR9+TzZsenWQ8yfWtk4Af+3pSfyPjI0/JKUd9vnUMAAAAAACwtAzA7DpTJ27LxOiZ KVsfmpS1Sb7VOgkG2A+TvDZ7dw7KxNjfuO4ZYGdVV0ADAAAA0FcMwOx648duzcTIudm86RdTywvj amhYTtuTem52XzgwE6NTOWl4S+sgAAAAAABg+RiAWTpTJ27L5MhfZvOmR6fU30/y9dZJsIJ1U8q7 M1Qfk4mxtXnxMd9tHQQAAAAAACw/AzBLb+rEbRkfOyebLz0wJSck9eOtk2BlKbPp5tCMjzw3J4/9 a+sagBWlxhXQAAAAAPSVVa0DGCBTU90kH0zywWy4+PCUzmlJjkt8YRV2Ss1H06mvyvjopa1TAAAA AACA3mAApo3Joy5Lclmm5x+T2n1ZSn4jyerWWdAXSr0wyeszMWb4BQAAAAAAfooBmLYmhr+Q5KSs n1+XzuILk7IuyUNbZ0EP6ia5ICV/nPGxT7SOARgYxU0lAAAAAPQXAzC9Yd3wTUmmMzV/dvarJ6TW k5MMt86CHrA9Ke9Kp7wxpwz/S+sYAAAAAACgtxmA6S1TwwtJ3pvkvTlj469kqK5N8vwka9qGwbL7 XpJzUzpnZ3z4m61jAAAAAACA/mAApnedOvLFJOOZueAV6a4+IaW8KKmjiasYWdGuTuqZ2bZ4Xl5x zI9axwAMvFJKam1dAQAAAAB3mwGY3jd+7NYk70nynszMHZiU30mtv53kQW3DYJfpJvmHlPLWfO+S j2Rqqts6qK908r+zmP1bZ9DQmlu3tk5gJSsbUuvfta6goa27f7t1AgAAAMCOMADTX8ZHr07y6px/ /h/l2/uNpHSel9RnJtmrdRrshOuS/EW6nfOybvjrrWP61imjG1snACvY+PDHk3y8dQYAAADAXVq9 +I7cUj7UOoOGtu1xQ+IqXVaCMy7fM0O3PD0pz0tyTJLdWifBnegmmU2pf57V+74/aw/Z3joIAAAA AABYOQzArCxvnr9vdl98Vmp5VpLhOOVO7/hKUt6RUt6Z8eFvto4BAAAAAABWJgMwK9dZs/tnsZyQ 1GclZSzJ6tZJDJxNqeVvU7vvyLqxj7WOAQAAAAAAVj4DMIPhnIv3ydbytNRyQmqOSck+rZNYsW5K zfsylPOz+z6zrngGAAAAAACWkwGYwXPOlbtly02HJ+XYJE9L8qjWSfS97yX5cErek2y9KOPHbm0d BAAAAAAADCYDMMzMHZiaY5McneTJSfZqXER/uCa1vj9D5f3Z1LkkU8MLrYMAAAAAAAAMwPCTpuZX Zf/666nd0dQyluSJSXZrnUVP2JKUy1LqbBY7F2bd8GdbBwEAAAAAAPwsAzDcmbPn75Nu94h06xFJ OTzJoUn2aJ3Fsuim5LPp5uJ06mwW7vXRnPqkW1tHAQAAAAAA3BkDMOyIqflVWVMfm3QPTyn/LTUj SfZvncWuUr+TUi5LLbPpLHwopxz97dZFAAAAAAAAO8IADPdErSVnzz0yi51DknpIkkOSHJzk3o3L uGu3JvlMkitS6xVZVT6ek0evaR0FAAAAAABwTxiAYVc7//yhfOd+B6V0D0k3j03Jryb5tST3a502 wGqSr6TUT6TbuSIlV2SPvT+XtYdsbx0GAAAAAACwKxmAYbmcPX9Ati/ePgaXx6TkV5I8Msm+jctW lpqbU+qXk/KFpH45NZ9PHfpk1g3f1DoNAAAAAABgqRmAobWZS+6XsvBLqfnl1PrIpD4yKY9M8rAk ezeu610/Hno7X0y6X0rtfDGL27+Ulx1zbes0AAAAAACAVgzA0MvWz++bofrQdPPQdPKw1Dw0qQ9J 8qCkPDCpByTZs3XmEtmUkmtSb/8o9etJ5+vplmuyetU1eckRm1sHAgAAAAAA9BoDMPS70y/bK6u3 PSid7v1TOw9M6gNS6pp0y5qUsialrknNmuT2j5r7pGSfZa68NcktSW5O8oOUel1q58bUekNKbkxy fVJuSCc3pnRvyK2L38orjvnRMjcCAAAAAAD0PQMwDKq3ze+RW1ftmW1b9kqns1tq2Tepq1PqvX78 OTWrUsted/hrlLItpfujn/j8xaTz/Qx1f5Du0C1ZtepHefHhN6WUuqS/FwAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAABYGv8frhKTMj/iNeUAAAAASUVORK5CYII= "
          id="image2691"
-         style="stroke-width:2.46555" />
-      <g
+         style="stroke-width:2.46555" /><g
          id="g2995-0-5"
-         style="display:inline;opacity:0.994;fill:#ff0000" />
-      <g
+         style="display:inline;opacity:0.994;fill:#ff0000" /><g
          id="g2995-3"
-         style="display:inline;opacity:1;fill:#ffff00">
-        <path
+         style="display:inline;opacity:1;fill:#ffff00"><path
            id="rect2978-67"
            style="color:#000000;overflow:visible;opacity:1;fill:#fec701;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-        <rect
+           d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><rect
            y="640"
            x="640"
            height="384"
            width="384"
            id="rect545-5"
-           style="color:#000000;overflow:visible;fill:#ffff00;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" />
-      </g>
-      <g
+           style="color:#000000;overflow:visible;fill:#ffff00;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" /></g><g
          id="g2995-5"
-         style="display:inline;opacity:1;fill:#ff0000">
-        <path
+         style="display:inline;opacity:1;fill:#ff0000"><path
            id="rect545-9"
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-           d="m 640,640 h 384 v 384 H 640 Z" />
-      </g>
-      <g
+           d="m 640,640 h 384 v 384 H 640 Z" /></g><g
          id="g2995-2"
-         style="display:inline;opacity:1;fill:#ff0000">
-        <rect
+         style="display:inline;opacity:1;fill:#ff0000"><rect
            y="640"
            x="640"
            height="384"
            width="384"
            id="rect545-0"
-           style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" />
-      </g>
-    </g>
-    <g
+           style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" /></g></g><g
        inkscape:label="GNOME"
        id="g1513"
        inkscape:groupmode="layer"
        style="display:none"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z"
          style="color:#000000;overflow:visible;opacity:1;fill:#8ff0a4;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path1493" />
-      <g
+         id="path1493" /><g
          style="display:inline;opacity:0.994;fill:#ff0000"
-         id="g1497" />
-      <g
+         id="g1497" /><g
          style="display:inline;opacity:1;fill:#ffff00"
-         id="g1503">
-        <path
+         id="g1503"><path
            d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
            style="color:#000000;overflow:visible;opacity:1;fill:#33d17a;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path1499" />
-        <rect
+           id="path1499" /><rect
            style="color:#000000;overflow:visible;fill:#ffff00;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
            id="rect1501"
            width="384"
            height="384"
            x="640"
-           y="640" />
-      </g>
-      <g
+           y="640" /></g><g
          style="display:inline;opacity:1;fill:#ff0000"
-         id="g1507">
-        <path
+         id="g1507"><path
            d="m 640,640 h 384 v 384 H 640 Z"
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-           id="path1505" />
-      </g>
-      <g
+           id="path1505" /></g><g
          style="display:inline;opacity:1;fill:#ff0000"
-         id="g1511">
-        <rect
+         id="g1511"><rect
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
            id="rect1509"
            width="384"
            height="384"
            x="640"
-           y="640" />
-      </g>
-      <g
+           y="640" /></g><g
          transform="matrix(0.93072896,0,0,0.92810694,179.0944,-317.89565)"
          id="g2510-6"
-         style="display:inline;stroke-width:1.07594">
-        <g
+         style="display:inline;stroke-width:1.07594"><g
            style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:0.735579;filter:url(#filter2033-3)"
            id="g2492-2"
-           transform="matrix(1.891639,0,0,1.891639,-6787.5298,-1678.2939)">
-          <g
+           transform="matrix(1.891639,0,0,1.891639,-6787.5298,-1678.2939)"><g
              id="g2490-6"
              style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.735579;stroke-miterlimit:4"
-             transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)">
-            <g
+             transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"><g
                id="g2488-1"
-               style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579">
-              <path
+               style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"><path
                  id="path2478-8"
                  style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"
-                 d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" />
-              <path
+                 d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" /><path
                  id="path2480-7"
                  style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"
-                 d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" />
-              <path
+                 d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" /><path
                  id="path2482-9"
                  style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"
-                 d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" />
-              <path
+                 d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" /><path
                  id="path2484-2"
                  style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"
-                 d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" />
-              <path
+                 d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" /><path
                  id="path2486-0"
                  style="fill:#ffffff;fill-opacity:1;stroke-width:0.735579"
-                 d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" />
-            </g>
-          </g>
-        </g>
-        <g
+                 d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" /></g></g></g><g
            transform="matrix(1.891639,0,0,1.891639,-6787.8882,-1677.6037)"
            id="g2508-2"
-           style="stroke-width:0.735579">
-          <g
+           style="stroke-width:0.735579"><g
              transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"
              style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.735579;stroke-miterlimit:4"
-             id="g2506-3">
-            <g
+             id="g2506-3"><g
                style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-               id="g2504-7">
-              <path
+               id="g2504-7"><path
                  d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z"
                  style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-                 id="path2494-5" />
-              <path
+                 id="path2494-5" /><path
                  d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z"
                  style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-                 id="path2496-9" />
-              <path
+                 id="path2496-9" /><path
                  d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z"
                  style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-                 id="path2498-2" />
-              <path
+                 id="path2498-2" /><path
                  d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z"
                  style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-                 id="path2500-2" />
-              <path
+                 id="path2500-2" /><path
                  d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z"
                  style="fill:#000000;fill-opacity:1;stroke-width:0.735579"
-                 id="path2502-8" />
-            </g>
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
+                 id="path2502-8" /></g></g></g></g></g><g
        style="display:none"
        inkscape:groupmode="layer"
        id="g2100"
        inkscape:label="dev"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          id="path2047"
          style="color:#000000;overflow:visible;opacity:1;fill:#f2f8fd;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" />
-      <g
+         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" /><g
          id="g2049"
-         style="display:inline;opacity:0.994;fill:#ff0000" />
-      <path
+         style="display:inline;opacity:0.994;fill:#ff0000" /><path
          d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
          style="color:#000000;overflow:visible;fill:#7ebae4;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path2051" />
-      <text
+         id="path2051" /><text
          xml:space="preserve"
          style="font-size:396.098px;line-height:934.207px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="527.61877"
@@ -1145,26 +912,20 @@
            id="tspan2118-2"
            x="527.61877"
            y="433.55325"
-           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:'Encode Sans Extra Condensed';-inkscape-font-specification:'Encode Sans Extra Condensed Heavy';fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px">dev</tspan></text>
-    </g>
-    <g
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:'Encode Sans Extra Condensed';-inkscape-font-specification:'Encode Sans Extra Condensed Heavy';fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px">dev</tspan></text></g><g
        style="display:none"
        inkscape:groupmode="layer"
        id="g748"
        inkscape:label="de"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          id="path738"
          style="color:#000000;overflow:visible;opacity:1;fill:#f2f8fd;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" />
-      <g
+         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" /><g
          id="g740"
-         style="display:inline;opacity:0.994;fill:#ff0000" />
-      <path
+         style="display:inline;opacity:0.994;fill:#ff0000" /><path
          d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
          style="color:#000000;overflow:visible;fill:#7ebae4;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path742" />
-      <text
+         id="path742" /><text
          xml:space="preserve"
          style="font-size:396.098px;line-height:934.207px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="527.61877"
@@ -1175,79 +936,55 @@
            id="tspan744"
            x="527.61877"
            y="433.55325"
-           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:'Encode Sans Extra Condensed';-inkscape-font-specification:'Encode Sans Extra Condensed Heavy';fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px">de</tspan></text>
-    </g>
-    <g
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:'Encode Sans Extra Condensed';-inkscape-font-specification:'Encode Sans Extra Condensed Heavy';fill:#27385d;fill-opacity:1;stroke:none;stroke-width:1px">de</tspan></text></g><g
        sodipodi:insensitive="true"
        inkscape:label="reproducible-builds"
        id="g2122"
        inkscape:groupmode="layer"
-       style="display:none">
-      <path
+       style="display:none"><path
          d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path2112" />
-      <g
+         id="path2112" /><g
          style="display:inline;opacity:0.994;fill:#ff0000"
-         id="g2114" />
-      <path
+         id="g2114" /><path
          id="path2116"
          style="color:#000000;display:inline;overflow:visible;fill:#1e5b96;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-      <g
+         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><g
          id="g1756"
-         transform="matrix(10.946507,0,0,10.946507,-277.6424,0)">
-        <g
+         transform="matrix(10.946507,0,0,10.946507,-277.6424,0)"><g
            id="circle2_25_"
-           transform="rotate(45,28.648425,77.049372)">
-          <circle
+           transform="rotate(45,28.648425,77.049372)"><circle
              fill="#1e5b96"
              cx="47.136002"
              cy="-7.244"
              r="9.8000002"
-             id="circle861" />
-        </g>
-        <g
+             id="circle861" /></g><g
            id="circle8_25_"
-           transform="rotate(45,28.648425,77.049372)">
-          <circle
+           transform="rotate(45,28.648425,77.049372)"><circle
              fill="#1e5b96"
              cx="5.6999998"
              cy="34.193001"
              r="9.8000002"
-             id="circle870" />
-        </g>
-        <g
+             id="circle870" /></g><g
            id="g24_25_"
-           transform="rotate(45,28.648425,77.049372)">
-          <g
-             id="polygon22_25_">
-            <polygon
+           transform="rotate(45,28.648425,77.049372)"><g
+             id="polygon22_25_"><polygon
                fill="#2b89d6"
-               points="19.842,3.929 8.953,14.818 24.863,14.747 24.792,30.657 35.681,19.768 35.681,3.929 "
-               id="polygon885" />
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
+               points="35.681,19.768 35.681,3.929 19.842,3.929 8.953,14.818 24.863,14.747 24.792,30.657 "
+               id="polygon885" /></g></g></g></g><g
        sodipodi:insensitive="true"
        style="display:none"
        inkscape:groupmode="layer"
        id="g2134"
-       inkscape:label="Security">
-      <path
+       inkscape:label="Security"><path
          id="path2124"
          style="color:#000000;overflow:visible;opacity:1;fill:#fdd8d8;fill-opacity:0.992157;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" />
-      <g
+         d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z" /><g
          id="g2126"
-         style="display:inline;opacity:0.994;fill:#ff0000" />
-      <path
+         style="display:inline;opacity:0.994;fill:#ff0000" /><path
          d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
          style="color:#000000;overflow:visible;fill:#ff0009;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path2128" />
-      <text
+         id="path2128" /><text
          xml:space="preserve"
          style="font-size:351.833px;line-height:829.806px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#960000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="619.74493"
@@ -1256,34 +993,27 @@
          transform="matrix(0.93756228,0,-0.22413914,1.0665958,0,0)"><tspan
            sodipodi:role="line"
            id="tspan2130"
-           x="619.74493"
+           x="619.745"
            y="419.91507"
            style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:'Encode Sans Extra Condensed';-inkscape-font-specification:'Encode Sans Extra Condensed Heavy';fill:#960000;fill-opacity:1;stroke:none;stroke-width:1px"
-           dx="0 -2.8284271 -11.313708 -11.833246">#@!%</tspan></text>
-    </g>
-    <g
+           dx="0 -2.8284271 -11.313708 -11.833246">#@!%</tspan></text></g><g
        sodipodi:insensitive="true"
        inkscape:groupmode="layer"
        id="layer16"
        inkscape:label="hydra"
-       style="display:none">
-      <g
+       style="display:none"><g
          id="g2222"
-         mask="url(#mask2224)">
-        <rect
+         mask="url(#mask2224)"><rect
            y="0"
            x="0"
            height="1024"
            width="1024"
            id="rect2155"
-           style="color:#000000;overflow:visible;opacity:1;fill:#4d85f6;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" />
-        <path
+           style="color:#000000;overflow:visible;opacity:1;fill:#4d85f6;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" /><path
            sodipodi:nodetypes="ccccccc"
            d="M 27.820624,-244.14468 1174.6382,63.14416 1086.7654,1102.193 512,1161.9021 832,157.33867 -189.35164,674.48887 Z"
            style="color:#000000;overflow:visible;opacity:1;fill:#405d99;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-           id="rect2157" />
-      </g>
-      <text
+           id="rect2157" /></g><text
          transform="scale(0.96597816,1.0352201)"
          id="text2132-9"
          y="488.43686"
@@ -1297,41 +1027,32 @@
            x="557.22968"
            id="tspan2130-7"
            sodipodi:role="line"
-           dx="0 0 0 0 0">hydra</tspan></text>
-    </g>
-    <g
+           dx="0 0 0 0 0">hydra</tspan></text></g><g
        sodipodi:insensitive="true"
        style="display:none"
        inkscape:label="offtopic"
        id="g688"
-       inkscape:groupmode="layer">
-      <path
+       inkscape:groupmode="layer"><path
          d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#7ebae4;fill-opacity:0.996078;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path704" />
-      <g
+         id="path704" /><g
          style="display:inline"
          id="g1733-3"
-         transform="matrix(0.9907111,-0.13598363,-0.13598363,-0.9907111,-63.216681,1245.1038)">
-        <ellipse
+         transform="matrix(0.9907111,-0.13598363,-0.13598363,-0.9907111,-63.216681,1245.1038)"><ellipse
            ry="266.5979"
            rx="431.36444"
            cy="830.2522"
            cx="659.63055"
            id="path1723-6"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:#727272;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:#727272;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
            style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 340.40314,693.25411 c -6.48469,-76.7834 -11.76992,-186.66352 53.37622,-230.07162 -8.94934,70.8547 63.1624,149.19909 93.20326,153.52269"
            id="path1725-7-5"
-           sodipodi:nodetypes="ccc" />
-        <path
+           sodipodi:nodetypes="ccc" /><path
            sodipodi:nodetypes="ccc"
            id="path1725-7"
            d="m 336.63319,654.80732 c -6.48469,-76.78342 -7.99997,-148.21675 57.14617,-191.62483 -8.94934,70.85465 33.11923,127.57803 63.16009,131.90168"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#727272;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <text
+           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#727272;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><text
          xml:space="preserve"
          style="font-size:305.065px;line-height:0.7;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:16.7666px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#4f4f4f;fill-opacity:1;stroke:#ffffff;stroke-width:22.0398;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
          x="425.36182"
@@ -1340,259 +1061,186 @@
          transform="matrix(0.96154923,-0.09239427,0.09901715,1.0304739,0,0)"><tspan
            id="tspan1529"
            sodipodi:role="line"
-           x="433.74509"
+           x="433.74512"
            y="472.25375"
            style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-family:'Encode Sans Condensed';-inkscape-font-specification:'Encode Sans Condensed, Ultra-Bold';fill:#4f4f4f;fill-opacity:1;stroke:#ffffff;stroke-width:22.0398;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
-           rotate="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">chat!</tspan></text>
-    </g>
-    <g
+           rotate="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">chat!</tspan></text></g><g
        sodipodi:insensitive="true"
        inkscape:label="gaming"
        id="g1575"
        inkscape:groupmode="layer"
-       style="display:none">
-      <path
+       style="display:none"><path
          d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z"
          style="color:#000000;overflow:visible;opacity:1;fill:#ea7900;fill-opacity:1;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path1555" />
-      <g
+         id="path1555" /><g
          style="display:inline;opacity:0.994;fill:#ff0000"
-         id="g1559" />
-      <g
+         id="g1559" /><g
          style="display:inline;opacity:1;fill:#ff0000"
-         id="g1569">
-        <path
+         id="g1569"><path
            d="m 640,640 h 384 v 384 H 640 Z"
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-           id="path1567" />
-      </g>
-      <path
+           id="path1567" /></g><path
          id="path1561"
          style="color:#000000;overflow:visible;fill:#ea7900;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-      <g
+         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><g
          style="display:inline;opacity:1;fill:#ff0000"
-         id="g1573">
-        <rect
+         id="g1573"><rect
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:0;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
            id="rect1571"
            width="384"
            height="384"
            x="640"
-           y="640" />
-      </g>
-      <g
-         id="g2006">
-        <g
+           y="640" /></g><g
+         id="g2006"><g
            style="display:inline;fill:#fff700;fill-opacity:1;filter:url(#filter2196)"
            id="g1602-2"
-           transform="translate(-1629.711,-154.73905)">
-          <g
+           transform="translate(-1629.711,-154.73905)"><g
              style="fill:#fff700;fill-opacity:1"
              id="g1638-6"
-             transform="translate(1628.4971,151.51917)">
-            <path
+             transform="translate(1628.4971,151.51917)"><path
                id="path1626-1"
                d="m 615.45139,161.9012 c 0.2235,-0.97046 2.06041,-9.79587 4.082,-19.61203 2.0216,-9.81616 3.80885,-17.98077 3.97167,-18.14359 0.40261,-0.40262 21.08238,28.72538 21.01503,29.60023 -0.0486,0.63152 -4.30659,2.09423 -23.17034,7.95954 l -6.30474,1.96033 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1624-8"
                d="m 556.12657,196.95485 c -0.6884,-5.50606 -3.11282,-56.92855 -2.79915,-59.37098 0.30902,-2.40628 -2.63097,-4.96857 33.85936,29.50938 l 9.16555,8.6601 -19.51358,12.32978 c -10.73246,6.78138 -19.68598,12.32978 -19.8967,12.32978 -0.21072,0 -0.57769,-1.55613 -0.81548,-3.45806 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1622-7"
                d="m 599.2586,648.62513 17.98275,-13.62813 6.02023,-13.49809 6.02023,-13.49808 29.17856,-14.15965 c 23.94565,-11.62024 29.3895,-14.56624 30.35477,-16.42681 1.63369,-3.14894 1.68075,-3.16757 3.59674,-1.42446 1.38146,1.25682 6.32986,2.19698 25.8387,4.90915 13.27151,1.84505 24.18505,3.30964 24.25232,3.25464 0.5321,-0.43493 39.14364,-82.34062 38.92137,-82.5629 -0.1587,-0.1587 -11.15911,2.87653 -24.44535,6.74497 -13.28624,3.86843 -24.2945,6.89581 -24.46279,6.72751 -0.1683,-0.16829 5.78679,-9.04596 13.23352,-19.72817 l 13.53952,-19.42217 -1.76071,-3.29266 c -0.96839,-1.81096 -15.60457,-28.55681 -32.52484,-59.43521 -26.88221,-49.05832 -30.55026,-56.16574 -29.06924,-56.32623 0.93219,-0.10102 22.93142,2.86118 48.88719,6.58266 25.95576,3.72148 47.34864,6.63799 47.53973,6.48113 0.19108,-0.15686 -0.25108,-0.73911 -0.9826,-1.29387 -0.7315,-0.55477 -36.48696,-28.83585 -79.45657,-62.84685 l -78.12657,-61.83818 8.37684,-7.86179 c 4.60727,-4.32398 9.52968,-8.83183 10.93869,-10.01744 l 2.56185,-2.15565 29.91682,3.65537 c 16.45426,2.01046 30.02108,3.55112 30.1485,3.42371 0.12741,-0.12742 -8.77926,-6.05202 -19.7926,-13.16578 l -20.02426,-12.93411 8.89884,-8.54344 8.89884,-8.54343 -37.3206,-77.2465 C 635.87215,68.069087 618.99381,33.230652 618.89105,33.135934 618.45237,32.731536 423.83773,11.370017 423.5399,11.693569 423.35916,11.889913 403.68684,53.9744 379.82363,105.21465 l -43.38765,93.16411 -2.07361,64.27916 c -1.14047,35.35354 -2.41931,64.81949 -2.84185,65.47989 -0.42254,0.6604 -11.4166,14.57399 -24.43125,30.91909 -21.74936,27.31503 -36.24102,45.68328 -68.06108,86.26775 -13.64415,17.40224 -51.01034,65.48176 -52.7228,67.83904 -1.37019,1.88614 -0.99579,1.68873 80.49076,-42.43976 33.78725,-18.29725 61.54323,-32.99244 61.67996,-32.65599 0.13673,0.33645 -0.50403,23.29135 -1.4239,51.01087 -0.91989,27.71953 -1.67252,53.30774 -1.67252,56.86268 v 6.46353 l 107.12426,49.50792 107.12425,49.50792 7.61261,-3.78156 c 4.18693,-2.07985 7.93777,-3.78155 8.3352,-3.78155 0.39742,0 5.96406,4.36638 12.3703,9.70307 6.40624,5.33669 12.02612,9.47568 12.48863,9.19776 0.4625,-0.27793 8.93315,-6.63798 18.82366,-14.13345 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1616-9"
                d="m 474.27953,591.19545 -63.87234,-58.10026 0.25529,-2.99884 c 0.3707,-4.35471 33.41306,-240.35348 33.69098,-240.6314 0.12862,-0.12862 13.86717,52.00457 30.53011,115.85154 39.34923,150.77343 42.69111,163.78458 42.195,164.28069 -0.2289,0.2289 -10.11156,1.20198 -21.96148,2.16241 -11.84991,0.96043 -21.76398,1.96492 -22.03127,2.2322 -0.26728,0.26728 12.83923,11.55676 29.12556,25.08775 l 29.61153,24.60178 3.31979,12.71291 c 1.82588,6.9921 3.24989,12.75534 3.16447,12.80719 -0.0854,0.0519 -28.89786,-26.05083 -64.02764,-58.00597 z m 255.33676,-8.91804 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.039 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -17.90053,-2.44098 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 325.58488,531.1658 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m 0.81366,-25.22346 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 0.83008,-24.81664 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66147 -0.19394,1.00691 -0.35262,0.18308 -0.35262,-1.83073 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66148 -0.19394,1.0069 -0.35262,0.18307 -0.35262,-1.83074 z m 4.88197,-151.34081 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66148 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 304.90099,-15.76675 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m -304.08733,-9.45671 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.0069 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18307 -0.35261,-1.83073 z m 378.54545,1.61405 c 0.28109,-0.45482 0.85192,-0.61629 1.26851,-0.35881 1.12858,0.69749 0.91814,1.18574 -0.51108,1.18574 -0.69768,0 -1.03852,-0.37212 -0.75743,-0.82693 z m -7.07688,-0.54255 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42736 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49159 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58735,-0.23505 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -35.64849,-0.56505 c 0,-0.16896 0.64075,-0.80971 1.4239,-1.42391 1.29052,-1.01208 1.31929,-0.9833 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m 29.1392,-0.24861 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -7.37379,-0.79672 c 0.55939,-0.22571 1.47476,-0.22571 2.03415,0 0.55939,0.22572 0.10171,0.41041 -1.01708,0.41041 -1.11878,0 -1.57646,-0.18469 -1.01707,-0.41041 z m -6.45843,-0.8306 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81367 c 0.58735,-0.23504 1.28914,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.21021,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 336.17889,203.66755 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18308 -0.35261,-1.83073 z m 339.88838,0.50645 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.30721,0.3072 -1.06295,1.35536 -1.73112,1.78638 -1.73112,1.1167 z M 555.9501,200.03292 c -0.25193,-0.65651 -0.30103,-1.66342 -0.10911,-2.23757 0.19191,-0.57415 0.54183,-0.037 0.77758,1.19365 0.46032,2.40292 0.0806,2.99593 -0.66847,1.04392 z m 132.32208,-7.25016 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01208 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -133.31182,-9.45672 c 0,-1.11878 0.18469,-1.57647 0.4104,-1.01707 0.22572,0.55939 0.22572,1.47475 0,2.03415 -0.22571,0.55939 -0.4104,0.1017 -0.4104,-1.01708 z m 34.37479,-14.03564 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.8525 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -35.25268,-1.89854 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 20.60679,-11.93368 -1.55001,-1.83074 1.83073,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55002,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m -21.42045,-3.52586 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 6.38346,-10.7132 -1.97257,-2.23756 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15264,-1.00691 -2.23756,-2.23757 z m -7.13289,-5.08537 c 0,-1.11879 0.18469,-1.57647 0.4104,-1.01708 0.22572,0.55939 0.22572,1.47476 0,2.03415 -0.22571,0.55939 -0.4104,0.10171 -0.4104,-1.01707 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1614-2"
                d="m 530.75161,642.84068 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.13661 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11145,-1.55002 z m -8.52772,-7.72977 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84366 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 14.60368,-6.50928 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -23.55394,-1.62732 -1.97257,-2.23757 2.23757,1.97257 c 2.09134,1.84366 2.6107,2.50256 1.97257,2.50256 -0.14575,0 -1.15265,-1.0069 -2.23757,-2.23756 z m 18.67198,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.0683 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 1.35535,1.06294 1.78637,1.73111 1.1167,1.73111 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.4239 z m -22.74028,-1.62732 -1.97257,-2.23757 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15265,-1.0069 -2.23756,-2.23756 z m 17.85832,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.06831 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -21.92663,-1.62732 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84367 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 17.04466,-2.44098 c -1.01208,-1.29051 -0.9833,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73112,-1.1167 z m -4.88196,-4.0683 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.4239,1.25494 1.4239,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -20.72185,-1.22049 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 15.83989,-2.84781 c -1.01209,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 1.35535,1.06295 1.78637,1.73112 1.1167,1.73112 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.42391 z m -24.79015,-5.28879 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 10.95793,-6.10245 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -19.9082,-2.03415 -1.55001,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m 15.02624,-2.03416 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m 0.32268,-3.20825 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0968,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 9.76393,-0.81366 c 0.79166,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m -34.06311,-2.08054 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 43.82703,1.26688 c 0.79167,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m 10.57758,-0.81366 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 8.73137,-0.56178 c 0,-0.17159 0.91537,-0.48696 2.03415,-0.70083 1.11878,-0.21387 2.03415,-0.0735 2.03415,0.31198 0,0.38545 -0.91537,0.70083 -2.03415,0.70083 -1.11878,0 -2.03415,-0.14039 -2.03415,-0.31198 z m -72.08624,-8.02804 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82384 -1.83073,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z m 89.97764,-15.94255 C 505.1846,521.1947 491.46956,468.2441 474.7119,404.26794 457.95424,340.29179 444.31937,287.9002 444.41218,287.84218 c 0.0928,-0.058 25.61597,4.07623 56.71813,9.18719 43.68682,7.17897 56.91954,9.6216 58.17671,10.73886 0.89503,0.79542 45.48591,38.30942 99.09084,83.36445 56.63281,47.59994 97.84546,81.68217 98.3752,81.35477 0.51955,-0.3211 0.68647,-0.19907 0.38809,0.28373 -0.28797,0.46596 0.0516,1.32453 0.75453,1.90794 1.07186,0.88956 -18.97326,4.83342 -124.2136,24.43885 -69.02044,12.85797 -126.16936,23.55533 -126.99759,23.77192 -1.01588,0.26566 -1.50884,-0.0448 -1.515,-0.95394 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1612-0"
                d="m 559.92226,646.50215 c -30.89503,-25.35456 -87.13957,-72.19328 -86.93957,-72.40059 0.15887,-0.16467 54.14597,-4.64838 148.16252,-12.30512 15.66296,-1.2756 28.62852,-2.19237 28.81235,-2.03726 0.30868,0.26043 -9.9116,23.5602 -26.00362,59.28193 -3.62874,8.05524 -7.13932,15.24722 -7.80127,15.98219 -1.30072,1.44416 -35.68355,27.54864 -36.28499,27.54864 -0.20024,0 -9.17568,-7.23141 -19.94542,-16.06979 z m 156.62352,-66.14344 c -11.97158,-1.69742 -22.1298,-3.20811 -22.57384,-3.35707 -1.38845,-0.46582 -32.53471,-40.08008 -31.91642,-40.59382 0.3225,-0.26796 16.14761,-4.97324 35.16692,-10.45616 19.01931,-5.48292 45.67559,-13.18256 59.23617,-17.11029 18.88877,-5.47101 24.53913,-6.83552 24.15762,-5.83385 -0.27388,0.71912 -8.9879,19.15717 -19.36447,40.97343 -17.67114,37.15274 -18.99553,39.65955 -20.90299,39.56496 -1.12007,-0.0556 -11.83141,-1.48977 -23.80299,-3.1872 z m -7.93209,-350.32516 c -0.67127,-0.16281 -25.75235,-3.23328 -55.73573,-6.82326 -29.98339,-3.58998 -55.55997,-6.80116 -56.83686,-7.13595 -2.3102,-0.60572 -2.2366,-0.70773 14.97065,-20.74681 9.51074,-11.07595 17.64526,-20.13809 18.0767,-20.13809 0.68832,0 82.78014,52.92946 84.77334,54.6584 0.75427,0.65426 -2.79799,0.77996 -5.2481,0.18571 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1610-2"
                d="m 535.79842,637.95731 c -1.7419,-6.82381 -3.36664,-12.94132 -3.61053,-13.59448 -0.36714,-0.98323 16.078,12.20797 21.33503,17.11353 1.4893,1.38975 1.29999,1.55591 -5.88278,5.16332 -4.08189,2.05004 -7.70354,3.72672 -8.04812,3.72595 -0.34458,-7.8e-4 -2.05169,-5.58452 -3.7936,-12.40832 z m 95.758,-35.69954 c 1.0647,-2.40451 5.7153,-12.88731 10.33467,-23.29513 4.61938,-10.40781 8.24888,-19.05132 8.06555,-19.20781 -0.18333,-0.15647 -28.70973,2.04311 -63.392,4.88798 -34.68227,2.84487 -64.32966,5.08081 -65.88309,4.96876 l -2.82442,-0.20373 -6.00656,-23.03738 c -3.30361,-12.67055 -5.87717,-23.15577 -5.71902,-23.30048 0.54437,-0.49809 250.69056,-46.89436 251.45601,-46.63922 0.53919,0.17973 -24.23019,37.01189 -26.56024,39.49519 -0.11337,0.12083 -15.65689,4.72443 -34.54116,10.23025 -18.88427,5.5058 -34.37372,10.304 -34.42101,10.66266 -0.0473,0.35865 6.37973,8.81415 14.28226,18.78999 l 14.36824,18.1379 -1.42024,2.47462 c -1.19495,2.08208 -5.87073,4.62496 -29.47588,16.0302 -15.43061,7.45556 -28.53788,13.74062 -29.12728,13.96679 -0.70766,0.27156 -0.41416,-1.07363 0.86417,-3.96059 z m 27.37153,-210.70145 c -54.34399,-45.68306 -99.45179,-83.68476 -100.23955,-84.44823 -1.3583,-1.31643 0.48194,-2.96264 35.62584,-31.86942 20.38196,-16.7647 37.32004,-30.56596 37.64017,-30.66945 0.47911,-0.15489 60.09032,107.8891 61.11142,110.76311 0.30299,0.85279 60.42231,111.09717 63.60686,116.63969 0.83566,1.45442 1.41659,2.6444 1.29096,2.6444 -0.12564,0 -44.6917,-37.37705 -99.0357,-83.0601 z M 627.90876,220.19859 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1608-3"
                d="m 454.64789,574.08638 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25494 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01209,-1.29052 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -111.12384,-18.9176 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23066 -0.33896,0.22376 -0.33896,-2.23756 z m 0.81366,-25.22347 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23067 -0.33896,0.22376 -0.33896,-2.23756 z m 0.80255,-24.81664 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0111 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.06831 -0.19313,1.00075 -0.34615,-0.0111 -0.34005,-2.24876 z m 0.76971,-24.00298 c 0,-1.56629 0.16746,-2.20705 0.37212,-1.4239 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37212,0.14239 -0.37212,-1.42391 z m 372.31508,-82.7355 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z M 332.93535,312.29119 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 56.58091,-44.48117 c -29.23368,-24.2409 -53.09794,-44.47053 -53.03168,-44.95473 0.21219,-1.55069 85.8061,-184.735319 86.71374,-185.581266 0.59477,-0.554338 0.70093,-0.507211 0.33312,0.147867 -0.38389,0.683686 16.07957,233.234119 19.21461,271.411249 0.13781,1.67817 0.17672,3.05122 0.0865,3.05122 -0.0902,0 -24.08256,-19.83345 -53.31625,-44.07434 z m -55.76725,19.25771 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 308.14453,-2.44098 c 1.05105,-1.11879 2.09406,-2.03415 2.31782,-2.03415 0.22376,0 -0.45311,0.91536 -1.50416,2.03415 -1.05104,1.11878 -2.09406,2.03415 -2.31781,2.03415 -0.22376,0 0.45311,-0.91537 1.50415,-2.03415 z M 336.18999,211.39732 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0112 -0.34005,-2.24875 z m 343.94559,-11.39124 c 1.05104,-1.11879 2.09406,-2.03415 2.31781,-2.03415 0.22376,0 -0.45311,0.91536 -1.50415,2.03415 -1.05105,1.11878 -2.09406,2.03415 -2.31782,2.03415 -0.22376,0 0.45311,-0.91537 1.50416,-2.03415 z m 10.57758,-9.6643 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -135.6925,-2.94744 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z M 554.207,171.9348 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 31.08597,-6.7127 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.89899,-2.38979 z m -31.89963,-8.74685 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z m 16.8543,-5.4922 -2.80401,-3.05123 3.05122,2.80401 c 1.67818,1.5422 3.05123,2.91526 3.05123,3.05123 0,0.62132 -0.68854,0.036 -3.29844,-2.80401 z m -17.66796,-9.96734 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 2.60786,-4.27172 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.62861 -0.67137,0.0752 -2.89899,-2.38979 z M 610.00823,32.243072 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235043 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1606-7"
                d="m 537.33,649.5401 c -0.28109,-0.45481 -0.9085,-0.58131 -1.39424,-0.28111 -0.53983,0.33363 -0.64796,0.16528 -0.27816,-0.43307 0.46325,-0.74956 0.87394,-0.75567 1.75304,-0.0261 1.15148,0.95565 1.45946,1.5672 0.78924,1.5672 -0.19735,0 -0.5888,-0.37212 -0.86988,-0.82693 z m -9.01937,-8.32674 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 143.68834,-5.08538 c 1.11878,-0.63955 2.4003,-1.16283 2.84781,-1.16283 0.44751,0 -0.10171,0.52328 -1.22049,1.16283 -1.11878,0.63955 -2.4003,1.16282 -2.84781,1.16282 -0.44751,0 0.10171,-0.52327 1.22049,-1.16282 z m -152.63861,-3.05123 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97824,-0.82384 -1.83074,-1.83074 z m 187.626,-1.42391 c 0.67127,-0.43381 1.58664,-0.78873 2.03415,-0.78873 0.44751,0 0.26444,0.35492 -0.40683,0.78873 -0.67127,0.43382 -1.58664,0.78874 -2.03415,0.78874 -0.44751,0 -0.26444,-0.35492 0.40683,-0.78874 z m -196.57626,-6.71269 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.56992,-7.72978 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -8.51695,-7.72977 -1.55001,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z M 325.74885,541.7314 c 0.39493,-7.3419 2.15104,-62.67352 3.07267,-96.81358 0.20916,-7.74798 0.31681,-8.18782 2.2538,-9.20885 1.11878,-0.58973 10.90784,-5.86715 21.75348,-11.72759 18.43432,-9.961 19.74514,-10.81902 20.11539,-13.16682 0.47844,-3.0338 12.6638,-140.97437 12.65357,-143.24068 -0.006,-1.29008 -0.72025,-0.90295 -3.75383,2.03415 -4.87689,4.72178 -24.80153,27.83844 -38.05666,44.15349 -5.74714,7.07386 -10.58243,12.72849 -10.74508,12.56583 -0.28824,-0.28822 3.50624,-121.94487 3.92494,-125.83969 0.1847,-1.71807 6.69597,3.41796 52.86574,41.70009 28.9603,24.01271 52.82929,43.65948 53.04221,43.65948 0.21292,0 0.53698,-1.18997 0.72014,-2.64439 0.18317,-1.45442 0.26009,-0.81366 0.17095,1.4239 -0.13804,3.46458 -8.88658,23.44784 -58.95363,134.66078 -32.33535,71.82586 -58.96096,130.77015 -59.16802,130.98732 -0.20706,0.21717 -0.16012,-3.62737 0.10433,-8.54344 z m 95.97228,2.65638 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z M 788.35239,369.33447 c 0,-0.17589 0.56824,-0.53783 1.26275,-0.80435 0.7241,-0.27786 1.0507,-0.14145 0.76564,0.31978 -0.47783,0.77315 -2.02839,1.14356 -2.02839,0.48457 z M 442.75196,271.60818 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z M 441.9383,261.0306 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 192.08986,-4.86752 c 0,-0.66333 0.94588,-2.03638 2.10196,-3.05123 l 2.10195,-1.84517 -2.03415,2.30311 c -1.11878,1.26672 -1.9121,2.48721 -1.76293,2.71221 0.14917,0.22499 0.11866,0.56164 -0.0678,0.7481 -0.18647,0.18647 -0.33903,-0.2037 -0.33903,-0.86702 z m -192.90352,-6.52372 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 206.87135,-7.72977 c 0.80999,-0.89503 1.65579,-1.62732 1.87954,-1.62732 0.22376,0 -0.25588,0.73229 -1.06588,1.62732 -0.80999,0.89502 -1.65578,1.62732 -1.87953,1.62732 -0.22376,0 0.25588,-0.7323 1.06587,-1.62732 z m -207.68501,-2.84781 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 193.2934,-6.65828 c 0.58735,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -194.10706,-4.73297 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77794 -0.3629,-0.0502 -0.35386,-1.84022 z m 160.74699,0.66467 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.35672,-1.11952 c 0,-0.47393 0.36614,-0.63539 0.81366,-0.35881 0.44751,0.27658 0.81366,0.66434 0.81366,0.86168 0,0.19735 -0.36615,0.35881 -0.81366,0.35881 -0.44752,0 -0.81366,-0.38776 -0.81366,-0.86168 z m 3.25464,-4.32749 c 0,-0.16895 0.64075,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z M 437.87,204.88804 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 163.34053,0.91328 c 0,-0.16895 0.64076,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 4.88196,-5.69562 c 0,-0.16896 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 77.70456,-3.7611 c 0.80999,-0.89502 1.65578,-1.62732 1.87954,-1.62732 0.22375,0 -0.25589,0.7323 -1.06588,1.62732 -0.80999,0.89503 -1.65579,1.62733 -1.87954,1.62733 -0.22376,0 0.25589,-0.7323 1.06588,-1.62733 z m -246.74071,-2.03415 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 117.83979,-3.32244 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m -118.65345,-8.0688 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77794 -0.3629,-0.0502 -0.35387,-1.84022 z m 117.83979,-7.39074 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z m 40.9483,-1.35611 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -159.60175,-2.64439 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84023 z m 145.79564,-0.61024 -2.38979,-2.6444 2.6444,2.3898 c 1.45441,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.899,-2.38979 z m -27.14219,-0.27122 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z M 433.8017,149.55914 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 131.54619,-3.45806 -1.97256,-2.23756 2.23756,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97257,2.50257 -0.14575,0 -1.15265,-1.00691 -2.23757,-2.23757 z m -12.89274,-1.4917 c 0.0391,-0.94788 0.23184,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z M 432.98804,138.1679 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m -0.81366,-11.39124 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z M 429.7334,94.230241 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391244 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 427.29242,60.87017 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 425.6651,38.087683 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-10.577584 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-            <path
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /><path
                id="path1604-5"
                d="M 431.32579,600.8968 C 330.01805,554.11766 326.13757,552.24573 326.41154,550.28682 c 0.28417,-2.03182 116.28364,-260.49411 116.7169,-260.06083 0.20821,0.20821 -32.53324,235.67376 -33.45866,240.62347 -0.36185,1.93543 5.28726,7.28799 63.43218,60.10243 56.19895,51.04686 64.56575,58.74763 63.62599,58.56111 -0.11188,-0.0222 -47.54285,-21.8995 -105.40216,-48.6162 z M 187.87111,512.45482 c 0,-0.4171 20.70122,-27.22253 52.47148,-67.94383 26.33584,-33.75579 75.58157,-95.95614 102.7006,-129.71709 12.63865,-15.73408 33.66382,-40.22181 38.7966,-45.18587 3.03769,-2.93782 3.75213,-3.32455 3.75797,-2.03415 0.0102,2.27047 -12.17563,140.21031 -12.65472,143.24682 -0.37241,2.36037 -1.70365,3.22416 -21.31772,13.83222 -11.50629,6.22305 -21.85828,11.72213 -23.00443,12.22019 -2.08092,0.90425 -130.7428,70.32107 -137.29173,74.07286 -1.90193,1.08959 -3.45805,1.76857 -3.45805,1.50885 z M 741.97376,362.55905 693.56097,355.6059 663.13353,299.93669 c -20.74911,-37.96203 -30.76865,-55.53829 -31.50018,-55.25757 -0.59001,0.22641 -17.63334,14.03966 -37.87408,30.69613 l -36.80134,30.28447 -56.18851,-9.18258 c -30.90367,-5.05043 -56.25792,-9.24203 -56.34279,-9.31469 -0.0849,-0.0727 -4.67032,-61.81947 -10.18991,-137.21516 L 424.20111,12.864215 426.25442,12.6415 c 2.09207,-0.226922 191.97524,20.598542 192.40443,21.101978 0.12937,0.151747 16.80892,34.693733 37.06566,76.759972 20.25674,42.06623 36.95473,76.70669 37.10665,76.97878 0.15192,0.2721 -3.68412,4.18419 -8.52453,8.69355 l -8.80074,8.19882 -23.11205,-14.99803 c -12.71161,-8.24891 -23.3574,-14.90711 -23.6573,-14.79599 -0.29989,0.11112 -6.70746,7.35849 -14.23905,16.10526 -20.81761,24.17645 -21.67874,25.20578 -21.33593,25.50313 0.17556,0.15227 13.31742,1.81335 29.20414,3.69129 15.88671,1.87793 29.53692,3.6679 30.3338,3.97771 1.17093,0.45522 -0.58035,2.43253 -9.1296,10.30792 -5.81814,5.35956 -10.31467,9.97916 -9.99228,10.26579 0.32238,0.28663 35.00398,27.72184 77.07022,60.96714 83.92398,66.32581 81.36767,64.28536 80.41138,64.1844 -0.36997,-0.0391 -22.45843,-3.19993 -49.08546,-7.02417 z M 577.80361,188.0883 l 19.3281,-12.22641 -8.33476,-7.92393 c -34.7879,-33.07314 -35.99219,-34.14534 -36.24379,-32.26837 -0.13453,1.00355 0.50623,15.68949 1.4239,32.6354 0.91767,16.94593 1.66849,31.32487 1.66849,31.95323 0,1.74538 1.2152,1.07795 22.15806,-12.16992 z m 53.25426,-28.85635 c 7.97344,-2.51144 14.62777,-4.68638 14.78742,-4.83321 0.15965,-0.14683 -4.74154,-7.26919 -10.89153,-15.82746 -6.14999,-8.55829 -11.45822,-15.26241 -11.79608,-14.89806 -0.33786,0.36435 -2.43505,9.54152 -4.66042,20.39371 -2.99865,14.62311 -3.77305,19.73126 -2.99133,19.73126 0.58015,0 7.57852,-2.05481 15.55194,-4.56624 z"
-               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" />
-          </g>
-        </g>
-        <g
-           id="g1800">
-          <g
+               style="fill:#fff700;fill-opacity:1;stroke-width:0.81366" /></g></g><g
+           id="g1800"><g
              style="display:inline;fill:#33005b;fill-opacity:1;filter:url(#filter1784)"
              id="g1602-6"
-             transform="matrix(1.0065297,0,0,1.018788,-1631.9008,-143.76888)">
-            <g
+             transform="matrix(1.0065297,0,0,1.018788,-1631.9008,-143.76888)"><g
                style="fill:#33005b;fill-opacity:1"
                id="g1638-2"
-               transform="translate(1628.4971,151.51917)">
-              <path
+               transform="translate(1628.4971,151.51917)"><path
                  id="path1626-9"
                  d="m 615.45139,161.9012 c 0.2235,-0.97046 2.06041,-9.79587 4.082,-19.61203 2.0216,-9.81616 3.80885,-17.98077 3.97167,-18.14359 0.40261,-0.40262 21.08238,28.72538 21.01503,29.60023 -0.0486,0.63152 -4.30659,2.09423 -23.17034,7.95954 l -6.30474,1.96033 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1624-1"
                  d="m 556.12657,196.95485 c -0.6884,-5.50606 -3.11282,-56.92855 -2.79915,-59.37098 0.30902,-2.40628 -2.63097,-4.96857 33.85936,29.50938 l 9.16555,8.6601 -19.51358,12.32978 c -10.73246,6.78138 -19.68598,12.32978 -19.8967,12.32978 -0.21072,0 -0.57769,-1.55613 -0.81548,-3.45806 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1622-2"
                  d="m 599.2586,648.62513 17.98275,-13.62813 6.02023,-13.49809 6.02023,-13.49808 29.17856,-14.15965 c 23.94565,-11.62024 29.3895,-14.56624 30.35477,-16.42681 1.63369,-3.14894 1.68075,-3.16757 3.59674,-1.42446 1.38146,1.25682 6.32986,2.19698 25.8387,4.90915 13.27151,1.84505 24.18505,3.30964 24.25232,3.25464 0.5321,-0.43493 39.14364,-82.34062 38.92137,-82.5629 -0.1587,-0.1587 -11.15911,2.87653 -24.44535,6.74497 -13.28624,3.86843 -24.2945,6.89581 -24.46279,6.72751 -0.1683,-0.16829 5.78679,-9.04596 13.23352,-19.72817 l 13.53952,-19.42217 -1.76071,-3.29266 c -0.96839,-1.81096 -15.60457,-28.55681 -32.52484,-59.43521 -26.88221,-49.05832 -30.55026,-56.16574 -29.06924,-56.32623 0.93219,-0.10102 22.93142,2.86118 48.88719,6.58266 25.95576,3.72148 47.34864,6.63799 47.53973,6.48113 0.19108,-0.15686 -0.25108,-0.73911 -0.9826,-1.29387 -0.7315,-0.55477 -36.48696,-28.83585 -79.45657,-62.84685 l -78.12657,-61.83818 8.37684,-7.86179 c 4.60727,-4.32398 9.52968,-8.83183 10.93869,-10.01744 l 2.56185,-2.15565 29.91682,3.65537 c 16.45426,2.01046 30.02108,3.55112 30.1485,3.42371 0.12741,-0.12742 -8.77926,-6.05202 -19.7926,-13.16578 l -20.02426,-12.93411 8.89884,-8.54344 8.89884,-8.54343 -37.3206,-77.2465 C 635.87215,68.069087 618.99381,33.230652 618.89105,33.135934 618.45237,32.731536 423.83773,11.370017 423.5399,11.693569 423.35916,11.889913 403.68684,53.9744 379.82363,105.21465 l -43.38765,93.16411 -2.07361,64.27916 c -1.14047,35.35354 -2.41931,64.81949 -2.84185,65.47989 -0.42254,0.6604 -11.4166,14.57399 -24.43125,30.91909 -21.74936,27.31503 -36.24102,45.68328 -68.06108,86.26775 -13.64415,17.40224 -51.01034,65.48176 -52.7228,67.83904 -1.37019,1.88614 -0.99579,1.68873 80.49076,-42.43976 33.78725,-18.29725 61.54323,-32.99244 61.67996,-32.65599 0.13673,0.33645 -0.50403,23.29135 -1.4239,51.01087 -0.91989,27.71953 -1.67252,53.30774 -1.67252,56.86268 v 6.46353 l 107.12426,49.50792 107.12425,49.50792 7.61261,-3.78156 c 4.18693,-2.07985 7.93777,-3.78155 8.3352,-3.78155 0.39742,0 5.96406,4.36638 12.3703,9.70307 6.40624,5.33669 12.02612,9.47568 12.48863,9.19776 0.4625,-0.27793 8.93315,-6.63798 18.82366,-14.13345 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1616-7"
                  d="m 474.27953,591.19545 -63.87234,-58.10026 0.25529,-2.99884 c 0.3707,-4.35471 33.41306,-240.35348 33.69098,-240.6314 0.12862,-0.12862 13.86717,52.00457 30.53011,115.85154 39.34923,150.77343 42.69111,163.78458 42.195,164.28069 -0.2289,0.2289 -10.11156,1.20198 -21.96148,2.16241 -11.84991,0.96043 -21.76398,1.96492 -22.03127,2.2322 -0.26728,0.26728 12.83923,11.55676 29.12556,25.08775 l 29.61153,24.60178 3.31979,12.71291 c 1.82588,6.9921 3.24989,12.75534 3.16447,12.80719 -0.0854,0.0519 -28.89786,-26.05083 -64.02764,-58.00597 z m 255.33676,-8.91804 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.039 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -17.90053,-2.44098 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 325.58488,531.1658 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m 0.81366,-25.22346 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 0.83008,-24.81664 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66147 -0.19394,1.00691 -0.35262,0.18308 -0.35262,-1.83073 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66148 -0.19394,1.0069 -0.35262,0.18307 -0.35262,-1.83074 z m 4.88197,-151.34081 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66148 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 304.90099,-15.76675 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m -304.08733,-9.45671 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.0069 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18307 -0.35261,-1.83073 z m 378.54545,1.61405 c 0.28109,-0.45482 0.85192,-0.61629 1.26851,-0.35881 1.12858,0.69749 0.91814,1.18574 -0.51108,1.18574 -0.69768,0 -1.03852,-0.37212 -0.75743,-0.82693 z m -7.07688,-0.54255 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42736 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49159 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58735,-0.23505 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -35.64849,-0.56505 c 0,-0.16896 0.64075,-0.80971 1.4239,-1.42391 1.29052,-1.01208 1.31929,-0.9833 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m 29.1392,-0.24861 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -7.37379,-0.79672 c 0.55939,-0.22571 1.47476,-0.22571 2.03415,0 0.55939,0.22572 0.10171,0.41041 -1.01708,0.41041 -1.11878,0 -1.57646,-0.18469 -1.01707,-0.41041 z m -6.45843,-0.8306 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81367 c 0.58735,-0.23504 1.28914,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.21021,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 336.17889,203.66755 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18308 -0.35261,-1.83073 z m 339.88838,0.50645 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.30721,0.3072 -1.06295,1.35536 -1.73112,1.78638 -1.73112,1.1167 z M 555.9501,200.03292 c -0.25193,-0.65651 -0.30103,-1.66342 -0.10911,-2.23757 0.19191,-0.57415 0.54183,-0.037 0.77758,1.19365 0.46032,2.40292 0.0806,2.99593 -0.66847,1.04392 z m 132.32208,-7.25016 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01208 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -133.31182,-9.45672 c 0,-1.11878 0.18469,-1.57647 0.4104,-1.01707 0.22572,0.55939 0.22572,1.47475 0,2.03415 -0.22571,0.55939 -0.4104,0.1017 -0.4104,-1.01708 z m 34.37479,-14.03564 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.8525 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -35.25268,-1.89854 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 20.60679,-11.93368 -1.55001,-1.83074 1.83073,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55002,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m -21.42045,-3.52586 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 6.38346,-10.7132 -1.97257,-2.23756 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15264,-1.00691 -2.23756,-2.23757 z m -7.13289,-5.08537 c 0,-1.11879 0.18469,-1.57647 0.4104,-1.01708 0.22572,0.55939 0.22572,1.47476 0,2.03415 -0.22571,0.55939 -0.4104,0.10171 -0.4104,-1.01707 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1614-0"
                  d="m 530.75161,642.84068 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.13661 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11145,-1.55002 z m -8.52772,-7.72977 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84366 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 14.60368,-6.50928 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -23.55394,-1.62732 -1.97257,-2.23757 2.23757,1.97257 c 2.09134,1.84366 2.6107,2.50256 1.97257,2.50256 -0.14575,0 -1.15265,-1.0069 -2.23757,-2.23756 z m 18.67198,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.0683 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 1.35535,1.06294 1.78637,1.73111 1.1167,1.73111 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.4239 z m -22.74028,-1.62732 -1.97257,-2.23757 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15265,-1.0069 -2.23756,-2.23756 z m 17.85832,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.06831 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -21.92663,-1.62732 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84367 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 17.04466,-2.44098 c -1.01208,-1.29051 -0.9833,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73112,-1.1167 z m -4.88196,-4.0683 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.4239,1.25494 1.4239,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -20.72185,-1.22049 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 15.83989,-2.84781 c -1.01209,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 1.35535,1.06295 1.78637,1.73112 1.1167,1.73112 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.42391 z m -24.79015,-5.28879 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 10.95793,-6.10245 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -19.9082,-2.03415 -1.55001,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m 15.02624,-2.03416 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m 0.32268,-3.20825 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0968,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 9.76393,-0.81366 c 0.79166,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m -34.06311,-2.08054 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 43.82703,1.26688 c 0.79167,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m 10.57758,-0.81366 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 8.73137,-0.56178 c 0,-0.17159 0.91537,-0.48696 2.03415,-0.70083 1.11878,-0.21387 2.03415,-0.0735 2.03415,0.31198 0,0.38545 -0.91537,0.70083 -2.03415,0.70083 -1.11878,0 -2.03415,-0.14039 -2.03415,-0.31198 z m -72.08624,-8.02804 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82384 -1.83073,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z m 89.97764,-15.94255 C 505.1846,521.1947 491.46956,468.2441 474.7119,404.26794 457.95424,340.29179 444.31937,287.9002 444.41218,287.84218 c 0.0928,-0.058 25.61597,4.07623 56.71813,9.18719 43.68682,7.17897 56.91954,9.6216 58.17671,10.73886 0.89503,0.79542 45.48591,38.30942 99.09084,83.36445 56.63281,47.59994 97.84546,81.68217 98.3752,81.35477 0.51955,-0.3211 0.68647,-0.19907 0.38809,0.28373 -0.28797,0.46596 0.0516,1.32453 0.75453,1.90794 1.07186,0.88956 -18.97326,4.83342 -124.2136,24.43885 -69.02044,12.85797 -126.16936,23.55533 -126.99759,23.77192 -1.01588,0.26566 -1.50884,-0.0448 -1.515,-0.95394 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1612-9"
                  d="m 559.92226,646.50215 c -30.89503,-25.35456 -87.13957,-72.19328 -86.93957,-72.40059 0.15887,-0.16467 54.14597,-4.64838 148.16252,-12.30512 15.66296,-1.2756 28.62852,-2.19237 28.81235,-2.03726 0.30868,0.26043 -9.9116,23.5602 -26.00362,59.28193 -3.62874,8.05524 -7.13932,15.24722 -7.80127,15.98219 -1.30072,1.44416 -35.68355,27.54864 -36.28499,27.54864 -0.20024,0 -9.17568,-7.23141 -19.94542,-16.06979 z m 156.62352,-66.14344 c -11.97158,-1.69742 -22.1298,-3.20811 -22.57384,-3.35707 -1.38845,-0.46582 -32.53471,-40.08008 -31.91642,-40.59382 0.3225,-0.26796 16.14761,-4.97324 35.16692,-10.45616 19.01931,-5.48292 45.67559,-13.18256 59.23617,-17.11029 18.88877,-5.47101 24.53913,-6.83552 24.15762,-5.83385 -0.27388,0.71912 -8.9879,19.15717 -19.36447,40.97343 -17.67114,37.15274 -18.99553,39.65955 -20.90299,39.56496 -1.12007,-0.0556 -11.83141,-1.48977 -23.80299,-3.1872 z m -7.93209,-350.32516 c -0.67127,-0.16281 -25.75235,-3.23328 -55.73573,-6.82326 -29.98339,-3.58998 -55.55997,-6.80116 -56.83686,-7.13595 -2.3102,-0.60572 -2.2366,-0.70773 14.97065,-20.74681 9.51074,-11.07595 17.64526,-20.13809 18.0767,-20.13809 0.68832,0 82.78014,52.92946 84.77334,54.6584 0.75427,0.65426 -2.79799,0.77996 -5.2481,0.18571 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1610-3"
                  d="m 535.79842,637.95731 c -1.7419,-6.82381 -3.36664,-12.94132 -3.61053,-13.59448 -0.36714,-0.98323 16.078,12.20797 21.33503,17.11353 1.4893,1.38975 1.29999,1.55591 -5.88278,5.16332 -4.08189,2.05004 -7.70354,3.72672 -8.04812,3.72595 -0.34458,-7.8e-4 -2.05169,-5.58452 -3.7936,-12.40832 z m 95.758,-35.69954 c 1.0647,-2.40451 5.7153,-12.88731 10.33467,-23.29513 4.61938,-10.40781 8.24888,-19.05132 8.06555,-19.20781 -0.18333,-0.15647 -28.70973,2.04311 -63.392,4.88798 -34.68227,2.84487 -64.32966,5.08081 -65.88309,4.96876 l -2.82442,-0.20373 -6.00656,-23.03738 c -3.30361,-12.67055 -5.87717,-23.15577 -5.71902,-23.30048 0.54437,-0.49809 250.69056,-46.89436 251.45601,-46.63922 0.53919,0.17973 -24.23019,37.01189 -26.56024,39.49519 -0.11337,0.12083 -15.65689,4.72443 -34.54116,10.23025 -18.88427,5.5058 -34.37372,10.304 -34.42101,10.66266 -0.0473,0.35865 6.37973,8.81415 14.28226,18.78999 l 14.36824,18.1379 -1.42024,2.47462 c -1.19495,2.08208 -5.87073,4.62496 -29.47588,16.0302 -15.43061,7.45556 -28.53788,13.74062 -29.12728,13.96679 -0.70766,0.27156 -0.41416,-1.07363 0.86417,-3.96059 z m 27.37153,-210.70145 c -54.34399,-45.68306 -99.45179,-83.68476 -100.23955,-84.44823 -1.3583,-1.31643 0.48194,-2.96264 35.62584,-31.86942 20.38196,-16.7647 37.32004,-30.56596 37.64017,-30.66945 0.47911,-0.15489 60.09032,107.8891 61.11142,110.76311 0.30299,0.85279 60.42231,111.09717 63.60686,116.63969 0.83566,1.45442 1.41659,2.6444 1.29096,2.6444 -0.12564,0 -44.6917,-37.37705 -99.0357,-83.0601 z M 627.90876,220.19859 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1608-6"
                  d="m 454.64789,574.08638 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25494 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01209,-1.29052 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -111.12384,-18.9176 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23066 -0.33896,0.22376 -0.33896,-2.23756 z m 0.81366,-25.22347 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23067 -0.33896,0.22376 -0.33896,-2.23756 z m 0.80255,-24.81664 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0111 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.06831 -0.19313,1.00075 -0.34615,-0.0111 -0.34005,-2.24876 z m 0.76971,-24.00298 c 0,-1.56629 0.16746,-2.20705 0.37212,-1.4239 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37212,0.14239 -0.37212,-1.42391 z m 372.31508,-82.7355 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z M 332.93535,312.29119 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 56.58091,-44.48117 c -29.23368,-24.2409 -53.09794,-44.47053 -53.03168,-44.95473 0.21219,-1.55069 85.8061,-184.735319 86.71374,-185.581266 0.59477,-0.554338 0.70093,-0.507211 0.33312,0.147867 -0.38389,0.683686 16.07957,233.234119 19.21461,271.411249 0.13781,1.67817 0.17672,3.05122 0.0865,3.05122 -0.0902,0 -24.08256,-19.83345 -53.31625,-44.07434 z m -55.76725,19.25771 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 308.14453,-2.44098 c 1.05105,-1.11879 2.09406,-2.03415 2.31782,-2.03415 0.22376,0 -0.45311,0.91536 -1.50416,2.03415 -1.05104,1.11878 -2.09406,2.03415 -2.31781,2.03415 -0.22376,0 0.45311,-0.91537 1.50415,-2.03415 z M 336.18999,211.39732 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0112 -0.34005,-2.24875 z m 343.94559,-11.39124 c 1.05104,-1.11879 2.09406,-2.03415 2.31781,-2.03415 0.22376,0 -0.45311,0.91536 -1.50415,2.03415 -1.05105,1.11878 -2.09406,2.03415 -2.31782,2.03415 -0.22376,0 0.45311,-0.91537 1.50416,-2.03415 z m 10.57758,-9.6643 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -135.6925,-2.94744 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z M 554.207,171.9348 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 31.08597,-6.7127 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.89899,-2.38979 z m -31.89963,-8.74685 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z m 16.8543,-5.4922 -2.80401,-3.05123 3.05122,2.80401 c 1.67818,1.5422 3.05123,2.91526 3.05123,3.05123 0,0.62132 -0.68854,0.036 -3.29844,-2.80401 z m -17.66796,-9.96734 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 2.60786,-4.27172 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.62861 -0.67137,0.0752 -2.89899,-2.38979 z M 610.00823,32.243072 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235043 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1606-0"
                  d="m 537.33,649.5401 c -0.28109,-0.45481 -0.9085,-0.58131 -1.39424,-0.28111 -0.53983,0.33363 -0.64796,0.16528 -0.27816,-0.43307 0.46325,-0.74956 0.87394,-0.75567 1.75304,-0.0261 1.15148,0.95565 1.45946,1.5672 0.78924,1.5672 -0.19735,0 -0.5888,-0.37212 -0.86988,-0.82693 z m -9.01937,-8.32674 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 143.68834,-5.08538 c 1.11878,-0.63955 2.4003,-1.16283 2.84781,-1.16283 0.44751,0 -0.10171,0.52328 -1.22049,1.16283 -1.11878,0.63955 -2.4003,1.16282 -2.84781,1.16282 -0.44751,0 0.10171,-0.52327 1.22049,-1.16282 z m -152.63861,-3.05123 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97824,-0.82384 -1.83074,-1.83074 z m 187.626,-1.42391 c 0.67127,-0.43381 1.58664,-0.78873 2.03415,-0.78873 0.44751,0 0.26444,0.35492 -0.40683,0.78873 -0.67127,0.43382 -1.58664,0.78874 -2.03415,0.78874 -0.44751,0 -0.26444,-0.35492 0.40683,-0.78874 z m -196.57626,-6.71269 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.56992,-7.72978 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -8.51695,-7.72977 -1.55001,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z M 325.74885,541.7314 c 0.39493,-7.3419 2.15104,-62.67352 3.07267,-96.81358 0.20916,-7.74798 0.31681,-8.18782 2.2538,-9.20885 1.11878,-0.58973 10.90784,-5.86715 21.75348,-11.72759 18.43432,-9.961 19.74514,-10.81902 20.11539,-13.16682 0.47844,-3.0338 12.6638,-140.97437 12.65357,-143.24068 -0.006,-1.29008 -0.72025,-0.90295 -3.75383,2.03415 -4.87689,4.72178 -24.80153,27.83844 -38.05666,44.15349 -5.74714,7.07386 -10.58243,12.72849 -10.74508,12.56583 -0.28824,-0.28822 3.50624,-121.94487 3.92494,-125.83969 0.1847,-1.71807 6.69597,3.41796 52.86574,41.70009 28.9603,24.01271 52.82929,43.65948 53.04221,43.65948 0.21292,0 0.53698,-1.18997 0.72014,-2.64439 0.18317,-1.45442 0.26009,-0.81366 0.17095,1.4239 -0.13804,3.46458 -8.88658,23.44784 -58.95363,134.66078 -32.33535,71.82586 -58.96096,130.77015 -59.16802,130.98732 -0.20706,0.21717 -0.16012,-3.62737 0.10433,-8.54344 z m 95.97228,2.65638 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z M 788.35239,369.33447 c 0,-0.17589 0.56824,-0.53783 1.26275,-0.80435 0.7241,-0.27786 1.0507,-0.14145 0.76564,0.31978 -0.47783,0.77315 -2.02839,1.14356 -2.02839,0.48457 z M 442.75196,271.60818 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z M 441.9383,261.0306 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 192.08986,-4.86752 c 0,-0.66333 0.94588,-2.03638 2.10196,-3.05123 l 2.10195,-1.84517 -2.03415,2.30311 c -1.11878,1.26672 -1.9121,2.48721 -1.76293,2.71221 0.14917,0.22499 0.11866,0.56164 -0.0678,0.7481 -0.18647,0.18647 -0.33903,-0.2037 -0.33903,-0.86702 z m -192.90352,-6.52372 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 206.87135,-7.72977 c 0.80999,-0.89503 1.65579,-1.62732 1.87954,-1.62732 0.22376,0 -0.25588,0.73229 -1.06588,1.62732 -0.80999,0.89502 -1.65578,1.62732 -1.87953,1.62732 -0.22376,0 0.25588,-0.7323 1.06587,-1.62732 z m -207.68501,-2.84781 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 193.2934,-6.65828 c 0.58735,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -194.10706,-4.73297 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77794 -0.3629,-0.0502 -0.35386,-1.84022 z m 160.74699,0.66467 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.35672,-1.11952 c 0,-0.47393 0.36614,-0.63539 0.81366,-0.35881 0.44751,0.27658 0.81366,0.66434 0.81366,0.86168 0,0.19735 -0.36615,0.35881 -0.81366,0.35881 -0.44752,0 -0.81366,-0.38776 -0.81366,-0.86168 z m 3.25464,-4.32749 c 0,-0.16895 0.64075,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z M 437.87,204.88804 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 163.34053,0.91328 c 0,-0.16895 0.64076,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 4.88196,-5.69562 c 0,-0.16896 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 77.70456,-3.7611 c 0.80999,-0.89502 1.65578,-1.62732 1.87954,-1.62732 0.22375,0 -0.25589,0.7323 -1.06588,1.62732 -0.80999,0.89503 -1.65579,1.62733 -1.87954,1.62733 -0.22376,0 0.25589,-0.7323 1.06588,-1.62733 z m -246.74071,-2.03415 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 117.83979,-3.32244 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m -118.65345,-8.0688 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77794 -0.3629,-0.0502 -0.35387,-1.84022 z m 117.83979,-7.39074 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z m 40.9483,-1.35611 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -159.60175,-2.64439 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84023 z m 145.79564,-0.61024 -2.38979,-2.6444 2.6444,2.3898 c 1.45441,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.899,-2.38979 z m -27.14219,-0.27122 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z M 433.8017,149.55914 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 131.54619,-3.45806 -1.97256,-2.23756 2.23756,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97257,2.50257 -0.14575,0 -1.15265,-1.00691 -2.23757,-2.23757 z m -12.89274,-1.4917 c 0.0391,-0.94788 0.23184,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z M 432.98804,138.1679 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m -0.81366,-11.39124 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z M 429.7334,94.230241 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391244 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 427.29242,60.87017 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 425.6651,38.087683 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-10.577584 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-              <path
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /><path
                  id="path1604-6"
                  d="M 431.32579,600.8968 C 330.01805,554.11766 326.13757,552.24573 326.41154,550.28682 c 0.28417,-2.03182 116.28364,-260.49411 116.7169,-260.06083 0.20821,0.20821 -32.53324,235.67376 -33.45866,240.62347 -0.36185,1.93543 5.28726,7.28799 63.43218,60.10243 56.19895,51.04686 64.56575,58.74763 63.62599,58.56111 -0.11188,-0.0222 -47.54285,-21.8995 -105.40216,-48.6162 z M 187.87111,512.45482 c 0,-0.4171 20.70122,-27.22253 52.47148,-67.94383 26.33584,-33.75579 75.58157,-95.95614 102.7006,-129.71709 12.63865,-15.73408 33.66382,-40.22181 38.7966,-45.18587 3.03769,-2.93782 3.75213,-3.32455 3.75797,-2.03415 0.0102,2.27047 -12.17563,140.21031 -12.65472,143.24682 -0.37241,2.36037 -1.70365,3.22416 -21.31772,13.83222 -11.50629,6.22305 -21.85828,11.72213 -23.00443,12.22019 -2.08092,0.90425 -130.7428,70.32107 -137.29173,74.07286 -1.90193,1.08959 -3.45805,1.76857 -3.45805,1.50885 z M 741.97376,362.55905 693.56097,355.6059 663.13353,299.93669 c -20.74911,-37.96203 -30.76865,-55.53829 -31.50018,-55.25757 -0.59001,0.22641 -17.63334,14.03966 -37.87408,30.69613 l -36.80134,30.28447 -56.18851,-9.18258 c -30.90367,-5.05043 -56.25792,-9.24203 -56.34279,-9.31469 -0.0849,-0.0727 -4.67032,-61.81947 -10.18991,-137.21516 L 424.20111,12.864215 426.25442,12.6415 c 2.09207,-0.226922 191.97524,20.598542 192.40443,21.101978 0.12937,0.151747 16.80892,34.693733 37.06566,76.759972 20.25674,42.06623 36.95473,76.70669 37.10665,76.97878 0.15192,0.2721 -3.68412,4.18419 -8.52453,8.69355 l -8.80074,8.19882 -23.11205,-14.99803 c -12.71161,-8.24891 -23.3574,-14.90711 -23.6573,-14.79599 -0.29989,0.11112 -6.70746,7.35849 -14.23905,16.10526 -20.81761,24.17645 -21.67874,25.20578 -21.33593,25.50313 0.17556,0.15227 13.31742,1.81335 29.20414,3.69129 15.88671,1.87793 29.53692,3.6679 30.3338,3.97771 1.17093,0.45522 -0.58035,2.43253 -9.1296,10.30792 -5.81814,5.35956 -10.31467,9.97916 -9.99228,10.26579 0.32238,0.28663 35.00398,27.72184 77.07022,60.96714 83.92398,66.32581 81.36767,64.28536 80.41138,64.1844 -0.36997,-0.0391 -22.45843,-3.19993 -49.08546,-7.02417 z M 577.80361,188.0883 l 19.3281,-12.22641 -8.33476,-7.92393 c -34.7879,-33.07314 -35.99219,-34.14534 -36.24379,-32.26837 -0.13453,1.00355 0.50623,15.68949 1.4239,32.6354 0.91767,16.94593 1.66849,31.32487 1.66849,31.95323 0,1.74538 1.2152,1.07795 22.15806,-12.16992 z m 53.25426,-28.85635 c 7.97344,-2.51144 14.62777,-4.68638 14.78742,-4.83321 0.15965,-0.14683 -4.74154,-7.26919 -10.89153,-15.82746 -6.14999,-8.55829 -11.45822,-15.26241 -11.79608,-14.89806 -0.33786,0.36435 -2.43505,9.54152 -4.66042,20.39371 -2.99865,14.62311 -3.77305,19.73126 -2.99133,19.73126 0.58015,0 7.57852,-2.05481 15.55194,-4.56624 z"
-                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" />
-            </g>
-          </g>
-        </g>
-        <image
+                 style="fill:#33005b;fill-opacity:1;stroke-width:0.81366" /></g></g></g><image
            y="-83.554527"
            x="165.08862"
            width="646.04626"
            height="913.74048"
            preserveAspectRatio="none"
            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAxoAAARjCAYAAADoylLVAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJzs3XuU1NWd7/3P91dVfePWchEaCF1VE/ASM4ZooqO5kFEUk4ga0tGIlyK03c0kEaOBeMvVXM/k kElWPBmT8JwkrpXD6LPMJLOeNTmQSdZEn6Nn9GTGiZN5vEDTdiMgCArIpS+1nz+gEbChL/Wr2r/f r96vtVgqNPX76Ezo+tTe370lAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKiclO8AAFBJn/rEJ2aed+GF 6aeeeuqg7ywAACRZ2ncAAKikgVTq1scff/zMXC73bkndZtbjnOuR1O2c6wmCoMc5193Z2blFUr/n uAAAxJb5DgAAlVIoFBrr0+nOJ556asJre/acckXXOVeUtF1Sz5Ey0i2pxznXHQRBT7FY7Nm8eXOP KCMAAAyJFQ0AVaMune6QWWM6PfwffWYWSGo68uNdZjb485KkIAiUy+WcpO1mdnRFZPCvg+WEMgIA qFasaACoCoVCoa4und5kZk1PP/OMtm3fXpHnOuecpJfN7OiKyLFbtIrFYk9XV1ePpL6KBAIAoEJY 0QBQFeozmYIOr04oM4IVjbDY4SWQ6Ud+nG9mOnZ1JJVKDa6MvHzsysiRMtLtnOspFovdlBEAQNyw ogEg8VpaWlJTGhv/06S5kvTCpk3a2NnpO9aoOOecme3QG1u0js6LOOe6BwYGel588cVuUUYAABHB igaAxJvS2NgyWDIkqaamxmecMTmyMnK6pNPN7LwjPzf4a0qn08rlcoNl5OhJWoOrJMVisWdgYKCn u7u7W1Kvp38NAEAVoWgASDyTbjv2nyu5daqSTigj7zz214IgUBAEyufzkrRjsIjo8KlaR7drDQwM dFNGAABhYOsUgETraG1dYGa/O/bnduzcqT88/bSvSHExWEaOrowcKSPd/f39PT09PS+KMgIAOIVk fqwHAG+488SfyGQyPnLEzTQzmyZp/uBPDA6y19TUDK6M7Dx2i9bg3x/ZptVdV1fX/cILLxzylB8A 4BkrGgASa0Vr63lOetIGhxmOOHDggH7/v/6Xr1hVxTn3it7YonX04sNisdidSqV6giB4kTICAMnE igaAJFt1YsmQpNraWh9ZqpKZTZE0RdI7jvyzJCmVOnwxe7FYVC6Xe0UnbNHSkZWRI2WkizICAPHD igaARGovFOYGmcyfdJIPVNb/9rc6fJce4sA5t0tvnKJ13MWHOlxKXty8efNBzzEBAMdgRQNAIlkm c4dO8WdcJp1Wbx9XTsSFmU2WNFnSuUf+WccuVgVBoFwut0tHtmjpjYsPB+8a6enr63uxp6fngJd/ AQCoQqxoAEictra2pqBY3GRmdSf7mkcff1z79++vZCxEgHNu97FFZPCvgxcfUkYAIDysaABInJRz K3WKkiEl9y4NnJqZnSbpNElvP/bCw8G/1tTUKJfLvWpm3TqyRUvHrJIUi8We/v7+LsoIAAyPFQ0A iVIoFBrr0+lOmTWe6uv+9emn9fLOnZWKhYRxzr16whatniAIjm7X6u3tffGll15iyQxAVeMjPQCJ UpdOdwxXMiROnkJp7PD/jzVKOufYeZHBv6+rq1M+n39Nb2zROnZepLtYLPb09fV1UUYAJBkrGgAS o6WlJTVl0qRuM2sa7mufe+EFdXZ1VSIWcCqv6XAJOXq8r46Uk4GBgZ5Dhw51bd++/XXPGQFgTFjR AJAYUxobbzRp2JIhSWlmNBANkyRNMrO3HfuTZqZ0Oq10Oq18Pr9Hx8+LHN2uVSwWu/ft29eza9eu PV7SA8Ap8J0WQGKYdNdIv5aigRiZKOlsMzt78CcGt2gFQaDGxkY1NjYOlpHjLj4c3Ka1b9++bsoI gErjOy2ARFixfPnVkuaN9Os5dQoJM5IysneoI30HV0bS6XTPpk2bXvP3rwAgafhOCyAZguDO0Xw5 w+CoQhPM7CxJZ504vB4EgSQpn8/vO/FI38GVkYGBgZ5UKtWzefPmV739GwCIFYbBAcReR2vrAjP7 3Wh+z+uvv67HnniiXJGAJNt34hYtHbljJJVK9RSLxW7KCACJFQ0AyTCq1QyJGQ2gBOPN7ExJZ0pv XHiYSqUkSUEQKJfLvS7p6MrI4BYt51xPKpXq7u/v73nxxRd3e8oPoEJY0QAQaytaW89z0pM2+G5n hIrFojb8blSLIABC5Jx7XW/eonX0vpGBgYFuyggQb3ykByDuVo22ZEiHP3U1MznnypEJwDDMbJyk M478ODovMiidTiuXyx04tohIeqyzs/NHXgIDGDVWNADEVltbW1PKuRc1xg9Nfvf736u3ry/kVADK xTlXNLPcpk2bXvSdBcDwAt8BAGCsAuc+pxJWZjl5CogXMwucc/f6zgFgZCgaAGKpUCg0yrn2Ul6j pqYmrDgAKsTMlmWz2Rm+cwAYHkUDQCzVpdO3mVldKa+RyWTCigOgctJmdpfvEACGR9EAEDuFQqHO pJWlvg63gwOxdcusWbOm+A4B4NQoGgBipz6d7pBZY6mvw10aQDyZWX1tbe0q3zkAnBpFA0CstLS0 pJy0OozXomgAsfbJfD4/yXcIACdH0QAQK1MaG280s6YwXquWYXAgzsZLus13CAAnR9EAECsmhTYE yqlTQLw5526bPn36ON85AAyNogEgNlYsX361pHlhvR6nTgHxZmaN9fX1n/SdA8DQKBoA4iMI7gzz 5Th1Coi/IAhWSeJTAyCCKBoAYmFFa+uFki4I8zUZBgcSYWoul+vwHQLAm1E0AMSCk0JdzZDYOgUk yF2SUr5DADgeRQNA5LUXCnMlLQ77dYMgUCrFexMg7sysKZfLLfOdA8DxKBoAIi9Ip+8xMyvHa9fW 1pbjZQFU3r2SyvLnBICxoWgAiLS2trYmmS0t1+szEA4kg5k15/P5633nAPAGigaASAuc+5yksrUB BsKBRPmi7wAA3kDRABBZhUKhUc61l/MZDIQDiTI3n89/xHcIAIdRNABEVl06fZuZ1ZXzGWydAhLn K74DADiMogEgkgqFQp1JK8v9nJqamnI/AkBlva25ufkK3yEAUDQARFR9Ot0hs8ZyP4eiASRPKpW6 13cGABQNABHU0tKSctLqSjyLrVNAIl2UzWYX+A4BVDuKBoDImdLY2GJmTZV4FqdOAclkZvf4zgBU O4oGgOhx7rOVehSnTgHJZGaXNjc3z/edA6hmFA0AkdK+fPkiMzuvUs+rZUYDSKwgCL7sOwNQzSga ACIlCII7K/m82traSj4OQAWZ2ZVz5sw523cOoFpRNABExorW1gslvb+SzwyCQGZWyUcCqKBUKsVt 4YAnFA0AkeGkiq5mDOLkKSDRPjp79uy3+g4BVCOKBoBIaC8U5kpa7OPZaQbCgcQysyCTyXCvBuAB RQNAJATp9D3maQ8TKxpAspnZ0nw+P8d3DqDaUDQAeNfW1tYks6W+ns/JU0DipSXd5TsEUG0oGgC8 Szm3UoffCHjByVNAVfhENpud4TsEUE0oGgC8KhQKjc65Dp8ZuB0cqAo1klb7DgFUE4oGAK/q0ukO M5vkMwNFA6gOZtaRz+e9/nkDVBOKBgBvCoVCnQ5vm/KKogFUBzOrd86xqgFUCEUDgDf1mUzBgsD7 nmlOnQKqh5ndOn369HG+cwDVgKIBwIuWlpaUk273nUNiGByoMuMbGho+4zsEUA0oGgC8mNLY2GLS XN85JI63BarQHdlsts53CCDpKBoA/HDuDt8RBjGjAVQXM2s0s0/6zgEkHUUDQMW1L1++yMzO951j UCaT8R0BQIWZ2Z2S+B8/UEYUDQAVFwTBnb4zHCsIApmZ7xgAKmtqPp+/xXcIIMkoGgAqakVr64WS 3u87x4k4eQqoPs65eyWlfOcAkoqiAaDSbvMdYCicPAVUHzNryufzN/nOASQVRQNAxbQXCnNltsR3 jqHUcPIUUK3uksTeSaAMKBoAKsYymTskRXKPEgPhQNWam81mr/UdAkgiigaAimhra2uSczf7znEy zGgA1SsIgnt9ZwCSiKIBoCJSzq00s8hekMVdGkBVe1s2m73KdwggaSgaAMquUCg0yrl23zlOhaIB VLcgCL7gOwOQNBQNAGVXl053yKzRd45TqWUYHKh278zlcpf5DgEkCUUDQFkVCoU6Sbf6zjEcTp0C IOke3wGAJKFoACir+kymYGZNvnMMh1OnAJjZ+5qbm//Cdw4gKSgaAMqmpaUl5aTbfecYCU6dAiBJ QRB80XcGICkoGgDKZkpjY4tJc33nGAmGwQFIkpld3tzcPN93DiAJKBoAysak23xnGCm2TgEYlEql OIEKCAFFA0BZdLS2LpB0ge8cIxUEgVKplO8YACLAOXfVnDlzzvadA4g7igaAcrnTd4DRqq2t9R0B QASYmaXTaW4LB0pE0QAQuhWtredJit159AyEAxjknLs2n8/P8Z0DiDOKBoByWGVm5jvEaDEQDmCQ mQXFYpETqIASUDQAhKq9UJgrsyW+c4wFA+EAjhUEwU3ZbHaG7xxAXFE0AITKMpk7JMVyaYCtUwBO kDYzZjWAMaJoAAhNW1tbk5y72XeOsaqpqfEdAUDEmNkts2bNmuI7BxBHFA0AoUk5t9LM6nznGCuK BoAh1NTU1MTuFD0gCigaAEJRKBTq5Fy77xylYOsUgJP4ZD6fn+Q7BBA3FA0AoahPpztk1ug7Ryk4 dQrAUMys3jl3h+8cQNxQNACUrKWlJeWk1b5zlIpTpwCcjJl9Zvr06eN85wDihKIBoGRTGhtvNLMm 3zlKxdYpAKcwfty4cbf6DgHECUUDQMlMust3hjDU1Nb6jgAg2m7PZrOxPfACqDSKBoCSrFi+/GpJ 83znCEMmnVYMLzQHUDlTgyDo8B0CiAuKBoDSBEGijn1k+xSAU3HOrZbEQBcwAhQNAGPW0dq6QNIF vnOEKc1AOIBTMLOmbDb7Cd85gDigaAAoRaJWMyRWNAAMz8zukpTynQOIOooGgDFZ0dp6nqTLfOcI Wy23gwMYhpk153K5pb5zAFFH0QAwVqssgZPTtZw8BWAEzOxe3xmAqKNoABi1tra2Jpkt8Z2jHLgd HMAIzc3lci2+QwBRRtEAMGqBc5+TlMh35BQNACNlZl/0nQGIMooGgFEpFAqNcq7dd45yoWgAGIW3 5fP5D/sOAUQVRQPAqNSl07eZWWJvxuXUKQCj9GXfAYCoomgAGLFCoVBn0krfOcqJYXAAo/TOfD5/ ie8QQBRRNACMWH063SGzRt85yonjbQGMwT2+AwBRRNEAMCItLS0pJ632naPcmNEAMAYfaG5unu87 BBA1FA0AIzKlsfFGM2vynaPcMpmM7wgAYiiVSn3VdwYgaigaAEbEpLt8Z6iEIAiUwHsIAZTfB+fM mXO27xBAlFA0AAxrxfLlV0ua5ztHpXDyFICxSKVSX/GdAYgSigaA4QXBnb4jVBInTwEYo4/Mnj37 rb5DAFFB0QBwSitaWy+UdIHvHJVUw8lTAMbAzCyTyXBbOHAERQPAKTmpqlYzJAbCAZTk+nw+P8d3 CCAKKBoATqq9UJgrabHvHJXGjAaAsTKzwDl3r+8cQBRQNACcVJBO32NVeAQTd2kAKIWZLctmszN8 5wB8o2gAGFJbW1uTzJb6zuEDRQNAidJmVhVHggOnQtEAMKTAuc9Jqsp33LUMgwMo3S2zZs2a4jsE 4BNFA8CbFAqFRjnX7juHL5w6BaBUZlZfW1u7yncOwCeKBoA3qUunbzOzOt85fOHUKQAh+WQ+n5/k OwTgC0UDwHEKhUKdSSt95/CJU6cAhGS8pNt8hwB8oWgAOE59JlOQWaPvHD4xDA4gLM6526ZPnz7O dw7AB4oGgKNaWlpSTrrddw7f2DoFICxm1lhfX/9J3zkAHygaAI6a0tjYYtJc3zl8C4JAqVTKdwwA CREEwSpJfIKBqkPRAPAG5z7rO0JU1NbW+o4AIDmm5nK5Dt8hgEqjaACQJLUvX77IzM7znSMqGAgH ELK7JLFUiqpC0QAgSQqC4E7fGaKEgXAAYTKzplwut8x3DqCSKBoAtKK19UJJ7/edI0oYCAdQBvdK Mt8hgEqhaACQk1jNOAFbpwCEzcya8/n89b5zAJVC0QCqXHuhMFfSYt85oqampsZ3BADJ9EXfAYBK oWgAVS5Ip+8xM5byT0DRAFAmc/P5/Ed8hwAqgaIBVLG2trYmmS31nSOK2DoFoIzu8R0AqASKBlDF Us6tlMQ76iFw6hSAMnpnc3PzFb5DAOVG0QCqVKFQaHTOcYHUSXDqFIBySqVS9/rOAJQbRQOoUnXp dIeZTfKdI6rYOgWgzC7KZrMcK45Eo2gAVahQKNRJutV3jiirqa31HQFAwpkZqxpINIoGUIXqM5mC mTX5zhFlmXRaHMYFoJzM7NLm5ub5vnMA5ULRAKpMS0tLykm3+84RB2yfAuKhNsYrkEEQfNl3BqBc KBpAlZnS2Nhi0lzfOeIgzUA4EHl1dXX61re+5TvGmJnZlXPmzDnbdw6gHCgaQLVx7g7fEeKCFQ0g +s4880xdeeWVWrJkie8oY5ZKpbgtHIlE0QCqSPvy5YvM7HzfOeKiltvBgcibP//wiMOXvvQlzZ49 23OaMfvo7Nmz3+o7BBA2igZQRYIguNN3hjiJ875voFq84x3vkCQ1NDTou9/9bizvwDGzIJPJcAIV EoeiAVSJFa2tF0rizPZR4HZwIPrOPvuN8YZ3vOMduu222zymGTszW5rP5+f4zgGEiaIBVI94fvf1 iKIBRNvkyZOVzWaP+7m2tjZddNFFfgKVJi3pLt8hgDBRNIAq0F4ozJVZfCclPaFoANF2zjnnKAiO fysTBIHWrFmjiRMnekpVkk9ks9kZvkMAYaFoAFXAMpk7dPjTMowCp04B0XbstqljTZs2Td/4xjcq nCYUNZJW+w4BhIWiASRcW1tbk5y72XeOOGIYHIi2wUHwoSxatEjXX399BdOEw8w68vn8JN85gDBQ NICESzm30szqfOeII463BaJt8Gjbk7nrrrs0d2687ic1s3rnHKsaSASKBpBghUKhUc61+84RV8xo ANE1depUTZ069ZRf09DQoO9973uxO/LWzG6dPn36ON85gFJRNIAEq0unO2TW6DtHXMXtzQlQTU42 n3GiefPm6XOf+1yZ04RufENDw2d8hwBKRdEAEqpQKNRJutV3jjgLgkBm5jsGgCEMt23qWMuWLYvj kbd3ZLNZtr0i1igaQELVZzIFM2vynSPuOHkKYZk9e7bvCIlyqkHwoaxZs2bYrVZRYmaNZvZJ3zmA UlA0gIRy0u2+MyQBJ08hLN/85jfj+Kl6ZI1069SgadOmac2aNWVKUx5mdqck9nAitigaQAKtWL78 apPiddRKRNVw8hRC0tfXpx//+Me69NJLfUeJvVmzZo1pdeLiiy+O25G3U/P5/C2+QwBjRdEAkigI 7vQdISkYCEdY9uzZo9raWt1///1avHix7zixNpr5jBPF7cjbI0fdpnznAMaCogEkTEdr6wJJF/jO kRTMaCAse/bskXT42OQ1a9bE7ZP1SDnrrLPG/HvjduStmTXn8/mbfOcAxoKiASQPqxkh4i4NhOXQ oUNH/97MdN9996m9nWtuxqKUFQ0plkfe3iWJI/AQOxQNIEFWtLaeJ+ky3zmShKKBsBxbNAatXr1a q1at8pAmvsxM5557bsmvE7Mjb+dms9mP+Q4BjBZFA0iWVcbFD6GqZRgcIdm7d++QP9/R0aGvfOUr FU4TX7lcTnV14VwvEacjb4Mg+LzvDMBoUTSAhGgvFObKbInvHEnDqVMIy+CMxlCWLl2qNWvWKJVi 5nc4pW6bOlbMjrx9Wy6X4xQBxApFA0gIy2TukMQ+n5DFZWAU0XeqoiFJV111le6//37K7TBGe1Hf cC6++GItW7Ys1NcsFzP7ou8MwGhQNIAEaGtra5JzN/vOkUScOoWwDFc0JGnhwoVau3YtZeMURntR 30isXr06LkfevjOXyy30HQIYKYoGkAAp51aaWTiblnEchsERlqGGwYdy0UUXae3ataqvry9zovgx M5155pmhv25NTY2+973vxeW/+b2+AwAjRdEAYq5QKNTJOc7ILBO2TiEsIy0a0uGy8eCDD2rChAll TBQ/Z555ZmiD4CeaN2+e7r777rK8dpjM7H3Nzc1/4TsHMBIUDSDm6tPpDpk1+s6RVEEQMKCLUIxk 69Sx5s+fr3Xr1mny5MllShQ/YQ6CD+X666/X5ZdfXtZnhCEIAmY1EAsUDSDGWlpaUk5a7TtH0tXW 1vqOgAQYbdGQDn+C//DDD6upqakMieKnlBvBR+ob3/hG5I+8NbPLm5uby9u6gBBQNIAYm9LYeKOZ 8Q6kzBgIRxjGUjQkKZvN6qGHHlJzc3PIieKn3CsakjRp0iStWbNGUb+SKJVKfcF3BmA4FA0gxky6 y3eGasBAOMLQ29ur3t7eMf3emTNn6uGHH9YZZ5wRcqr4qK2trdi//8UXX6z29miPvjnnrpozZ074 R3ABIaJoADG1YvnyqyXN852jGjAQjrCMdVVDkqZMmaJ169aFfo9EXJx11lkKgsq9bVm5cmWkj7w1 M0un05xAhUijaABxFQR3+o5QLdg6hbCM5uSpoUycOFEPPvig/uIvqu/QoUpsmzpWHI68dc5dm8/n 5/jOAZwMRQOIoY7W1gWSLvCdo1pweRrCUmrRkKSGhgatXbtWl156aQiJ4sPHSk7Uj7w1s6BYLHIC FSKLogHEE6sZFUTRQFhK2Tp1rNraWt1///1avHhxKK8XB+W4EXwkon7kbRAEN2Wz2Rm+cwBDoWgA MbOitfU8SZf5zlFN2DqFsIRVNKTDhxSsWbNG119/fWivGVWTJ09WNpv19vyIH3mbNjNmNRBJFA0g flZZ1M9dTBhOnUJYwiwakmRmuu+++xJfNs4555yKDoKfKOpH3prZLbNmzZriOwdwIooGECNtbW1N MlviO0e14dQphCXsojHovvvui/xxrKXwtW3qWBE/8rampqaGLbWIHIoGECOBc5+TxMfrFcbWKYQl jGHwk1m9erVWrVpVttf3KSpH+q5cuVLnnnuu7xgn88l8Pj/JdwjgWBQNICYKhUKjnIvsx2lJVlNb 6zsCEqKcRUOSOjo69JWvfKWsz/DhbW97m+8I2rt3r379619H9rhbM6t3zt3hOwdwLD6mA2KiLp2+ zczqfOeoRpl0WmYm55zvKIi5vXv3lv0ZS5cu1fjx47Vq1SoNDAyU/XnlNnXqVM2cOdPLs7dv367f /OY3Wr9+vZ544gn19/d7yTEKn54+ffq3tm/f/rrvIIBE0QBioVAo1Jm00neOapZJp9Xb1+c7BmKu XDMaJ7rqqqvU0NCgW2+9Vb29vRV5ZrlUej5j48aNWr9+vTZs2KB///d/j9UHDGbWOG7cuE9L+qbv LIBE0QBioT6d7pBZo+8c1SydyVA0ULJKFQ1JWrhwodauXau2tjYdOHCgYs8NW7lvBHfO6emnn9b6 9ev1m9/8Rhs3bizr8yrgjmw2+zebN28+6DsIQNEAIq6lpSXlpNXRPFSxejAQjjBUsmhI0kUXXaQH H3xQy5Ytq8i2rXIoxyD4wMCAnnzySa1fv16//vWvtX379tCf4dFUSe2Svus7CMB3TiDipjQ23mhS k+8c1a6W28ERgnIPgw9l/vz5WrdunW688Ubt2rWr4s8vVVhbpw4cOKDHHntM69ev129/+1u9+uqr obxuFJnZ5yT9N0ksw8IrigYQcSbd5TsDpFpOnkIIfBQNSTrzzDP18MMP64YbbtDWrVu9ZBiLWbNm lXQj96uvvqrf/va3Wr9+vR577LFYbyEbDTNrymazyzZv3vxD31lQ3SgaQIS1L1++SNI83znA7eAI R6W3Th0rm83qoYce0g033KCuri5vOUZjLPMZx54U9fjjjyfi5K2xMLO7Ja2VVJ3/ARAJfOcEIiwI Am56jQiKBsLgs2hI0syZM/Xwww/rxhtv1LPPPus1y0icddZZI/q6OJ8UVS5m1pzL5a7v7Ox80HcW VC++cwIRtaK19UJJ7/edA4dRNBAG30VDkqZMmaJ169bpuuuui3zZONmKRgJPiioLM/u8JIoGvOE7 JxBRTrqTk6aig1OnEIbe3l719vaqxvPhAhMnTtS6deu0bNky/du//ZvXLCdjZjr33HOP/nN/f78e f/xxrV+/Xv/0T/+UtJOiymVuLpf7aGdn5//tOwiqE985gQhqLxTmSlrsOwfewDA4wnLo0CHvRUM6 XDYefPBBtbW16fHHH/cd501yuZycc9qwYcPRbVFxPaLXJzP7kiSKBryA+TCeAAAgAElEQVSgaAAR FKTT98iMBY0I4XhbhOXQoUOaMGGC7xiSpIaGBq1du1a33nqrfvOb3/iOc5wdO3boXe96V9WcFFVG b8vn8x/atGnT/+M7CKpP4DsAgOO1tbU1yWyp7xw4HjMaCEsU5jSOVVtbq/vvv1+LF0drEXXv3r2U jPB8xXcAVCeKBhAxgXOfE6uNkZPJZHxHQEJErWhIh4v0mjVrdP311/uOgvJ4Z3Nz81/6DoHqQ9EA IqRQKDTKuXbfOfBmQRCwmw2hiGLRkA4PX993331qb+ePoCRKpVL3+s6A6kPRACKkLp2+zczqfOfA 0Dh5CmGIatEYtHr1aq1atcp3DITvA83NzaO/AREoAUUDiIhCoVBn0krfOXBynDyFMES9aEhSR0eH vvIVtvUnTSqV+qrvDKguFA0gIuozmYLMGn3nwMlF4UhSxN+hQ4d8RxiRpUuXas2aNUqlUr6jIDwf nDNnztm+Q6B6UDSACGhpaUk56XbfOXBqDIQjDHEpGpJ01VVX6f7776dkJ0gqlWKpChVD0QAiYEpj Y4tJc33nwKkxo4EwxO3SuYULF2rt2rWqr6/3HQXh+Mjs2bPf6jsEqgNFA4gC5+7wHQHD4y4NhCEO Mxonuuiii/Tggw9SNhLAzCyTyXzRdw5UB4oG4Fn78uWLzOx83zkwPIoGwhDHoiFJ8+fP14MPPhiZ W81Rkuvz+fwc3yGQfBQNwLMgCO70nQEjU8s+dYQgrkVDOlw21q1bp8mTJ/uOghKYWeCcu8d3DiQf RQPwaEVr64WS3u87B0aGgViEIU7D4EM588wz9fDDD6upqcl3FJTAzArZbHaG7xxINooG4JGTWM2I EU6dQhjiXjQkKZvN6qGHHlJzc7PvKKe08j279e0Pv6zT6gd8R4miGlbUUW4UDcCT9kJhrqTFvnNg 5Dh1CmF49dVXfUcIxcyZM/Xwww9rxoxofih++bx9uvU9u3XNOfu0/pZuLZz7uu9IkeOca5s1a9YU 3zmQXBQNwJMgnb7HzMx3Dowcw+AIw759+3xHCMWWLVt0zz33aNu2bb6jvMn8mQe15sodR/95ckNR f7tku37wkW2aNq7fY7JoMbP62traz/rOgeSiaAAetLW1Nclsqe8cGB22TiEMcR4Gl6Risaif/OQn WrRokTZs2OA7zps0n9anH350m+oy7k2/dtm8/dpwS4+uPXev+JjnqE/l8/lJvkMgmSgagAcp51ZK 4uPxmAmCQKlUyncMxFxvb696e3t9xxiTZ599Vtdcc43uu+8+7d+/33ecNzmtfkD/V8tWTW4onvRr JtQV9fUrduh/XP+SZk7sq2C6yBpfLBZX+g6BZKJoABVWKBQanXMdvnNgbGpra31HQALEbSB8//79 +vrXv67FixfrmWee8R1nSOnA6Ycf3abs5JFtjXrXWw7qf7b26ObzXlNQ5asbZvaZ6dOnj/OdA8lD 0QAqrC6d7jAzlqljioFwhCFORePRRx/V5ZdfrrVr16q/P7rzDV9btEPvnDW6/64NNU5fWPiKHrmp R/OmxXOVKQxm1tjQ0PBXvnMgeSgaQAUVCoU6Sbf6zoGxYyAcYYjDnMbu3bu1atUqFQoFvfTSS77j nNLK9+zWR/987EP2b2/q1T8Utugz792ldPDm2Y5qYGarJTGIhlBRNIAKqs9kCmbGLVcxxkA4whDl ouGc07p167Rw4UI98sgjvuMMa8nb9+rW9+wu+XXSKadPXfyqflXo0Tkz4rPiFKKpuVyu3XcIJAtF A6iQlpaWlJNu950DpWHrFMIQ1aKxefNmXXfddbrnnnu0e3fpb97Lbf7Mg/raoh3Df+EonHF6n35x 0xbd/ZevqKGm6lY37pbEiRcIDUUDqJApjY0tJs31nQOlqamp8R0BCRC1otHf368f/OAHuuKKK/TU U0/5jjMig8fYZsrwtjgIpOXvfk2/Xt6t82cfCP8BEWVmTblcruA7B5KDogFUinN3+I6A0lE0EIYo DYM/+eSTuvLKK/Xtb387NsfujuQY2zDMmtSvdUu36quLdmpCbXmfFSGfl1Tl53AhLBQNoALaly9f ZGbn+86B0rF1CmGIQtHYu3evPv/5z+vjH/+4nnvuOd9xRqw2XRzVMbalMpM+/o49Wn9Lt96Tjd7d IWEzs+Z8Pv9x3zmQDBQNoALM7DbfGRAOTp1CGHxvnVq/fr0WLlyon//853IuXnMIa64c/TG2YTh9 /IB+et02ffvDL+u0+oGKP7/CvuQ7AJKBogGU2YrW1vMkXeY7B8LBqVMIw969e7089+WXX1ZHR4dW rFihHTvCHaKuhJXv2a1FZ7zuNcM15+zThlt6dOXZYz9ONwbmNjc3X+M7BOKPogGU3yozY79rQrB1 CmGo9IpGsVjUT37yE1122WXasGFDRZ8dlrCOsQ3DaQ0D+pvFL+sn127VtHHRvcSwFKlU6l7fGRB/ FA2gjNoLhbkyW+I7B8JTU1vrOwISoJJF49lnn9U111yj++67z9tKSqkuzu4P/RjbMLw3d0AbbunR tefuVQI/TnrnnDlzLvYdAvFG0QDKyDKZOyTxEXiCZNJpsUCFUlWiaPT29uo73/mOFi9erGeeeabs zyuX5tP6dP8128tyjG0YJtQV9fUrduh/XP+Smk/r8x0nNM65n7744ov/r+8ciDeKBlAmbW1tTXLu Zt85ED62T6FU5T516tFHH9WiRYv0/e9/X/398d3aM3iM7YTa6A+sv+stB/WPy3vUceGrCmL+WYRz 7vudnZ0F3zkQfxQNoExSzq00szrfORC+NAPhKFG5isbu3bu1atUqFQoFdXV1leUZlVLpY2zDUJt2 WrVglx65qUfzpsXjTpIh3NXZ2flp3yGQDBQNoAwKhUKjnGv3nQPlwYoGSlWOrVO//OUvtXDhQj3y yCOhv3almZy3Y2zD8PamXv1DYYs+895dqklFfzVGktxhN2/atOmbvrMgOSgaQBnUpdMdMmv0nQPl Ucvt4ChRmEVj8+bNuvnmm3X77bdr9+5onMpUqs++f5f3Y2xLlU45feriV/WPy7t1zozIF6b+YrG4 pLOz82e+gyBZKBpAyAqFQp2kW33nQPnUcvIUShRG0ejv79cPfvADXXHFFXrsscdCSBUNS96+Vx1/ 8ZrvGKHJTu7XL27aorv/8hU11ERvdcM5d8A598Gurq5f+M6C5KFoACGrz2QKZtbkOwfKh9vBUare 3l719o59D/8f//hHXXnllfr2t79d0utETVSPsS1VEEjL3/2afr28W+/J7vcd51h7zez9nZ2d8bxc BZFH0QBC5qTbfWdAeVE0EIaxDITv3btXn//85/WRj3xEzz33XBlS+RP1Y2zDMGtSv3563TZ9+8Mv a0Jt0WsW59wrfX19F23atOlJr0GQaBQNIEQrli+/2qS5vnOgvCgaCMNoi8b69eu1cOFC/fznP1ex 6PdNatjidIxtGK45Z5/W39KthXP9zKE457b29/df0N3dHd8LVhALFA0gTEFwp+8IKD9OnUIYRjqn 8fLLL6ujo0MrVqzQjh3J21YUx2Nsw3D6+AH97ZLt+sFHtmnauIr+u7/Q29v77u7u7o2VfCiqE0UD CElHa+sCSRf4zoHyYxgcYRiuaBSLRf3kJz/RZZddpg0bkrmFPu7H2Ibhsnn7teGWHl177t5KPO6P vb29F2zZsqWnEg8D+FgOCA+rGVWC420RhlMVjWeffVarV6/WM88ke2dLEo6xDcOEuqK+fsUOXXHm Pt39j1P10p7wLwV1zv3Lvn37LtmxY8e+0F8cOAlWNIAQXHf11dmBgYGLfOdAZaTYOoUQDFU0ent7 9Z3vfEeLFy9OfMlI2jG2YXhv7oD+Z2uPbj7vNQUW3us659Y7595PyUCl8d0SCMFr+/bNeGXPnmDq 1KlqnDTJdxyUWU0m/E8bUX1OHAZ/9NFH9cUvflFdXV2eElVOUo+xDUNDjdMXFr6ia87Zq5W/mq6u 3aX9eeOc+7vOzs7rQooHjAorGkAInFSXCoJxr+zcqe0vv+w7DsosCAKZhfhxI6rSYNHYvXu3Vq1a pUKhUBUl44xphxJ/jG0Y3t7Uq39c3qOOC19VOhjbaVzOuZ9SMuATRQMIgXOuTjr8BvT1ffvUuXmz 50QoN06eQqn27t2rX/7yl1q4cKEeeeQR33Eq4rT6Aa1t2VY1x9iWqjbttGrBLv2q0KN500Z3MaNz 7vudnZ2F8iQDRobPE4AQ/Fk+f46ZXSfp6CfdO3buVGNjo4KAPp9EW7dtS9SNzKi8P/7xj/rVr36l gwcP+o5SEbXpov77tds0b1qf7yixM3VcUdedu1eZlNMfttRpwA27onpXZ2fnPZXIBpwK74CAEARS 3Yk/l0mntXHjRh2okjcR1aaGk6dQopHeo5EEHGNbunTK6VMXv6p/XN6t82cfGPJr3GE3b9q06ZsV jgcMiaIBhOHI1qkTZTIZ9XR369XXOFklaTIMhAMjds8lr3CMbUiyk/u1bulWfXXRTjXUHLcFrb9Y LC7p7Oz8ma9swIkoGkAI3BArGoPS6bRe2blTL23dWslIKDNmNICRuX7+Hi17V/Ws3lSCmfTxd+zR r5d36z3Z/XLOHXDOfbCrq+sXvrMBx+I7JRCGIDhp0Tj8y4EOHjigTZ2dyudylUqFMkpTNIBhXZzd ry9cutN3jMSaNalfP71um7bvS/9u+rj+f7V234mA47GiAYTATrGicfRrzGSSnnv+eQ0MDFQgFcqJ ogGcGsfYVs708f0flPSf7ke6yncW4FgUDSAcwxaNQYND4q/v31/OPCizWobBgZOaMaGfY2wrzTRV Tn/vHtAv3H/XDN9xAImiAYTCnWQY/GQymYxeeukl7dq9u1yRUGacOgUMrTZd1NqWbWqayMqtF6ar 1av/zz2gVufEzaLwiqIBhGNURUOS0qmUdu/axZB4THHqFPBmg8fYnnk6d8x4ZZok04/0I/2ze0Bz fMdB9aJoAGFwbtxYftvgkPgLGzfKObYYxAmnTgFvxjG2kfNemf7kHtCt7ku850Pl8f90QAiKYywa 0uEh8VQQ6Lnnn1dfHzfmxgXD4MDxlp3/GsfYRtM4mb6rJv1v92Od4zsMqgtFAwiBSQ2lvkZNJqPO zk6GxGOCrVPAGy7O7tfdl7ziOwZOxXS+BvQH90Pd5x4Qf4ChIigaQBjMTgvjZRgSj48gCJRKcW4n MHiMbcDYcfSZMpLulfR/3I90nu84SD6KBhACJ9WH9VqDQ+LdPT1hvSTKpLa21ncEwCuOsY0p09tV 1L+4H+q/up9pzFt/geFQNIBwjPrUqVMJgkD9fX3auGkTQ+IRxkA4qtn4Go6xjTVTIOl2HdR/uAf0 Ht9xkEwUDSAcoRaNQYEZQ+IRxkA4qpXJ6f5rtnOMbTI0y/R790P9rXtAk3yHQbJQNIAQ2Cgv7BuN wSHxffv2lesRGCMGwlGt7rnkFb0nd8B3DITHJLVL+k/3Iy30HQbJQdEAwmBW1s36mUxG27Zt046d O8v5GIwSW6dQjTjGNsFMTXJa736on7kHNNV3HMQfRQMIR025H5BKpbR3zx6GxCOkpqbs/2cHIqfn tbS+9k9T9JOnJmnDc+P0p+01eu0AbycS5kaZ/uR+qOt8B0G8cRgdEILLLrnk9cCs5Ls0Rqp/YEB/ ls8rCPjm7tOLPT36z2ef9R0DiIT6jNNbGvs0e1K/Zk3s16xJ/Zo1se/wXyf1a+o4hsZjyWm9anSz LdM231EQPxQNIASXX3JJn5lVdB9Nb1+fctksn6p7tHXbNv37f/yH7xhALGRSTm9pfKOEzJx4fCmZ Pr5ffHYSUU6vSfqs2rTWTByFiBGjaAAhWHTppV7+4O3r79fMpiaNHz/ex+Or3o6dO/WHp5/2HQNI hFQgzRwsIRP6NLvx2JWRfjVN7FcmxXtczx5VoE9Yq17wHQTxQNEASrRgwYK6unTa2/ErAwMDmtTY qGlTmdurtFdfe03/+6mnfMcAqoKZdPq4/qNbsWZPeqOEzJzYp1kT+1VfQxGpgINy+rK26r/Yl1T0 HQbRRtEASrRgwYLGunR6t88MzjmlUik1Nzf7jFF1Xn/9dT32xBO+YwA4YnLDgGZN7D+6GjLzyIzI 4BatCXW8Lw6N01NKaZm16hnfURBdFA2gRB9csGBGMZ3e6juHJPUNDOitDIlXTF9/v377z//sOwaA EWrIFDXntDdWQ2ZO6DtudWRyAwPro+LUJ9O3dFBftVt1yHccRA9FAyjRogULskqnO33nGMSQeGWt /+1v5RzbNYAkqEk5zTntjQJy4hataeMYWB+S0/MK9HG7Rf/HdxREC7dNASUqSnVR+r5Tk8loc1eX Tj/9dDVOmuQ7TuJl0mn19vX5jgEgBL0Dphd2ZvTCzsyQv54K3HED6scWkZkT+zRz4oBSQRV+8GCa q6L+xf1Qf6M6fcFu0uu+IyEaKBpAiVwmU6eIfaKdSaf1ys6dOnTokKaffrrvOImWzmQoGkCVGCia Xnw1oxdfHbqIBCZNn3B8CXnX7P3/8d7cwS2SmmVqllRX0dCVYgok3a6DWuJ+pFvsFm3wHQn+UTSA EqWdq4tWzTgsCAK9vm+fug4cYEi8jDJp/hgFcFjRSVv3pLV1T1pP9UjFYvHOzZt3fevYr3E/0nSZ mjWgZklZDRYQp+yRIjLBR/YQNctpvfuhHpTTp61dr/kOBH+Y0QBKtOjSSxdI+p3vHKfSNzCgP8vl lEqlfEdJnH99+mm9vHOn7xgAIsQdHtwqdHZ2/mzUv/e/6TSljysezXLHlZIpIcctH6etCrTCbtEv fUeBH3wUB5TIOVdnFu3OnkmltHHjRr1lzhzV1yVz1d6X2tpa3xEAREt/sVj8WFdX1y/G8pvtr7Rb 0m5J/zbUr7uHVK9dyimlrIonrIY4Ncs0Q1H5INnUJKe/dw/o71WjFbZM23xHQmVRNIASOakuGn+i n1omk1FPd7emMSQeqjRbpwAc4Zw7IOmqrq6uss0n2Md0QNKfjvx4c4YHlJFTVsGREnK4jGSPlJBm SbMlVXZ523S1evUB94A+a+36cUWfDa/4DgmUKIjRYF+aIfHQUTQAHLHXzC7ZtGnTkz5DWLv6JD1/ 5MebuIeU0h7NVr+aFQy5RWuOTOEv1ZomSfqRe0Atkm6xdr0Y+jMQOXyHBErlXJ0ivnXqWIND4p37 9yuXzfqOE3sUDQDOuVf6+/sXdHd3R/6WbPuYBiR1HfnxJs7J9EPNUHBkYD04ZjXkjVIybuwBdJmk P7kHdLe26vv2JXFde4LxHRIoUVy2Th3LzCTn9Nzzz+vP8nmGxEvAqVNAdXPObe3v739vd3f3Rt9Z wmAmJ2nrkR9PDPU17qeaooPHFI835kMGS8lpwzxmnEzfVZNudD/Wx61VL4T974Fo4DskUKogiM3W qRNl0mmGxEvEMDhQ1V7o7e39wJYtW3p8B6kku1mvSHpF0h+G+nX3gBqUUl7FI8VDR07NsqN/P/3w C+l8FfVH94C+LOm/Htn2hQShaAAlshjNaAxlcEh8ytSpmnzacB9C4US1NTW+IwDw44+9vb0LtmzZ sst3kKixdu2X9MyRH0Nya3WG+o87tvd295C+d2TYHQlB0QBKF+uiIR2eM9i9a5cOHjyomU1NvuPE CjMaQPVxzv3Lvn37LtmxY8c+31niypbrWUnP+s6B8gp8BwDizjkX+6IhHR4SP3jggDZ1dvqOEiuZ TMZ3BAAV5Jxb75x7PyUDGB5FAyhdIoqGdHhI3CQ99/zz6utjq+xIBEGgqF/YCCA0j3R2dn5w8+bN B30HAeKAogGUyrmxH/MXUZl0Wp2dnXp9/37fUWKBk6eA5HPO/XTTpk1LJA34zgLEBUUDKFExgUVD Orwl6KWXXtKu3bt9R4k8Tp4Cks059/3Ozs6C7xxA3FA0gBKZ1OA7Q7mkUynt3rVL3T1VdXLjqNVw 8hSQWMVi8c7Ozs5P+84BxBFFAyiVWaLPhA2CQP19fdq4aZOcc77jRBID4UDyuMNu3rx587d8ZwHi iqIBlMhJ9b4zVEJgxpD4STCjASROf7FYXNLZ2fkz30GAOKNoAKVLzKlTw6nJZBgSHwJ3aQDJ4Zw7 4Jz7YFdX1y98ZwHijqIBlK5qiob0xpD4jp07fUeJDIoGkBh7zez9nZ2dG3wHAZKAogGUyBJyYd9o pFMp7d2zhyHxI2oZBgdizzn3Sl9f30WbNm160ncWICkoGkCpzKrybFMzY0j8CE6dAuLNObe1v7// gu7u7md8ZwGShKIBlK6q32UODon39vb6juINp04BsfZCb2/vu7u7uzf6DgIkDUUDKJVZVRcN6fCQ +OauLu3bt893FC84dQqIrT/29vZesGXLFvaBAmVA0QBKZFW+ojEok05r27ZtVTkkzjA4ED/OuX/Z u3fvRT09Pbt8ZwGSiqIBlMjMeJd5ROrIkHhXV5fvKBXF1ikgPiZNSMk5t+PAgQMf3rFjR3UuwwIV QtEASrBgwYKqO3FqOGamYrGo5154QcVi0XecigiCQKlUyncMAKfQODGlv/5ikzoK02Rm0+rr6x/N 5/PzfOcCkoyiAZSGonESmVRKz7/wQtUMidfWVuXhY0AsnH1Gvb68eppqMr2aOb1fuTm1MrMzJD2Z z+c/5DsfkFQUDaAEDRSNU6qmIXEGwoFouuwDjWq/cbykviM/47R86WmDvzzROfcP+Xz+y5JYlgRC RtEASlCkaAxrcEh8+8sv+45SVgyEA9HTdtN0feiSlKTjt3FOGNend7x9nCTJzEzSF/L5/PrZs2dP rnxKILkoGkAJKBojk0ql9Pq+fYkeEmcgHIiOTEb60uqZetu8/pN+zQ0fmXTiT/1lJpP5Qy6X+/Oy hgOqCEUDKIHLZCgaI5T0IXG2TgHRMG1KRt+8t0mnTTx0yq/LZA7pQwtPO+7nzKxZ0hO5XO5jZYwI VA2KBlCCtHMUjVEaHBI/cPCg7yihqqnhOhXAt/POHad7b5+sdGpkh1Bc+r5aBSe8EzKzejP7u2w2 u0bckwSUhKIBlMCxdWpMajIZ9XR369XXXvMdJTQUDcCvq6+Yopta6iV38u1SJwqsT0s/Om3oXwuC z+RyuX/OZrMzwsoIVBuKBlACx4rGmKXTab2yc2dihsTZOgX4YSbdvqJJH7jYSXKj/v3nnxuovs5O 8tp2oZn9IZvNXlBiTKAqUTSAErCiUZogCPT6vn3q3LzZd5SSceoUUHnjGgJ9456Zap7VK2nosjAs 169bbjz9pL9sZk1BEPw+l8stH9sDgOpF0QBKEFA0SmZmknN67vnnNTAw4DvOmHHqFFBZ+eY6ffWu 6aqvO/XQ90j8WXNRp0875f+Ga8zsx7lc7keS+B87MEIUDaAUbJ0KTSad1saNG2M7JM7WKaBy3nfh JK1sm6DARjb0Pbyibrlh6rBfZWatuVzu9/l8fk5IDwYSjaIBlICtU+HKxHhIvKa21ncEoCoUrpum JR9OSy7cY7JPn9Knt+aG/yPdzC50zv2hubn5A6EGABKIogGUIggoGiEbHBJ/aetW31FGJZNOH94G BqAsUinTvbc3af455bqHx2nZx08b/sskmdmUIAg25HK5z5YpDJAIFA2gBMaKRlkEQaCDBw5oU2en 7yijwvYpoDwaJ6b0zXtnaNrksLZKDW18Q68ueteEEX2tmaXM7K9zudy6bDbL9wJgCBQNoDR8cykT M5NJsRoSTzMQDoTu7DPq9eXV01STKW/JGLTkyvGj+nozu9bMnsjn8/PKFAmILYoGUALu0Si/wSHx 1/fv9x1lWKxoAOG67AONar9xvKS+ij0zHfTqyssnj+r3mNm5kp7M5/MfKk8qIJ4oGkBpKBoVkMlk 9NJLL2nX7t2+o5xSLbeDA6H5q0/M0AcvSUkq10zGyV3y3hoFo3+HNNE59w/5fP7LGvOlHkCyUDSA Ujg3zneEapFOpbR7165ID4nXcvIUULKaGtN9d87UGfk+b+/WTX0qfHza6H/f4RMhvpDL5X41derU kQ17AAlG0QBKUHRudOvrKMngkPgLGzfKOec7zptwOzhQmllNNfrmvTM0cXzpl/CV6tyzTRPHj+1t kpl9eMKECU8yt4FqR9EASuCkBt8Zqo2ZKRUEeu7559XXV7l92yNB0QDG7l3zx2v1JxuVCioz9D0s N6DWG08f8283szMkPZnL5T4WXiggXigaQAkCM4qGJzWZjDo7OyM1JE7RAMbm2qun6IYldZKidcJc 8+wBNU0vafZqopn9XTabXSMpFVIsIDYoGkAJnFTvO0M1i9qQOKdOAaMTBNLqT83QRedLUvS2Q8oV dcuNU0p+mSAIPpPP59fPnj2b7baoKhQNoDScOuXZ4JB4d0+P7ygMgwOjMK4h0DfumalZM6K1BfJE Uxp79fazQlm8/stMJvOHXC7352G8GBAHFA2gFM6xohEBQRCov69PGzdt8jokzvG2wMjkm+v01bum q67W/9D3SFy/ZFIor2NmzZKeyOVyy0N5QSDiKBpACUziI+wICcy8DokzowEM730XTtLKtgkKLCJD 3yPQUNer910YWtmoN7Mf53K5H0nKhPKiQERRNIBSmFVt0SgWK3+J1kgMDonv27ev4s/OZHjPAJxK 4bppWvLhtOSi+efHqVz9wXDP/jCz1lwu9/tsNjsj1BcGIoSiAZSm6vbKFJ3T1u3bdeDgQd9RTiqT yWjbtm3asXNnRZ8bBIEO39cF4FjptOnzdzRp/jnxKxiDUkGvWhaXPhh+LDO70Mz+kM1mLwj1hYGI oGgApTCrqqJxqLdXL/b0aO/rryuVivZJjalUSnv37Kn4kDgnTwHHmzolo2/e26Spp8Vnq9TJvOfd aQUhv3Mys6YgCH7P3AaSiKIBlMCqaEXjUG+vtmzdqt4j8w/piBcN6fDlfv19fXr+hRcqttWLk6eA N5xzZoM+/5nJyqTjMfQ9vH59YunYL/E7hZrBuY1sNstphkgMikx2W8AAACAASURBVAZQAjOrio+v Dxw8qO6XXlL/wBuXaQVhf6xXRulUSs+/8IJ6e8v/iWoNJ08BkqQrLz9Nt9wwTlK/7yih+vMzpYnj y/Pnn5m1mtkT+Xx+TlkeAFRYfN4pABGzYMGCqvjUaf+BA+rZuvW4FYEgCGJVNKTDQ+Kbu7rKPiTO QDggrWyfrkvfa5LiO5NxMs4NqP3msqxqSJLM7Fzn3B+am5s/ULaHABUSr3cKQLQkvmjsP3BAW7Zt e9PdFKmYlYxBmXS67EPizGigmjXUm75290zl39IvKbkHI8xu6lfT9PKtXprZlCAINuRyuc+W7SFA BcTz3QIQAQ0JLxoHDx0asmRI8b4vYnBIvKurqyyvH+f/NkApZjXV6Gt3T9f4hqTMY5yKU9tN4Z5A dSIzS5nZX+dyuXVTp06dUNaHAWVC0QDGqJjgotHb16eerVtPest21E+cGo6ZqVgs6rkyDIlTNFCN 3jV/vFZ/slGB+bks04fJk3r19rPCvVtjKGZ27YQJE57M5/Pzyv4wIGQUDWCMklo0BgYGtOWEmYwT xeHEqZHIlGFIvJZhcFSZa6+eohuW1EkaGPZrk+aGj4ZzW/hwzOwMSU/m8/kPVeSBQEgoGsAYuUwm cUWjWCxqy7Zt6us/9SkxSfrUfnBI/NXXXgvn9SgaqBJBIH3u00266HxJGnr1M+nqanv1gYsrUzYk TXTO/UM+n/+ykjwAg0ShaABjlHYuUUWjWCzqpe3bdfDQ8Purk3b7dSad1is7d2r7yy+X/lqcOoUq MHFCoP+fvXsPkuyq7wT//Z17b77qlZWZ9ejqqsq8V60Xb2EMAgEWSI2MBALMgIwwSAZkMex6bI09 wBhjsGdZeYzN7BKMmVnLD7wzMsgYtSR7N0ASXgjPhDyyFTGe2d1YbFe2Wv2S+lHvfGee/aM6peru 6q6qrMx77uP7iVAE0d2V90t3Veb93XN+v3P/52YwMxX+Q/j26t23DH77VJdsvPn+muu6j7Jvg8KA hQZRj3SEtk5prXH8+edRqVZ39OejsnVqM6UU1tfW9twkzqlTFHUH3BR+4zOTSCXj0PS9PUs18NPv Lfh6TRF518jIyNOu677K1wsT7RILDaIe6YisaGitceKFF3ZcZADR2jq12eYm8Xa7t/3mUf27IQKA m9+axc9/YgSC+DR978QbX2chmfR3pfdc38ZTrut+0NcLE+0CCw2iHkVlRePUmTNYW1/f1ddEcUVj M8ey8I//+I+o1mq7/1punaKIuucjU3j3OyxAR+8Qvr1r4WMfGtwhfpciImkR+VapVPoKgGi/MVMo sdAg6pGKQKGxuLyMpZWVXX9d2Mfb7oTjODj63HO7bhJXSsXi74fiw3GAL356Bq+4+vJDIuLu2is1 sqNmfvaVUvd5nve92dnZnJEARJfAQoOoVyHfOrWyuopTZ87s+uuUUlAhPRl8t+wem8STyeSAEhH5 ayLv4Dd/dR/GR9mPsR2t2/i5j06YjPB2x3GeYd8GBUk87haIBiDMW6cq1SpOnjrV09daMSkyurpN 4uXDh3f8NWwIpyh4xTUZ/Oo/z8G2OFlqp/ZPt+DOm3vQICJFbPRtfNxYCKJN4nXHQNRPSoWy0Kg3 Gjh28mTPXx+X1YzNRATQGj/6+7/fUZM4G8Ip7N59yzju+ZkhQHO71O5o/OyH8kYTnOvbeMB13d8D wKYxMip+dwxEfSIhXNFotVo4euIEtO79cK0430Q7tr2jJnE2hFOY3ffJadz8FgHApu9ejI3U8ZpX DpmOARH5hOu6PyyVStOms1B8sdAg6l2oCo12u42jJ070PLa1K+oTp7bTbRI/u7h46T8T42KMwiuT FnzpV2ZQmm2CB0/vzZ3vGzUdAQAgIteLyDOlUukNprNQPLHQIOpRmM7R6J6V0WjuffZ9nFc0umzb xuLZszh+4sSWv59IJHxORLQ38/uT+NKvTGE4w6bvfkgmGrjl7VnTMQAAIrJPKfXDUqn0SdNZKH5Y aBD1LjSFxqkzZ3Z1IN/lxLFHYytKKdSqVSyUyxf9HgsNCpMbXj+CX/rUGJTwEL5++sm3BeojIqGU +rrrut8slUqBCkbRxjsGol5pbX4T7g70elbGpcR969RmIgIB8KO//3s0N60WcesUhcWd7y/gg7cn AL23LZV0MSVN3PlTBdMxziMid4jIU57nzZvOQvHAQoOoRx2tA38wUrVW6+msjMvh1qmLObaNcrmM 9UoFAP+OKPhsW/DZf7YPb7iu98EQtL03/JiFZDJY/S4i8mqt9TPFYvFtprNQ9LHQIOqRBgK9olFv NHD0Ej0Ee8GtU1tzHAfHjx/H2cVFTp2iQMuOWrj/c9PYN8nzMQZOt3DPRyZNp7iIiOSVUo+7rvvL prNQtPGOgahHSiRtOsOl9GOM7aVw69Sl2ZaFxbNnsXiZiVREJr3s6jR+/dMTSDgsMvxyZamD7Gjw 3jdFxBKRL7uu+81CoTBiOg9FU/C+84lCwnPdTymR/aZzXKjT6eC548fRavX/oC0RQSEX+B1jRokI lNXE/V94BV7zynFc4Q5jspBCMmWjXm+j3uDZBGTGzW/N4s6fSgNgP4a/NK65chR/9ddrpoNsSURe kUgkfiqXy31vcXGxv3ttKfa4kZiod4Gb3NHpdHDs5Mm+jLHdisVtUzsyP+cglxvG6IiNV1x7/ojL 1bUmnju2jmMnqjh2vILnjq/j2PEKFpf4hJkG5+c+OoWXX9UCD+EzY99kE+58EuUjwRwfLCJXA3ja 87w7FxYW/sJ0HooOFhpEvdI6cFunTp05s+2p1XthcdvUtqq1Gq4oFmBbCbSaF/9bjAw7eNnVWbzs 6vMLkPVK67zC49iJKp47to4zZ4N5Y0Lh4DjA5+6bwfgov4/M0vjEh3P43P3975vro1Gt9WOe5/2r hYWFLwLgpADaMxYaRD0SIGk6w2aLy8tYXl0d6DU4TWl7S8vLmJwswrZ3d5bGUMbGVQdGcdWB808U rtXbOHq8gmPHKzh6rgh57ngFp07XMIAWHIqQibyDz/6zAmyLRUYQDA818KYfH8F/fnqw79N7ISIC 4Ndc131ts9m86+jRo2dNZ6Jw410DUa9EAlNoDGKM7VbYCH55zVYLq+vrmJoYhhIbgGCvDwVTSQsH 3BEccM/v1aw32jhxsvriNqyjx9Zx9EQFL5yqod1mBRJ3P/bqIXz0g8OA5pa8IHn/u4cDXWh0ici7 HMd5xnXd28vl8t+ZzkPhxUKDqHeBOP650Wzi2MmTvlyLo20vb3F5GQBQKGQgInCcFJrN/pzIfqFk wkJpfhil+eHzfr3Z7ODE8+f3fxw9XsGJ56ssQGLive/M4203CKD7PxCC9sZWDbzrHTn8+feCv1Ag IkWt9VOu695dLpcfMp2HwomFBlGvRIwXGu12G8dOnECn40+DJ7dOXVq73cbyygqUEgxnNha7HDs5 sELjUhxHYX52CPOzQ3gjJl7K19E4cfLcFqwTlRf7QI6dqKDZZINwFIgA931yH4r7uVUqyG5+awL/ xxOAT2/beyIbY9y/VSqVrj98+PC/AEeW0S7xroGoR2J4RaM7Yao5gDG2l8KpU5e2tLICrTUmCxko tXESsLXLPo1BspRgdmYIszNDeMOmX+90NF44XTu39ar6Ui/IiSrqdd5ThMVQRuHz/3wa6VQdG1v2 KKgETdx1RwF/+CenTUfZMaXUfZ7nvbrRaHyAfRu0Gyw0iHokIsZ+frTWOPnCC6jV/X1yyRWNrWmt sbyyAgCY2/9SM7cSC0pZ6HSCe8OulGB6Mo3pyTRed91Lv661xqkz9RcLj6PnVkCOHltHtRbc/z9x 5BVT+PlPjEMJVzLC4jWvUEinBNVaqLYzvt1xnGdKpdIdhw8f/mvTYSgceNdA1IMbb7zR6Bkap86c wVql4vt1Od52a6tra2i1N26+NxcawMaqRqfh7/apfhARTBZSmCykcN2rzj+k8cxiHUe7TejdQuRY BesV9gT47a3Xj+H9706w6TtsdBv3fGQKX/09f/rr+kVEiiLyQ9d1P1Uul3/fdB4KPhYaRL0xVmgs Li9j6dzTc79x6tTFtNbn/XtMTmTO+33bSqKJ8BUal5MfTyI/nsSrX3H+ry8tN3DsROWibVjLK4M5 QDLu7v7pCVz3ig6gQ7DZny5yRamNyQkHL5wK3c9HQkQecF33+nK5/CkAofs/QP5hoUHUgwyQMvHR 7tcY262ICFc0tlCpVs/bwjY1OXTe7zt2MmJlxqVlxxLIjiXw8msuPg1981kg3W1YZxe51acXliX4 l78wjYkcVzFCTXfwcx8t4H/6nUAf4ndJIvIJ13VfobV+3+HDh8O1NEO+YaFB1IOOgRWNZquF4z6N sd3KxjlOdKHuSNuuC7dOiSgoy0GnHd+HfiPDDq69agzXXjV23q9XKi0cPbcC0j0J/diJCk6fYQFy KdlRC5+7bxIJh0VGFEyMN3DATeEfyjXTUXoiItcDeKZYLH742Wef/UvTeSh4WGgQ9aADpPycv9Tp dHD85Em0Dc5D5LapizUaDVSqL61XKCWYmR6+6M85VgL1GBcal5LJ2LjqilFcdcWlTkM/vw/khVPx Pg39ZVence9HxgCwyIiSj905jl/5UjhXNQBARPYppR53Xfez5XL5t03noWBhoUHUA+04Kb/ueLTW OHnqFOoNszcXnDh1sQtXMybyaVjWxSWoZSeAxrpfsULvcqehHz9ZPXcGyEu9IM+/EP3DCN/xtixu u8kBt8NHz1C6gTf9+EgoTgy/FBGxAHzZdd3Xaa3vPnz4cDiXaKjveOdA1ANb65RftzWnz57F2rr5 m1SuaJyv2WphZW3tvF+7sD+jy7aCc55GmCUTFtz5YbgXnIbeam2chv7cuS1Y3VPRT5yMRgHyqY9N 4yqvCYBN31H1/ncNh7rQ6BKROwBc43ne7QsLC0dM5yHzWGgQ9UD71KOxvLp60VNzU9gIfr7lcwf0 bXZhf0aXiIJtJ9BqccvLINi2wtz+IcztP7/Qa3c0Tj7/0tar4+e2YYXlNPREQvD5f74Po8PsWYk6 22rgfbfl8PBfhP8sPBF5tdb6mWKx+AH2bRALDaIeaK1Tg26OrtZqeP7UqYFeYze4deolnU5nyxHD szMjW/zpDZbFQsNvlhLs35fB/n0ZvOHHCi/+eqejcep0Dc+dm4S1eRtWUE5D378vgV/6p3lYikVG XPzEGxN45P8EDLbi9Y2I5Df1bfwOgPAvLVJPeOdA1AMNpAZZZjSaTRwzOGFqK5bys/092FZWV9HZ 4m7gUlunAMC2k6jX1y75++QfpQRTk2lMTabxutfkX/x1rTVOn6nj2InKRduwqlX/CpAfv24YP/P+ DNj0HS+CJn72zkn8/n94wXSUvtjUt/ETq6urd54+fTr8e8No11hoEPVADXDrVLvTwbETJ7a8kTVJ sdAAsHEzuniJAxMvV2hYyhlUJOoTEcFEIYWJQgqveeX5p6GfXayf24K1sQ3r2Ln/vbbe39PQ73hv Hm96nQAIxsoK+etV1wKjwwora8F6/98LEXnXyMjI06Ojo7cvLCz8yHQe8hcLDaJeaJ3CALZOaa1x 4vnn0Wz19+alH7h1asNapYJm8+LJP0oJpicvHm3bJSLs0wix3HgSufEkXvXy8fN+fXmlcd4ZIN0z QZaWd/fvrBTwS5+axux0E9xlEmO6jXs+Monf+XqwVrT3SkSuBvC053l3Liws/IXpPOQf3jkQ9WBQ W6dOnz173rkMQcKpUxsWl5a2/PWJfBpDmcuvWth2koVGxIyNJjA2msDLrj7/MMLVtSaOnaic23r1 0qnoZxcv/vcfyij82i9NI5VkPwYB87Nt7JtK4MTzkXuvGNVaP+Z53r9aWFj4DXDZLhZYaBD1Qqm+ b51aXVsLzISprXDq1EaDfq2+9c3g5bZNddl2EgC3KcfByLCDa64cwzVXnl+A1OptHDm6juMnNrZe nTlTxQdud6CERQadozu45yN5/MZvh/cQv0uRjSkqv+Z53psbjcYHjh49Gv4xW3RZLDSIeiB97tGo 1es4GaAJUxdSSmHQU7bCYOkyheBOCg0lNgABt8bEVyppXXQaerWyhOWl4+D3BXXlsw288toM/tv/ WzEdZVDe7jjOM67r3l4ul//OdBgaHHZ3EvWmb4VGq93G8ZMnLzqTIUi4bWrjgL7VyxycODWxfaEh IrCdZD9jUQSkM1nkCiVsDOkh2nDn+8e2/0MhJiJFAE+5rvtB01locFhoEPVAa92XQkNrjeMnT6LV DvZWVTaCY9ttbZc7Q2MznhJOW0kkMihMeLBsfn/QhkyqgbdeH/liIy0i3yqVSl8BwEo7glhoEPWm L4XGC6dPX3LPf5DEfbRtu93G8iVG2nbNzW59KviFNvo0iC5m2QnkCx4Sie1Xxyge3ntrxnQEXyil 7vM873ulUmnadBbqr3jfPRD1Sus93wksLi9jeTUcjcFx3zq1tLKy7da26R1snQIAS9lQKt5/n3Rp SlkYzxeRzoxv/4cp8izVwAdvz23/B6Ph7SLyTKlUeoPpINQ/LDSIetDRek/v/OuVCk6dOdOvOAMX 561TWuttVzOGMg6Ghna+5YXbY+hyRARj2RmMju0zHYUC4IbXO4jLorKI7FNK/dB13Y+bzkL9EZNv XaL+0kDPKxqNZhMnnn++n3EGzorLp9wWVtfWtu2hmdu/s/6MLsfi9inaXmYoh/F8ESLx/fkjAGjh 4x+eNB3CTwkRecB13d8DcPnDiSjw+O5F1AMlku7l69qdDo6dOIFOgCdMbSWuZ2horbG0zWoGsPP+ jC6uaNBOJZPDyBc8WBbvt+LsldcAo8PxumUTkU+4rvtDz/PmTWeh3sXru5aoTzSw60JDa40Tzz+P Zqs1iEgDFdetU5VqdUfN+jsZbbuZEgtKxfPvlHbPdpLIT3hwnJ6eb1AEaN3GvXfFalUDACAi12ut nykWi28znYV6w0KDqDe7njp1+uxZVKrVQWQZuLg2g+/0pPbdFhoA4HD6FO2CUjZyhRJS6WiPO6VL m93Xwr6p+K2GikheKfW467q/bDoL7R4LDaJeaL2rR4vLKys7vmkNojiOt200GjsuDOf2727rFMDt U7R7IgrZ8VmMjE6Bp4jHkca9dxVMhzBCRCwR+bLrut8slUp9OzCXBi9+dw9EfSDAjh9HV2s1PH/6 9CDjDJRSKpaFxm4Kw902gwM8uI96NzRcQHZ8HhAxHYV8Nj5axyuvjcfZGlsRkTtE5Cn2bYRH/O4e iPpBZEeFRrPVwvGTJwedZqDiOHGq2WphZW1tR392t6Ntu0QUFBt8qUep9CjyBZe9PjH0kX8S7+1z IvJqrfUznufdZjoLbS9+dxBE/bHtnWWn08HxkyfR7nT8yDMwcWwEX97BAX1dU5O9n93ocFWD9sBx 0shPeLBt7iSJk2SygbfdEPtiI6+1fszzvF8HwKW9AGOhQdQLkW3vEE+eOoV6o+FHmoGK22jbTqez o5G2Xb30Z3TZbAinPbIsB/mCi2Rq99v3KLzefUt8t091iYgA+DXXdR8tFAr8AQgoFhpEPZBtVjTO Li1hbX3drzgDFbeJUyurq+jsYhWql/6MLosrGtQHohTGc/MYGs6bjkI+sVQDH3pfPBvDLyQi7xoZ GXna87yrTGehi7HQIOqBiFxyP1G1VsPps2f9jDNQcdo6pbXG4i5WM4DeRtt2iQhsTp+iPhkZncZY dj+4kyQerv8xC8kk/60BQESuBvA0+zaCh4UG0S7deOONl9wQHYXm7wtJjCbbrFUqaDabu/qavfRo AFzVoP5KZ7LIFUoQiddKZDy18LEPTZgOESSjm/o2+AMQECw0iHZvy0IjKs3fF4rT1qnFpaVdf81e ejQA9mlQ/yUSGRQmPJ7VEgPXXglkR+PzHr2dbt+G53nfm52dzZnOQyw0iHYtc4lCIyrN3xeKy9ap aq2GWr2+q68ZyjgYz+5t4o+lHHCrC/WbZSeQL3hIJPa24kbBpnUb9941aTpGEL3dcZxnXNd9lekg ccdCg2iXOlsUGlFq/r5QXFY0lno4uX2v26aAc30aDlc1qP+UsjCeLyKdGTcdhQZoZqoJd57vIRcS kSKAp1zX/aDpLHHGQoNoly4sNNYrlUg1f18oDuNtm60WVnsoFPtRaAA8JZwGR0Qwlp3B6Ng+01Fo YDQ+/mHuEtqKiKRF5FulUukr2MH5V9R/LDSIdkk7zouFRq1ex4nnnzcZZ6BEBCoGJ4Mv9rCaAQDz e+zP6OLkKRq0zFAO4/kiRKL/8xxHI0MNvOaV3CZ3KUqp+1zX/UGpVJo2nSVu+I5DtEu21ikAaLXb OH7yJDo7PEE6jKwYFBntdhvLuxxp2zU7058zopTYYJ8GDVoyOYx8wYNlOaaj0AD8zE/F+7Tw7YjI 9SLyTKlUeoPpLHES/bsIoj7TQEprjeMnT6LVbpuOM1Bx2Da1tLIC3WOx2K+tUyKCTQtlRANjO0nk Jzw4Ttp0FOozx6nj1puzpmMEmojsU0r90HXdj5vOEhcsNIh2SWudeuH06V1PKAqjqE+c0lr3vJoB 9K/QAACHY27JJ0rZyBVKSKX5BDxqDv5ECjFYiN6rhIg84Lru7wHg8t6A8duRaJeOnTjxnuXVVdMx fBH1iVOra2s9r0opJSjk+vdUmGcekJ9EFLLjsxgZnQIQ3e2fcaOkiQ+/n4f47YSIfMJ13R96njdv OkuUsdAg2oX5+fkbKrXaJ0zn8EuUVzS01ljaw2rGzPQwLKt/b6FKLCgV7cKOgmdouIDs+Dwg7BGK ite9RiGd4r/nTojI9VrrZ4rF4ttMZ4kqFhpEO7R///5Z27YfBhDdu+8LRHniVKVa3dP2t7nZ/kyc 2oyrGmRCKj2KfMGFUrF5a4s23cI9H5kynSI0RCSvlHrcdd1fNp0liqJ7F0HUR6VSKZVIJB4FEKs1 6ShPnep1pG3X9ET/R0naFvs0yAzHSSM/4cG2OZQgCq4otjE5wfaDnRIRS0S+7LruN0ulEn8I+ii6 dxFEfSQifyQi15nO4beobp1qNBqoVKt7eo3JiUyf0ryEDeFkkmU5yBdcNolHQgf3/Eysnov1hYjc ISJPeZ53leksUcFCg2gbnud9VkTuMJ3DhKiOt93ragYAzPXpsL7NRBQUzzggg0SxSTwqJvMNHHD5 cH63ROTVAJ72PO8201migIUG0WWUSqWf1Fp/yXQOU6I4darZamFlbW3PrzOIHg0AcCz2aZB5bBKP Ao2f/dC46RBhNaq1fszzvF8HT1PdExYaRJcwMzMzp5T6hojE8udERCK5orG8hwP6uvo92nYzNoRT ULBJPPyGMw286cdHTMcIJRERAL/muu6jhUKBf4k9iuUNFNF2Zmdn06lU6hCASdNZTIliI3in09nT SNuuiXy6r6NtN7O5okEBwibx8Hv/u4dNRwg1EXnXyMjI0+zb6E307iSI+iCRSDwA4LWmc5gUxdWM ldVVdDqdPb/OIPozukQULPZpUIB0m8STKT7UDSNbNfDuW3KmY4SaiFwN4GnXdT9oOkvYsNAguoDn eb8I4E7TOUyLWqGhtcZiH1YzgMEWGgBgc/oUBYwohfHcPIaG86ajUA9ueksCEVyk9tuoiHyrVCp9 BUC0PiAHiN92RJu4rvsWAL9lOkcQRK0RfK1SQbPZ7MtrDWK07WYsNCioRkanMZbdD/bHhougibt+ umA6RiQope7zPO97s7OzXCbaARYaROfMzMzMici3AXDfCqK3orG4tNS315qa7P9hfZtZit+CFFzp TBa5Qgki0XqPiLrXvFwhnWKB2CdvdxznGdd1X2U6SNCx0CDaYKdSqQcR4+bvC0XpsL5qrYZavd63 1xv01ikRgc3pUxRgiUQGhQmPU9LCRLfxcx+dMp0iMkSkCOAp13U/bjpLkLHQIALged7XALzZdI4g idLUqaU+HNDXpZRgZnrwU1y4fYqCzrITyBc8JBKDXeGj/vGKbUxOcMW0X0QkLSIPuK77e+BuiC1F 506CqEelUumTAO41nSNoorKi0Wy1sLq+3rfXG+Ro281YaFAYKGVhPF9EOsOD4UJBd3DvR9mr0W8i 8gnXdX9YKpWmTWcJGhYaFGvz8/M3KKW+ajpHEEWlR2Oxj6sZwOD7M7qU2GDDLYWBiGAsO4PRsX2m o9AOFMYbOODyXJR+E5HrReSZUqn0BtNZgoSFBsXW/v37Z23bfhhc7txSFLZOtdttLPdppG3XoPsz ukQEtsNVDQqPzFAO4/kiRML/3hF1H7uTK1CDICL7lFI/ZN/GS/huQLFUKpVSiUTiUQATprMEVRRW NJZWVqC17utrzs74d2gZTwmnsEkmh5EveDx0MuCG0g286cd5AOOAJLp9G6VSKfZLRyw0KJZE5I9E 5DrTOYJKKQWRcG/b0Vr3fTUD8G/rFMA+DQon20kiP+HBcdKmo9BlvP9dgx9qEWci8gkRecrzvHnT WUxioUGx43neZ0XkDtM5giwKh/Wtrq2h1W73/XX9LDQsZUOp8P9bUPwoZSNXKCGVHjMdhS7Bthp4 3208c26QROTVWutnisXi20xnMYWFBsWK67rv0Fp/yXSOoAv7xCmtNZYGsJoBANMT/o7y5DkFFFYi CtnxWYyMTgHo7xZG6o+feGMCEWjHCzQRySulHndd95dNZzGB314UG57nXSkifyrsVNxW2Fc0KtVq Xw/o6xrPJjE05O+Nv2Nx+xSF29BwAdnxeSDk2zGjSNDEx+7kObWDJiKWiHzZdd1vFgqFWDXH8IaL YqFQKIxorf8cgD8jg0Iu7I3g/R5p2+XXxKnNuKJBUZBKjyJfcKFUuFdLo+iV1wKjw7wd9IOI3DEy MvK053lXmc7iF35nURzIyMjIn4pIbH6w9yrMhUaj0UClWh3Ia/vZn9GlxGKfBkWC46SRn/Bg27Ef xBMsuo17PsJVDb+IyNUAnvY87zbTWfzAQoMiz/O8+0Xk0CgkzwAAIABJREFUFtM5wiTMZ2gMajUD AKZ87s/o4vQpigrLcpAvuEimYrV7JPDmZ9vYN8XVUx+NAvhzz/O+YDrIoIX3boJoB1zX/SCAz5jO ETZhXdFotlpYWVsb2Ov7eYbGZiw0KEpEKYzn5jE0nDcdhbp0B/d8lP8eBnzRdd3Hoty3wUKDIqtU Kr0GwB+ZzhFGYZ06tTyAA/o2m5s10+LDg/soikZGpzGW3Q+ATeJBkB9r4JXXZkzHiB0RedfIyMjT ruu+ynSWQWChQZGUy+VGlVKPighPjOpBGKdOdTqdgY207fJ7tG2XiILiScsUQelMFrlCCSLhe8+J og+/n+eemHCub+Opc7swIoWFBkWRZLPZbwKYMx0krMK4dWpldRWdTmdgrz+UcXwfbbuZw1UNiqhE IoPChMcJawGQTjXw1utZbJggImkR+VapVPoKgPB9CF8CCw2KHM/z7gfwTtM5wkopBQnZvHutNRYH vJoxt9/sFlr2aVCUWXYC+YKHRMLMqiG95L23cvuUSUqp+zzP+97s7Gwkjm1noUGRwubvvQvjxKm1 SgXNZnOg1zDVn9FlcUWDIk4pC+P5ItKZcdNRYs1SDdzxXjaGG/Z2x3GeKZVKbzAdZK/Cd0dBdAls /u6PMDaCLy4tDfwapkbbdokIbG4toYgTEYxlZzA6ts90lFh70+tsJJPhWtmOGhEpKqV+6Lrux01n 2QsWGhQJuVxuVES+yebvvQtbf0a1VkOtXh/4dUwXGgBXNSg+MkM5jOeLEOFtihktfOxDE6ZDEJAQ kQdc1/09AKGcCMKfYIoCyWaz3zw3tYH2KGwTp5YGeEDfZnP7zW6dAtinQfGSTA4jX/BgceKaEdde CWRHw/V5EFUi8gnXdX9YKpWmTWfZLRYaFHps/u6vMG2darZaWF1f9+VappvBAcBSDnjmAMWJ7SSR n/DgOFys9pvWbXzx0zN/B+CfdDqdz2qtf19r/QMAx/QgDyyiLYnI9SISur4NfmJRqLmu+0ER+Zbp HFEyVShgbNT80/udeOHMGV9WNIYyDv7sj39q4NfZifXqIlrNmukYRL7SuoPlpeOoVf1ZwaQNIqLT w+PX3/Tu7/6Xzb8+OzubdhznKhE50Ol0DojIlQAOiMgBrfWMhG10Ybg0Op3OLxw+fPjfmQ6yE+F5 dEl0ATZ/D0ZYejTa7TaWBzzStmtq0nx/RpdtJVhoUOyIKGTHZ7HupLC6chJ8TuoPrbW06vX/CODK zb9+9OjRKoD/eu6/88zOzqYTicSBdrt9QCl1ABsFyJUADmitZ1mE7FlCKfV113Vv1Frfffjw4UB/ IPAfm0JpZmamkEqlngEP5eu7uZkZpFMp0zG2dWZxEWcWF3251k/cMI9/ed8bfbnWdtqdJtbWTpuO QWRMrbqCpaWjAHfv+EIEOjmUe9/B27/7yF5f68CBA8lGo3GFUupKEemugBzARiEzJ+z+3xWt9X8V kdsXFhaOmM5yKVzRoDCyU6nUw2CRMRBhaAbXWvu2mgEEoz+jS4mNjWdEvMmieEqlR5G3XSyeOYJO p2U6TuRpDWnVqg8A2HOh8Q//8A91AP/Puf8ulCiVSt65VZArzxUg3f+KIhL8DyeficirtdbPFIvF Dzz77LN/aTrPVriiQaHjed5vgofyDcyBUgkq4If2rayu4uSpU75d75f+h9fj4Ntc3663HfZpEAHt dhOLZ46g1eLPgh/S6exnbn7f479l6PKO53luu90+cG4l5MWeEAAlxPzBuda6DeCz5XL5t01nuVCs /2EofIrF4q1gkTEwSqnAFxlaayz5uJoBBKtHAwAcO8lCg2LPshzkCy6Wlo6iXls1HSfymo3KrwMw VWg0FxYWfgTgR1v8nj07O1uybbtbhLy4IiIiLkJ6/sRunFvt+bLruq9bXV295/Tp04H5geCKBoWG 67pXi8hfAxgznSWqHNuGOz9vOsZlrVcqOHbypK/X/JMH3oPxbHD6Vjq6jdXVF0zHIAqM1ZWTWF87 YzpG5GWGsl+76T2P/7zpHLtgFYvF+W5PyLkJWQcAXHmuCInc4URa6//vXN/GVkWZ71hoUCicG6X3 jIhcYzpLlKVTKczNzJiOcVlHT5xApVr17XpBGm272eraC+h02qZjEAVGtbKE5eXjbBIfIMtyWlZ2 LXvLLX/nzwFGg6Vc1507V4Bcea4A6TaoXyEiwXm6tHsrAO5cWFj4C9NBuHWKQiGRSDwAgEXGgAV9 tG2j0fC1yACCt22qy7IT6DT8/bsgCrJ0JgvbSbJJfIDa7aZtVwoPAbjNdJY+6JTL5WcBPAvgyQt+ T1zXnQ9xETKqtX7M87x/tbCw8EUYnB7CFQ0KPM/zfhHAvzGdIw7GRkYwNTFhOsYlPX/qFJZX/d16 +sbX78cXPv1mX6+5E81mFZXqkukYRIHDJvHBElE6mxmdffN7Hj9uOoshMjMzM+s4TveckBcLkXNF SMZ0wM201n/ebDbvOnr06FkT1+eKBgWa67pvgbnms9ix7eC+JTRbLaysrfl+3emJgK5oWAnTEYgC iU3ig6V1Ryrt9sMA3mA6iyH6+PHjzwF4DsCFI2Vlbm5un2VZm88JuRLnxvSKiO8fKCLyLsdxnnFd 9/Zyufx3vl/f7wsS7dTMzMxcKpX6GwCTprPExUQ+j/GxYPbanz57FmeX/H+C//M/92O47R0HfL/u Tqyun0an3TQdgyiw2CQ+GCKi08Pj19/07u/+F9NZwqRUKk1vcU5Id0VkoAc2aa2rAO4ul8sPDfI6 Fwru40uKOzuVSh0CiwxfBfWwvk6n4/tI2665/aNGrrsTjpVAnYUG0SWNjE7DtlNYXjoOHnLZP1pr adYrD2HjDAvaocOHD58EcBLAX134e1dcccVkq9W6aDsWNk5N3/MTQBFJA/hWqVS6/vDhw/8CgC/T RLiiQYHked6/A3Cv6RxxMzczg3QqeD1uS8vLeOGMmaeS3/j6uzAV0O1TzVYNlcqi6RhEgddoVLB4 5gg2zjWjfkkN59578Pbv7vnEcLq8mZmZQiKROO+wwu6KiIjkenjJ7zcajQ/40bfBFQ0KnFKpdDdY ZBgRxBUNrTUWDa1mKCUo5NJGrr0TNvs0iHYkkcigMOHh7Nln0W41TMeJjHa98gcA8qZzRN3x48dP AzgN4KkLf69UKmVF5KpN54RsPjW9cImXfLvjOM+USqU7Dh8+/NcDjM4VDQqWYrF4nVLqr4I2tSEu DpRKgTsZfHV9HSeef97ItWdnRvDAV281cu2dWls/jTa3TxHtSKfTxtLZ59BoROEYiGDIZMZ/9ab3 fu9LpnPQxXK53Ojw8PCV3QMLsVGAdJvTJwE0tNafKpfLvz+oDFzRoMCYnp6esCzrEAAWGQaISOCK DABYNNAA3jU3G9z+jC7bTrLQINohpSyM54tYWT6BKrcd9kWjvv6r+iH8pnzQnz3/tHNnz55dOXv2 7N8C+NsLf29iYmI4nU5frZS6slgsus8++2x5EBlYaFBQSDqd/jaAedNB4soKYJFRrdVQq9eNXT+o o203s+0k6nX/x/4ShZWIYCw7A8dJYWX5hOk4oddqN1KPpw/+e+DxT5jOQjt36tSpNWwUIBcVIf0U vDsLiiXP8+4XkbeazhFnQTwVfGl52ej1JyeCv7hmKcd0BKJQygzlMJ4vQoS3QnvVaqzf9dRT7wz+ EjD5jj9dZFypVPoQgM+YzhF3QTusr9lqYXXd7D7qII+27RIR2Dabwol6kUwOI1/wYFks2Pei3W7a q8cb3zKdg4KHhQYZ5bru1SLygOkcFLyJU4uGVzOAcPRoABvbp4ioN7aTRH7Cg+MEd8JcGNTra7f8 4LGDV5rOQcHCQoOMyeVyowAOccJUMARpRaPdbmPZ0EjbrqCPtt2MhQbR3ihlI1coIZXe87losaV1 R2rNlq+nTlPwsdAgUySbzT4oIteYDkIbgjRxamllBVqbPcV3Ip+GZQXn7+RylNjgtHKivRFRyI7P YmR0CjxFvDfN+vqrv//IO28wnYOCIxyfohQ5nud9AcBtpnPQS4IydUprbXw1AwhHf0aXiMB2uKpB 1A9DwwVkx+cBYfG+W1praTbX/8R0DgqOYNxZUKwUi8VbtdafN52DzheUrVOra2totc2PYw9ToQHw lHCifkqlR5EvuFAqGO+LYdJoVOeeeOSmu0znoGBgoUG+cl33asuyHhTOEwycIIy31VpjKQCrGUA4 RttuxslTRP3lOGnkJzzYdsp0lNBpNupfNZ2BgoE3e+Sb2dnZNIBDANhtF0BBmDpVqVaNHtC32dRk 8A/r20yJzfMAiPrMshzkCy6SqRHTUUKl1ayPPvnIO75gOgeZx08l8k0ikXiAzd/BJCKBWNEIwkjb rrBtnWKfBtFgiFIYz81jaDhvOkqo1Ovr/1I/BPMfLGQUCw3yhed5nwVwp+kctLUgNII3Gg1UqlXT MQBsjLadmR42HWPXHIuFBtGgjIxOYyy7H5zwtjPtViP5ZPKmPzKdg8wyf3dBkXeu+ftLpnPQpXE1 43xhGm27mcU+DaKBSmeyyBVKEDH/nhkGtcranU899c5wLQ9TX4Xvk5RCZWZmZo7N38FnutBotlpY WVszmmGzsPVndCmxoBRvgIgGKZHIoDDhsbDfAa07auV449umc5A5vPmjgZmdnU2nUik2f4eA6Ubw 5QAc0LdZWAsNgKeEE/nBshPIFzwkEuF9r/BLo7528w8eO3il6RxkBgsNGphEIvEAgNeazkHbM7mi 0el0AjPStmt2JrwTZlhoEPlDKQvj+SLSmXHTUQJN645UG82HTecgM1ho0EB4nveLYPN3aJg8rG9l dRWdTsfY9bcStolTm/HgPiL/iAjGsjMYHdtnOkqgtRrrL/v+oYO3ms5B/mOhQX3nuu5bAPyW6Ry0 c6amTmmtsRiw1Qwg3FunRBSU5ZiOQRQrmaEcxvNFnmVzCVpDGs36A6ZzkP/4E0F9NTMzMyci3wbA O50QMbWisVapoNlsGrn25UxPhLfQAACHqxpEvksmh5EveLBY6G+p2azue/KRW+4xnYP8xUKD+mZT 8/ek6Sy0O6Z6NBaXloxc93LGs0kMDYX7Rp19GkRm2E4S+QkPjpM2HSWQmo3KV0xnIH+x0KC+cRzn 62DzdyiZ2DpVrdVQq9d9v+52wtyf0WVxRYPIGKVs5AolpNIcuHihZrM2/MTDB3/HdA7yDwsN6otS qfRJEbnLdA7qjYkVjaUAHdC3WZj7M7pEBDZn/BMZI6KQHZ/FyOgUgOCM7g6CemPtn+m/vNHcBBLy FQsN2jPXdd+ilPqq6RzUG6UURMTXazZbLayur/t6zZ2aCnl/RhdXNYjMGxouIDs+D/j8HhtknXbL fmLF/mPTOcgfLDRoT6anpyfY/B1uJg7rWwzoagYQ7jM0NmOfBlEwpNKjyBdcKMWH+F316todTzxy 05TpHDR4LDRoL+x0Ov1tsPk71PyeONVut7EcwJG2XXOz4e/RAABLsfYnCgrHSSM/4cG2U6ajBILu tFWn1fkz0zlo8FhoUM88z/uaiLzVdA7aG79XNJZWVqB1cPcsh320bddGnwZXNYiCwrIc5Asukqlo rJruVaOx/qbHv3PztaZz0GCx0KCelEqluwHcazoH7Z2fjeBa60CvZgxlnNCPtt2MhQZRsIhSGM/N Y2g4bzqKcVpr6aDFVY2IY6FBu1YsFq8TkX9rOgf1h5+FxuraGlrttm/X2625/dF60sjJU0TBNDI6 jbHsfgDxbhJv1tev+f6hg7eazkGDw0KDdmV6enrCsqxDIpIxnYX6w68zNLTWWArwagYQnf6MLiU2 4n4jQxRU6UwWuUIp1k3iWkPqjdofmc5Bg8NCg3ZDzjV/z5sOQv3j14pGpVoN5AF9m0VltG2XiMB2 uH2KKKgSiUzsm8RbrdrEE4/e9CnTOWgwWGjQjnmedz+bv6PHr6lTQR5p2xW1QgMAHPZpEAUam8SB Vr3xr01noMFgoUE7UiqVPgTgM6ZzUP/5MXWq0WigUq0O/Dp7Nbc/WlunADaEE4VB3JvEm83a8BOH Dv6vpnNQ/7HQoG2da/5+wHQOGgw/tk6FYTUDiF4zOAAosaCU/4cyEtHuxblJvF5f+9R3v/uq6C0r xxwLDbqsXC43yubv6FJKQWSwH2jtdhsra2sDvUY/RG207WYWp08RhUa3SVwkXg8IOu2WbVUn/nfT Oai/WGjQ5Ug2m30QbP6OLD8mTgX9gL6uqcnoPkhzLG6fIgqTRCKDwoQXu4cEtdr6e/7qkYMzpnNQ /7DQoEvyPO9+ALeZzkGDM+hG8E6nE6JtU9Hrz+iyrHjdrBBFgWUnkC94SCSi+xDkQrrTVpUWD/GL EhYatKVisXgr2PwdeYPuz1hZXUWn0xnoNfoliv0ZXUpZUJZjOgYR7ZJSFsbzRaQz46aj+KbRWH/D k4/d8nrTOag/WGjQRVzXvdqyrAdN56DBG+TEKa01FgN+QN9mURxtu5nDVQ2iUBIRjGVnMDq2z3QU X2itpdmo8x4kIlho0HlmZ2fTAA4BGDOdhQZvkFunKtUqms3mwF6/36LcowGwIZwo7DJDOYznixCJ /q1bq7HuPf7oLe8xnYP2LvrfrbQriUTiARG5xnQO8scgm8HPLi0N7LUHIeqFhs0VDaLQSyaHkS94 sCK+FVJrSLtW5Vj9CGChQS/yPO+zAO40nYP8M6gejWqthmqtNpDXHoRM2kYhlzYdY6BEFPs0iCLA dpLIT3hwnGi/ZzVb1cITDx/8tOkctDcsNAgA4LruW7TWXzKdg/w1qEJjKSSTprqmp4ZhWdF/O3R4 SjhRJChlI1coIZWO9i7nZqPy66Yz0N5E/5OVtjUzMzMnIt+WOGz8pPMMohm82WphdX297687SFHf NtVls9AgigwRhez4LEZGpwAE/6yiXrTajdQThw5+zXQO6h1vLMlOpVKHAEyaDkL+G8SKxnKIJk11 TUd84lSXpbh1iihqhoYLyI7PAyKmowxEo75+73e/+6p4vElHEAuNmPM872sAXms6B/lPKQXV52bw druNpRAWGrMRPkNjMxGBzelTRJGTSo8iX3Ch1GAPYTWh3W7asj7xp6ZzUG9YaMRYqVT6JIB7Tecg MwYxcWppZSU0B/RtFuVTwS/EU8KJoslx0shPeLDtlOkofdeor/3kXz1ycMZ0Dto9FhoxVSwWr1NK fdV0DjKn36sZWutQbpsC4tOjAQBOBG9CiGiDZTnIF1wkU9FapdW6I5VW+5DpHLR7LDRiaHp6esKy rEMAuGE7xvp9WN/q2hpa7XZfX9MPSknkR9tutrG1Ipp7uYkIEKUwnpvH0HDedJS+ajTWXvfkY7e8 3nQO2h0WGvEj6XT62wDmTQchs/o9cSqMvRkAMDMdj9G2XSIC2+H0KaKoGxmdxlh2P6LyYEFrLe16 7SHTOWh34vPpSgAAz/PuF5G3ms5B5vVzRaNSraJWr/ft9fw0Nxuf/owunhJOFA/pTBa5Qgkigzkz yW/1RqX4+KO3vMd0Dto5FhoxUiwWbwXwGdM5KBj62aNxdmmpb6/lt7iMtt2Mk6eI4iORyKAw4cGK yM99u175A9MZaOdYaMSE67pXW5b1oOkcFBz92jrVaDRQqVb78lomTE5kTEfwnRIbPJ+TKD4sO4F8 wUMiEf4HK81mLffkI+/4VdM5aGf4SRMDMzMzGQAPAxgznYWCwbYsJBP9ebq1uLzcl9cxJU6jbbvY p0EUP0pZGM8Xkc6Mm46yZ43a+uf0Q4jGfrCIY6ERA8lk8ndF5FrTOcg8y7Iwmc+jNDeHRB8KjXa7 jZW1tT4kMyeOPRoA4FgsNIjiRkQwlp3B6Ng+01H2pNVupJ5w3v6HpnPQ9lhoRFypVPqkiNxlOgeZ JQDGx8ZQmptDdmysb/0ZSysr0Fr35bVMiNto282isl+biHYvM5TDeL4Y6i2U9dr6h5966p3xfFIU IuH9DqNt8VA+AoCxkRG48/OYyOf7ehp4p9MJ/bapiXw6VqNtN1NiQSnuPCCKq2RyGPmCB8sK55Fa WnfU6okmx90GXDw/YWPg3KF8j4CH8sXWUDqN0uwspiYm+n44HwCsrK6i0+n0/XX9FMf+jM1sm9un iOLMdpLIT3hwnHCu7NZrq+/4wWMHrzSdgy6NhUY02ZlM5jsA5kwHIf+lkknMzcxg/759fenD2IrW GoshPaBvMxYaLDSI4k4pG7lCCal0+ObFaN2RWqP5HdM56NJYaESQ53lfA/Bm0znIX8lEAjNTU5jf vx/pVGqg16pUq2g2mwO9hh/iONp2Mx7cR0QAIKKQHZ/FyOgUgHD13TUb6y///iPvvMF0Dtpa//dT kFGlUuluAPeazkH+sS0L+fFxjI6MQER8uWaYD+jbbGoy/DPl90JEQVkOOu3wF41EtHdDwwVYVgJL S0eBkAz60BrSbFX+BMC86Sx0Ma5oREipVHqNiPyu6RzkD6UUCrkcSvPzGBsd9a3IqNZqqNZqvlxr 0OJeaACAw1UNItoklR5FvuBCqfA8i27UK3NPPHITJ2wGEAuNiJiZmSkopR4VkXB2dNGOiQjGx8bg zs0hl81C+VRgdC2FfNJUl1KC6clh0zGM45hbIrqQ46SRn/Bg24PdhttPrXqdUzYDiIVGNNipVOph sPk78kaHh1Gam9sYVWv5P5q02WphdX3d9+sOwkQ+jaEMh7KxT4OItmJZDvIFF8nUiOkoO9Js1Uef OHTTl0znoPOx0IgAz/N+G2z+jrRMOo3i7CymJyfhDGBU7U4tR2DSVBe3TW0QUbC5qkFEWxClMJ6b x9Bw3nSUHWk0ar+k//LG8Oz5igEWGiFXKpU+BOAXTOegwUgmEtg/PY3ZffuQHNCo2p1qt9tYYqER SRZXNYjoMkZGpzGW3Q/A3626u9VuNZJPLNvfMJ2DXsJCI8SKxeJ1IvKA6RzUf45tY2ZqCsXZWQxl gjGCdWllJfQH9G02OxOO7QB+4HkaRLSddCaLXKEEEf+37e5Gvbr60088ctOU6Ry0gYVGSOVyuVHL sg6JSDDuQqkvLMvCZD6P0twchoeC88Rdax2pbVMAD+vbzFLsVSGi7SUSGRQC3iSudUfpDr5pOgdt YKERTpLNZh8EZ0ZHhhJBfnwcpbk5ZMfGfBtVu1Ora2totdumY/QVt069RES4qkFEO2LZicA3iddr az/x+HduvtZ0DmKhEUqe590P4DbTOag/xkZGUJqbQ358HJYK5o9klHozuqYnWGhsxkKDiHYq6E3i Wnekjfa3TecgFhqh47ru7QA+YzoH7d3IuVG1UxMTsA1OktpOpVpFrV43HaOvxrNJDA2xAXozTp4i ot0KcpN4q7527fcPHbzVdI64C+7dDV3Edd2rReSPTeegvcmk0yjkckglw/EE+ezSkukIfcf+jIsp sbFxs6BNRyGiEElnsrDsBBbPHIHWwdliqzWk0ao/AGDGdJY444pGSMzOzqYBHAIwZjoL9SbhOC+O qg1LkdFoNFCpVk3H6Dv2Z1xMRGA74fi+JKJg6TaJWwFbGW02qvuefOSWe0zniDMWGiGRSCQeEJFr TOeg3bNtG9OTk4EaVbtTi8vLpiMMxBT7M7bksE+DiHq00STuIZEI1vtrs1H5iukMccZCIwQ8z/tF AHeazkG7o5RCIZdDaXYWo8PDgZsktZ12u42VtTXTMQaCZ2hsjQ3hRLQXSlkYzxeRzoybjvKiZrM2 /PjDN/8b0zniioVGwBWLxesA/JbpHLRzAmB8bAzu3Bxy2SxUQCdJbWdpZQVaR3O//twsezS2osSC UsE+jIuIgk1EMJadwejYPtNRXtRorP+P+i9vZF+yAeG8A4qJ6enpCcuyDgHgaVohMTo8DHd+HhP5 PCwrvDdsnU4nstumAI62vZyg7bEmonDKDOUwni9CxPytZqfdsp9ctv6D6RxxZP5fny4pk8l8CzyU LxQy6TSK+/djenIy0KNqd2pldRWdTsd0jIEYyjgcbXsZjsXtU0TUH8nkMPIFD5Zl/nlprbb+gSce uWnKdI64YaERUJ7nfRHA20znoMtLJZOYm5nB7L59SIZkktR2tNZYjOABfV1z+9mfcTlc0SCifrKd JPITHhwnbTSH7rRVp9X5jtEQMcRCI4CKxeKtWuvPm85Bl+bYNmampjC/fz/SqZTpOH1VqVbRbDZN xxgY9mdc3kafRvhX5YgoOJSykSuUkEqbndDfaKy/8fHv3Hyt0RAxw0+TgJmZmZmzLOtBsAgMJNuy kB8fx+jISOimSO1UFA/o24yjbbfn2EnUGy3TMYgoQkQUsuOzWHdSWF05CROniWutpaNb3wHAYsMn vJkNFjuVSvFQvgBSIsiPj6M0P4+x0dHIFhnVWg3VWs10jIFiobE9bp8iokEZGi4gOz4PGPocbTbW r/7+oYO3Grl4DLHQCBDP834bwGtN56DzNEYymX8ozc0hPz4OFdECo2spwpOmuub2c+vUdmyLhQYR DU4qPYp8wTWyTVNrSKNR+yPfLxxTLDQColQqfQjAL5jOQRu01h2t9Tc6nc7VExMT/xiFSVLbabZa WF1fNx1j4NgMvj0RBRWAKTFEFF2Ok0Z+woNt+9/n2GzVJp549KZP+X7hGGKhEQClUukaEXnAdA7a oLV+AsBry+Xy3YcPHz6sRMyOyvDJcoQnTXVxtO3OOTwlnIgGzLIc5Asukin/HwC16o1/7ftFY4iF hmG5XG5URB4WkYzpLIS/AXBzuVw+WC6X/2v3FzUQ+UKj3W5jKQaFxtQk+zN2ymahQUQ+EKUwnpvH 0HDe1+s2m7XhJx+++au+XjSGWGgYls1mHxSRa0zniDOt9WEAP7OwsPD6hYWFJ7f4A5EvNJZWViJ7 QN9mLDR2zlLcOkVE/hkZncZYdj/8nEZVa6z/0+9+91X8YBig6G88DzDP8z4L4DbTOWLslNb6N8rl 8v8GoHGZPxetgzIuoLWOxbYpAJhnI/iOiQhsO4Ev0EWbAAAgAElEQVRW63I/GkRE/ZPOZGHZCSye OQKt2wO/Xqfdsq3KxH8A8L6BXyymuKJhiOu6b9Faf8l0jjjSWlc7nc79KysrV5TL5a/h8kUGBIj0 HpLVtTW02oN/Qw+C2Rk2gu+GxelTROSzRCKDwoTn25jtWn399r965OCMLxeLIRYaBszMzMyJyLdF hH///moB+PetVuvA4cOHf+X06dOrO/oqkUgXGnHozeji1qndcQxMgyEisuwE8gUPicTg37N1p60q rdZ3Bn6hmOKNrgHJZPLbACZN54iZhwG8fGFh4ZPPPffc8V1+bWQf61aqVdTqddMxfMNCY3c2ZtxH ++wYIgompSyM54tIZ8YHfq1GY/31Tz52y+sHfqEYYo+GzzzP+3cA+M3sn//UarV+4ciRI3/b8yuI RLbQOLu0ZDqCbzJpG4Vc5Pv6+0pEYDtJtJrRPi2eiIJJRDCWnYHjpLCyfGJg19FaS6tRfxDAgYFd JKa4ouGjUqn0SQD3ms4RE/+t3W7ftrCw8OY9FRkAJKIrGo1GA5Vq1XQM30xPDcOy+Ja3WzwlnIhM ywzlMJ4vYpA7zpuNde/xR295z8AuEFNc0fBJqVR6jVKK85oH75jW+ovlcvkPAPRlXquIRPLnZHF5 2XQEX3HbVG9snxoyiYguJ5kcRr7gYfHss2i3m31/fa0h7XrlDwD4e6BHxPHxng9mZmYKSqlHAXAw /YBorRe11p9uNBpXlsvlB9CnIuPGG2+MZDdsu93Gytqa6Ri+mp5godELJezTIKJgsJ0k8hMeHGcw 22CbzVru+48e/JWBvHhMsdAYPDuVSj0MYM50kCjqjqptt9tXlMvlLx89erTfe4EiWWgsraxAa206 hq9m93O0bS9EBI4TyR8DIgohpWzkCiWk0mMDef16tfJ5/RCsgbx4DLHQGDDP874G4M2mc0SN1rqj tf5Gd1TtkSNHFgdxnUwEC41OpxO7bVMAMMfD+nrm2JGe8ExEISOikB2fxcjoFID+PjRrtRupJxI3 f72vLxpjLDQGqFQq3Q02f/ed1vqxVqv16nK5fHcPo2p3pRPBQmNldRWdTl92loUKezR659fBWURE uzE0XEB2fB6Q/m7vbNYrP/vUU+/k06k+YKExIMVi8ToR+bemc0TM37Tb7RvK5fLtzz333H/344JR KzS01liM0QF9XUoJR9vugRILSnEnAREFTyo9inzBPXfuT3+020175UTjm317wRhjoTEAuVxu1LKs QyKSMZ0lCrTWPwLw/oWFhdc/++yz/9nXa0dsc3qlWkWz2f9pHUE3M83RtnvFVQ0iCirHSSM/4cG2 +/eR3ait/eQPHjt4Zd9eMKb4ydt/ks1mHwQwbzpIBBzTWt9TLpdfvrCw8B30eyPmDthaR6rQiNMB fZvNzXIFfK9si30aRBRcluUgX3CRTPVn8IfWHak32t/qy4vFGAuNPvM87wsAbjOdI+RWO53OFzaN qm2ZCqIjtHWqWquhWovnCc8cbbt3bAgnoqATpTCem8fQcH+Owmg01l7z/UfeeUNfXiymInkQmSmu 675Fa/156XNTUow0APxupVL5n0+ePHnKdBgA0FqnovLvuRTDSVNdkxPcxbhXIgrKctAZwEFZRET9 NDI6DdtOYXnpOPayGUJrLc3m+oMAin0LFzNc0egTz/PmReTPRIR/pz3QWj/UarWuXVhYuC8oRQYQ nRWNZquF1fV10zGM4Wjb/nAs9mkQUTikM1nkCiWI7G2QRaNRnX/ikZvu6lOs2OFNcR/Mzs6mATwM YMJ0lrDRWj/RarVeVy6X7zhy5MiC6TwXUhEpNJZjOGlqM/Zo9AcbwokoTBKJDAoT3p7fu5qN+lf7 FCl2WGj0geM4XwfwWtM5Qua/A7i5XC4fPHLkyN+aDnNJEWgGb7fbWIpxocHRtv1jc0WDiELGshPI F7w9NYm3mvXR/+uRWz7fx1ixwUJjj0ql0idFhEtqO6S1PgzgZxYWFl69sLDwpOk824nC1qmllZVY HtDXNZFPc7Rtn4go2FzVIKKQUcrac5N4pb72Of0QeKDQLvHTdw9c132LUorLaTtzSmv98+Vy+eqF hYX/CCAcd75KhbrQ0Fpz2xT7M/rK4qoGEYXUyOg0xrL7Aex+yEu71Ug+kXj7H/Y/VbSx0OjR9PT0 hIh8G4BjOkuQaa2rnU7n/pWVlSvK5fLXsDFZKjQk5Csaq2traLXbpmMYxUKjv2yOuSWiENtLk3i9 uv7hp556Jz9UdoGFRo/S6fRDACZN5wi4f9/pdK44fPjwr5w+fXrVdJgehbrQiHNvRhdH2/aXpfhs hYjCrdcmca07avVE808HFCuSWGj0wPO83xSRG03nCCqt9WMArl5YWPjks88+e8J0nr3QIW4Gr1Sr qNXrpmMYNzXJw/r6SUS4qkFEoddtEk8kdvcZUa+tHvzBYwevHFCsyGGhsUvFYvFWAJ8xnSOg/lO7 3b6hXC7fvrCw8CPTYfpBgKzpDL06u7RkOkIgsNDoPxYaRBQFSlkYzxeRzozv+Gu07ki10Xx4gLEi hYXGLszMzMxZlvWg6RwB9N/a7fZtCwsLb3722Wf/s+kw/dTROpR3qY1GA5Vq1XQM45QSTE8Om44R OZw8RURRISIYy85gdGzfjr+m1Vh/2fcfeecNA4wVGbbpAGExOzubTiQShwCMmc4SIMe01l8sl8t/ gLBMkdol3ekMQYWvHl9cXjYdIRAm8mkMZdhT0G9KbGxMbdGmoxAR9UVmKAfLTmDp7HPQ+vK3NFpD ms3KNwHM+ZMuvMJ3B2UID+V7idZ6UWv96UajcWW5XH4AES0yAECLhK6TuN1uY2VtzXSMQOC2qcEQ EdgOt08RUbQkk8PIFzxY1vYPqBqNyuwTj9zEc9S2wUJjB0ql0l08lO9F/0uz2TxQLpe/fPTo0cjv zVEioTtSemllBVrzSTPAQmOQeEo4EUWR7SSRn/DgONt//LfqdZ6ltg0WGtsoFovXicjvms5hkta6 o7X+RqfTcRcWFu47evToWdOZ/KKBUBUanU6H26Y2mZ0ZMR0hstgQTkRRpZSNXKGEVPryu+Wbrfro k4duvt+nWKHEQuMycrncqGVZhySE22f6RWv9RLvdflW5XL778OHDh03n8Z3WoSo0VlZX0elEdifb rvGwvsGxlA2ldn/gFRFRGIgoZMdnMTI6hcv1o9Ub1fv0X97InudLYKFxGdls9kEA86ZzGPI3AG4u l8sHjxw58n+bDmNQaM7R0FpjkQf0nYdbpwZrt4ddERGFzdBwAdnxeUBky99vtxrJ7y/b3/A5Vmiw 0LgEz/M+C+A20zn8prX+EYD3LywsvH5hYeFJ03lMEyA0+0Mq1SqazabpGIEyPcFCY5AcKzQ/HkRE PUulR5EvuFBq64WLanX1p5945KYpn2OFAguNLbiu+xat9ZdM5/DZKa31z5fL5ZcvLCx8B5xbuUEk NHdSPKDvfOPZJIaG+MR9kLiiQURx4Thp5Cc82PbFGx207ijd1t8yECvwWGhcYGZmZk5Evi0icfm7 We10Ol9YWVm5olwufw1Ay3SggAnFnVS1VkO1VjMdI1DYnzF4SqxLPuEjIooay3KQL7hIpi4eNFKv r7/18e/cfK2BWIHGT4jz2alU6hCASdNBfNAC8PuVSuXzJ0+ePGU6TGCJhKLQWOKkqYuwP8Mfjp1E vcHnE0QUD6IUxnPzWF05ifW1My/+utYd6ejWnwF4mbl0wROXp/Y74nne1xDxQ/n0hocAvHxhYeGT LDIuT0KwotFstbC6vm46RuBMsT/DF9w+RURxNDI6jbHsfgAvNYk3G+vXfP/QwVvNpQoermicUyqV 7gZwr+kcg3RuVO1njxw58rems4SFiAT+Z2SZk6a2xDM0/MGD+4gortKZLCw7gcUzR6B1G1pDGs36 7wPYZzpbUHBFAy8eyvdvTecYoP+Ol0bVssjYoRtvvDHwo23b7TaWWGhsaW6WPRp+EFFQlmM6BhGR EYlEBoUJ78XV3WazOv3kI7fcYzhWYMS+0PA8b0wp9XAUD+XTWj+rtb5r4f9n787j5CrLvP9/71NV ve9LErJ2dxAGBVdcccHRGR0Uxmecnws4LjOjj7M4SoJheXQecGNTRHFBn9FRcQUGBVyAAQUHENlk X0N3ZyEJpJM63dVde53790d3QghZeqmq+5yqz/v14qVJus/5iunuuurc13UNDx/FqNp5CX2h4U9M sKBvPxhtWz0JtoQDqGOxeIN6+4bU0DD9c6eQT1/gOFJo1HuhYST9yBizynWQcrLWJq2160ZGRg4b GRn5ges8UdUS8kLDWsuxqf1obUkw2raK4hQaAOqc58XU3btKzS3dKhSybTdc+Zdfdp0pDOq60Bga GjpbNbSUz1qbCYLg7FKptHpkZOR8SXnXmaIsCHmhkZqcVLFUch0jlFYsoz+jmmIeR6cAwBijzq6l 6uw6RLls6l/uvPNldf/NMfSNrpWyatWq4ySd6jpHOVhrA0mXFIvFMzZt2rTFdZ5aEUhNYa7E6c3Y P/ozqssYo3i8QcUi720AQHNLj2KxxoT/5MR/SPqA6zwu1WWhMTg4eLgx5seuc5SDtfbqmQLjAddZ ao1NJJpkw7kgPZ3JKJvLuY4RWoy2rb5YjEIDACTJBoFKpYJsqfQm11lcq7tCo7+/v03SLyR1us6y ENbaP5RKpU9u3LjxFtdZalXc2qZwlhnSTt93HSHUKDSqLx5vVC436ToGAFRVsZhVNptSLjOpTHZC 2WxKhVxaktTds6KWJ5rOSt0VGm1tbd80xvyZ6xzzZa19zBhz+sjIyBWus9Q6G9IejXw+r3Qm4zpG qLEVvPqm+zSMpLCW5wCwEFa53JSymdT0P9mUctkJlUqFfX50W1vvQ8ef+MezqxwydOqq0BgaGvqE pPe5zjFPT1przxwZGfmepKLrMPXAWttkjDn4B1ZZcnzcdYTQW7GMHo1qM8YonmhUsZB1HQUAFiQI ijNPKVLKzBQUucyUrGY3Tj6eaCo09Om1FY4ZCXVTaKxateqlks5znWMeUkEQfLFYLJ6/efNm3sau Iis1ha3MKJVKmpjkeMqBtLYk1N0VyodRNS8ea6DQABAphUJGuUxK2VxKmfT00aeFfB8zRratrfcj b3/7Hckyxoysuig0hoaGOq21V0iK0pixvKRvpNPpL2zbtm276zD1yAvh0Sl/YkI2pA3qYcGxKXfi cXaXAAgnq0C57KSy2ZSymYndfRVBUN5DIq1tfbeecNId3yvrRSOsLgoNa+0lUVnKt2tUrbX2zNHR 0VHXeeqatU0K0dGpIAg4NjULFBrueCYu+jQAuBYEBWXSKeVyE9P/mU0pl5tSpb83NTW1T3avnHhz RW8SMTVfaAwNDZ0m6XjXOWbDWnt9qVT6xMaNGx90nQXhOzo1kUopCGZ3PrSeraQ/wxljjBKJJhUK nPIEUB35fFq5bEqZzHRBsdCjT/PleZ5tbu0+/o1vvI3zo3uo6UJj5cqVx1hrPx/Ght693CnptJGR kRtcB8EePC80R6estUqyoG9Wli9lK7hLiXgjhQaAsrO2NH30aWbiU3amr8IGJdfRJEkdHYsuPf69 t93oOkfY1GyhsWzZsuXxePznkkK73NlaO2qM+dTw8PCPxVmD0DEh6tFIZzIqFPY9Qg/PxtEpt2L0 aQBYoFKpoGxmXNnspLKZ8ZmjT2nXsfarublz5wnvu/s9rnOEUU0WGgMDA03GmKsk9bvOsh/brbWf GRkZ+bamm74RTqEpNFjQN3sUGm55JibPiykIybuMAMLLyiqfS+9u0M7NPK0olaLz0siLxYOG5o43 us4RVjVZaHie9x1JL3GdY2/W2oykC1Kp1LljY2Mp13lwYGHZo5HJZpXJcuRzNlqa4+rraXYdo+7F 4g0K8hyfAvCMICjtXnL3zMK7SU3PwImutrb+C/76xD/e5zpHWNVcoTEwMPBRSSe6zrGXoqTvFIvF z2zatGmL6zCYHSN1uc4gST6TpmZtyeI2xWKhPS1ZN+KxRhVEoQHUq0IhO73kLjupTGa6sCgU0pqe Slc7mlu6Nrzj7+76pOscYVZThcaqVate6nneV13n2MVOLzy4zBjz6eHh4cdc58HcBNa2eo6faBSK RaWmppxmiBKOTYVDIt5ImQHUAWsD5XOTzzRnZ1PKZicVlPbVU1hbRUY8nih1NLe+znWOsKuZQiOE S/luKZVKH9+4ceNdroNgfmwQtMpz++74OJOm5mRJP4VGGBjjyYsl9vNiA0AUBUFh9wjZTCalXCal XH5SqsMlssbItrUvOu0t771jk+ssYVczhUaIlvLdXyqVTtuwYcOvXQfBwlhjWlzev1QqyafQmJPl yxhtGxaJWINyFBpAJIVlN0VYtXb033nCSXd80XWOKKiJQmNoaOgTcryUz1q7VdO7MH7gMgfKxzPG aVexPzHBgr45WsGyvtCIxRukPMf+gDCzCqZ3U8xMfcpmU8plJhUERdfRQquhsSWb6Iof6zpHVES+ 0Fi5cuUxks5zdX9rbVLS2YVC4WubN2/mWHINsZKzQsNay7GpeaBHIzziMfZpAGESlGaOPuUmlEmn ZnZTTIk1XrNnjLFt7X0nvf3428K71CNkIl1o7LGUr+p9GdbajLX2wiAIzt+4cWOy2vdHFVjrrNBI TU6qWGIPwVx4nmG0bYgY4ykWS6jE8Smg6vL5qWcffcqkVCzmXMeKvPb2Rde+/T23XeE6R5REttBw tZTPTg98vqRYLJ7BqNqa52xhH70Zc7d0CaNtwyYeb6TQACrIBoFy2Qllcill09O9FPlsSkHEd1OE UWNz28Rf/92fjtP7XSeJlsgWGp7nfVNVXspnrb2mWCx+ctOmTQ9U875ww0iNLu6bzmSUzfHO01yt WE5/RtjE443K5SZdxwBqQrGY3d1DkclO91MUcpzgqQbP82x7W89xxnDObK4iWWgMDAx8UNIHq3jL O0ul0sc3bNhwaxXvCdeMcVJo7PR9F7eNPEbbhk/MC8u0cSBKrHK5qem9FLs3aE/wdNChtrb+Hx73 7ttucZ0jiiJXaKxateoIY8zXq3Eva+1jxpjTh4eHfy66pepR1btZ8/m80hlmCszHon6n04ixD8YY xeMNKhbzrqMAoRQExZmnFCllZgqKXGZKVhx9CouW1p4n3/H+P3Fgap4iVWgsX768ORaLXS6p0q8o tltrPzMyMnKxJGa81Stjql5oJMfHq33LmsFo23CKxxspNABJhUJGuUxK2VxKmfQEuykiIB5vKDV3 dBzjOkeURarQSCQS35T0/AreIhUEwRcnJye/PDY2lqrgfRABpspPNEqlkiYmOc8+X/RohFM83iiJ b6eoH9YGyuXYTVEL2jsWf/pt77x1g+scURaZQmNgYOCjxpgPVOjyeUnfSKfTX9i2bdv2Ct0DEWOM qerXhz8xIWs5oTcfjLYNL8/EJRlx+hS1KAgKu0fIZjLTR6By+UmJ7+WR19re+/DxJ/7xbNc5oi4S hcaqVate4nneV8t9XTv9qu4ya+2po6Ojo+W+PqLr2GOPrepo2yAIODa1AP29zYy2DSljjOKJRo6I IPLy+fSzd1Nw9KlmxRNNhYaehte7zlELQl9oLFmypD8Wi/1CZV7KZ629vlQqnbZx48a7ynld1Iyq FhoTqZSCgOa/+WIjeLjFYw28IENkWFtSLju5e+JTdqavwgYsUa0Hxsi2tfV+5Pjj7xhznaUWhL7Q aGlp+amkleW6nrX2XmPMKSMjI9eX65qoPS1SU7Ve9ltrlWRB34LQCB5u030aQPiUSgVlM+PKZieV zYwrl00px26KutbW3vuHE06643uuc9SKUBcaQ0ND50j683Jcy1o7aoz51MjIyE8k5sbhwIIqPtFI ZzIqFJiPvhDLl7a7joADiHlxeV5MAe8IwxErq3wuvbtBOzfztKJUYiIantHQ0JLpWpF6k+sctSS0 hcaqVauOk3RqGS61a1TttzXd9A0cVCA1VevEPwv6Fo6jU+EXizcoyLMjBpUXBKXdS+6eWXg3KWt5 jxH753mebe3sfvcb33gH5zzLKJSFxuDg4OHGmB8v5BrW2oy19sLJycmzGVWLubKJRFM1poZkslll snxPWygKjfBLxBpVEIUGyqtQyE4vuctOKpOZLiwKhbSmJ50Bs9fRsfiy4999x9WucyzE5Hla0rZO 21zn2FPoCo2lS5e2GGOukNS5gMt8KwiCszZs2LC1XLlQX+LWNlVjOKHPpKkF8zyjJYvaXMfAQcTi Vd9/iRpibaD87t0UM03a2UkFpX0dO6XIwNw0N3fuPOF9d73bdY65spcqltyoVwdGx1mjt2WlP0n6 oOtcewpdodHY2PgNzXMpn7X2amPMKcPDw4+VORbqjK1Cj0ahWFRqaqrSt6l5/b3Nam0p61A6VIBn YvK8OEvLcFBBUFQmM8FuClSFF4vbhuaON7rOMVsTX1Rf3uit1uhtOzbpLfLULUlGsgnpna7z7S1U hcbAwMAH57mU75ZSqbRuw4YNt5Y9FOqStbbJmMq+KzbOpKmy4NhUdCTijcrlKTTwjEIhM92YnUsp k55gNwWqrqNz8VdOOPGP97nOsT/WyoxfqJeUAr3NGr0tb/VyGXlG2vvh3VWda7TeScgDCE2hMTg4 +EJJ35jjpz1urV07MjIS6TN1CB8rNVWyzAiCQD6FRllQaERHLN4g5XmKV4+sgundFDNTn7LZlHKZ SZ5wwanmlu6NJ5x4x8muc+zNnq/Wnd70U4uxC/RXxmjJ7qJi3y9ObNzoM9VLOHuhKDSWLl3aZ4z5 paTmWX7Kk9baM0dGRr4nie9SKDuvwken/IkJFvSVCaNtoyMeo0+jHgSlwvSRp9yEMunUzG6KKUkc fUJ4xOOJUkdzy2td59hl/AIdWpTeZq3eNmb0eiM1StKsDldYXde1RndXOOK8hKHQiDc1Nf1c0oqD faC1Ninp7EKh8LXNmzczvgSVY23T7L6653NpSxN4GbGsLzqM8eTFEvtp4EUU5fNTz/RSzDRqF4s5 17GAg2prX3TaW957xyZX97dnqmFnm95gPb3NSscVpOdJkszcxxlYT+eUP2F5OC80hoaGzpc0m4ry wkKh8NnNmzfvrHQmoJJHp1KTkyqWWFxWLhydipZErEE5Co3IsUGgXHZCmVxK2fT01Kd8NqWA3RSI oJa2vntOOOmOL1b7vmMXaJk1epuxOm7M6s3GqFVa8Jy0P/afrBvLEK8inBYaAwMD75X0if39uZ3e rnOJtfbM0dHR0aoFAzyvYken6M0oryX9FBpREo83KkefRqgVi9ndPRSZ7HQ/RSGXdh0LKIuGxpZs Y2/imGrca+/xs5JeaGZOEJbt0EQQ3qcZksNCY9WqVUcYY/5jf39urb22WCyesmnTpgeqmQuQJFOh Ho1MNqtsjmMF5dLd1ajWVs79R0mMPo0Qscrlpqb3UuzeoD2hEk+cUKOMMbatve+ktx9/W8Uq5wOM ny07a3VX/yn6RQUuXTZOCo3ly5c3x2KxyyW17OOP75R02sjIyA1VjgXsZq3tqsR4252+X/Zr1jP6 M6LHGKN4vEHFYt51lLoSBMWZpxQpZWYKilxmSlYcfUL9aG9ffN3b33PbFeW85hzGz5ZdzKjqx7/m ykmhkUgkvqm9lvJZax8zxpw+PDz8czGaAu6V/YlGPp/XVJrjB+VEf0Y0xWIUGpXEbgrguRqb2yb+ +u/uPk7vX/i1dnxVHSroL+YwfrbsrPR493JdVp27zV/VC42BgYGP7rWUb7u19jMjIyMXi1G1CIlK HJ1KMmmq7BbTnxFJ8XijcrlJ1zEiz9pA+dyu3RTTR5+y2UmmegF78TzPtrf1HGfM/B/hjX1ZR9hA bzPScbao18ooIZWx12KOjNUXzLsU+skyVS00Vq5ceYzned+c+WXKWvvVVCp17tjYWKqaOYCDCaxt 9cr43aNUKmlikhdW5cYOjWiKeQlNv+3Hw+vZCoLC7hGymcz0EahcflKy/DsEDqato/+Hx737tlvm 8jn2TDUk2/XmQDpORm+T1YCrouI5rLb0rtAlrmPMRtUKjaGhoU5r7Q81/dTiO+l0+tPbtm3bXq37 A3Nhg6BVnle26/kTE7K8ICi7Fcvp0YgiY4ziiUaO8+xHPp9+9m4Kjj4B89bU3DH2jvf9aVYHpvY3 fjZsjHR+FJ5mSFUsNKy1P5B0ez6f/4vNmzevr9Z9gfmwxuxrUMG8BEGgcUbaVgSjbaMrHmuo+xfP 1paUy04+c+xppq/CBpF4/QCEXjzeUGprbH7D/v68KuNny8/vSeli1yFmqyqFxuDg4PHW2i+Mjo7+ sRr3AxbKM6a5XNeaSKVY0FcBrS0JRttGWDxeX//flUoFZTPjymYnlc2MK5dNKcduCqCi2jsWf/q4 E//40J6/V83xs5Vgrb5izlRk3qWpSqExMjJydTXuA5SLlcpSaFhrleRpRkUwcSraPBNXLfZpWFnl c+mZJxQT09OfsimVSkzZAqqptb334eNP/OPZLsfPVoAfK+jLrkPMhdPN4EBoWVuWQiOdyahQYAJM JbBDI9qMMUokmlQoZFxHmbcgKO1ecvfMwrtJWctuCsCl5kRD4eX+4+ePXaDvuho/WxFW3+o5TZEa YUmhAexbWcbbMtK2clYsY+JU1CXijZEpNAqF7PSSu+ykMpnpwqJQSCvar1qA2tFmi1oUZLXI5mx3 PucZ6btSqHst5sRKGXn6iuscc0WhAeyDkRoXeo1MNqt0JhovoqKIHRrRFwtln4bdPenp4LspauQV DBBBMVn1Bjn1Bzn126xa7O5eSCMp5jBaRRjp230na6vrHHNFoQHsizELLjR8nmZUFD0a0eeZmDwv psDRlKUgKE4fd8qklJk5ApXLTMnOf6cXgApqtiUtsln1l3LqtTnFaqzHa7+sitbTua5jzAeFBrBv C3qrtVAsKjU1Va4s2Ad6NGpDLN6gIF/5JyI4IgkAACAASURBVH+FQma6MTuXUiY9wW4KIAI8WXXb gvpLWS2yWbXZoutIbhj9qD+CTzMkCg1g34xZUKHB3ozKam1JqLurLG00cCwRa1RB5Ss0rILp3RQz U5+mn1hMKgjq9AUKEDENNtBim1V/Kas+m1O8Xp5a7J9NSJ9zHWK+KDSAfTALeKIRBIF8Co2K4thU 7YjF5l/TB6XC9Pbs3IQy6dTMboop1drIXKDWddqCFgVZ9Qc5dQb5mmngLpOrOtcosouuKTSAfTDG zPtrw5+YUBBwxruSKDRqh+fF5MUS+2m2fkY+P6VcNjVdWMw0aheLuSqlBFBOcVn1BTn1B1n1B1k1 7dkXRZGxJxs3+ozrEAtBoQHs5dhjj533mRxrLU3gVbCS/oyakog1KDdTaNggUC47oUwupWx6eupT PptSwG4KINJ2jZ/tD3Lqtnl5PHk8OKvrutbobtcxFoJCA3iueRcaqclJFUtuJujUk+VL2aFRSwrF rDZvvFfZbEqFfNp1HABlcIDxs5gl6+kc1xkWikID2EuL1DTf907pzagOjk7VlqbGdqUmnnIdA8AC 1e342Qqw0k39J+tG1zkWikID2EswzycamWxW2RxnxquBQqO2JBLNampqVzabch0FwBwwfrZyPEX/ aYZEoQE8RyA1efP4vJ2+X/YseK6W5rj6eppdx0CZtXUsotAAIqBRwXSvBeNnK8Za3dW3Vte4zlEO FBrAXmwi0SQ7t2+c+XxeU2nOllfDksVtisXmUwoizLo6l2rs6SdcxwCwFyOp0+bVX5qeEtWlA0+I w8LFjL7oOkO5UGgAe4lb2zTX92eSTJqqGo5N1abOrqWuIwCYkbCB+u2u8bM5NYipb9Vipce7l+sy 1znKhUID2IudY49GqVTSxORkpeJgL0v6KTRqUSLRpJaWLqXTHEEEXOiwheniopRVt82zzsIRY/UF 8y7VzIguCg1gL9baJjOHtaT+xITsHI9aYf6WL2O0ba3q6DqEQgOoEsbPhpDVlt4VusR1jHKi0AD2 YqWm2ZYZQRBonJG2VbWCZX01q6trqbZtedh1DKBmMX423Ix0fi09zZAoNIDn8OZwdGoilWJBX5XR o1G72tuXyBjDE0KgTBg/Gyl+T0oXuw5RbhQawN6sbdIsjk5Za5XkaUZVeZ5htG0Ni8Xiamnt0dTk DtdRgMhi/Gw0WauvmDOVdZ2j3Cg0gL3M9uhUOpNRocCYv2pauoTRtrWus/MQCg1gDhg/WxP8WEFf dh2iEig0gL153qyOTjHStvp6eZpR87q7l2vLkw+4jgGEGuNna4zVt3pOU02+qKDQAPZiZtGjkclm lc5kqhEHe7j3gaf1g5/er/e/5yjXUVAhrW398ry4goCz5MCeGD9bm6yUkaevuM5RKRQawF6stV0H G2/r8zTDmR9f/pB2JrP6+EeP1lzGECMaPM9Te3uvxsefch0FcCq+e/xsVouCnJpqaxgRZhjp230n a6vrHJVCoQE81wGfaBSKRaWmpqqVBftwzQ3DymQLWvuvr1RDIuY6DsqsvfMQCg3UpWZb0hKb3f3U gvGzNc6qaD2d6zpGJVFoAHs52NEp9maEw023bFLSz+nf1x2jttYG13FQRt3dK7R54z2uYwAVx/jZ Omf0o/4afpohSYxvAfYSWLvfRQ1BEMin0AiN+x58Wqd8+rfyx2tuImBda23tUaJh1utsgMiK20Av LuzUUDBJkVF/bEL6nOsQlUahAezFBsF+Cw1/YkJBwHSPMBndOK6T/88N2rI15ToKyqitvd91BKDi 8iamu+PdzIyqT1d1rtF61yEqjUID2Is1pmWfv28tTeAhtXXbpE7+PzdoZIPvOgrKpLNziesIQFUk vUY9FOt0HQPVZeNGn3EdohooNIC9eMbsc1lDanJSxRJTP8JqfCKnUz79W937AE3EtaCza7nrCEDV bIy1aqO3z/e4UIusrus6WXe7jlENFBrAXqy0z0KD3ozwm0oX9KnP/V433rzRdRQsUHNThxob93uK Eag5D8Y6NW4SrmOgCqync1xnqBYKDWBv1j6n0Mhks8rmci7SYI4KxUDnXPgH/eb6J1xHwQK1dyx2 HQGoGmuM7op3K8dLs5pmpZv6T9aNrnNUC3+bged6zribnT5n/6PmKxffqR/89H7XMbAAXZ1LXUcA qipr4jSH1zhP9fM0Q6LQAJ7DSI17/jqfz2sqnXYVBwvw48sf0oXfvEOlEj+2o6ize5nrCEDVJb1G PRrrcB0DFWCt7updo2tc56gmCg1gb8Y8q9BIMmkq0q65YVhnnXez8gUa+aMmkWhSUxMvuFB/RmJt etLbZ7sgIixm9EXXGaqNQgN4rt1rpkulkiYmJ11mQRncftdWfepzv9fkVN51FMxRRxd9GqhP99Mc XlOs9Hj3cl3mOke1UWgAezNmd6HhT0zIWusyDcqELeLR1N29wnUEwInAeDSH1xBj9QXzLtXdo3X+ 9gJ7MTNPNIIg0DgjbWsKW8Sjp6PjEBljXMcAnNjVHM7bXRFntaV3hS5xHcMFCg1gL8aYuCRNpFIs 6KtBu7aIP/r4DtdRMAuxWFwtrT2uYwDOJL1GPRZrdx0DC2Ck8+vxaYZEoQE8y7HHHtskSdZaJXma UbPGJ3Jad+bv2CIeEezTQL17ItZOc3hUWW3pSeli1zFcodAAnq1JktKZjAqFgussqKBcrsQW8Yjo ZswtQHN4VBldZM5U3TYHUmgAe2iZKTQYaVsf2CIeDe3tS+R5cdcxAKd2NYcXRM9ShPheXt90HcIl Cg1gD4HUlC8UtqUzGddRUEVsEQ83z/PU1t7rOgbgXNbEdQ/N4dFh9a2e01TX71xSaAB7CKSmiYmJ B1znQPWxRTzcOjqXuI4AhMJ2r4nm8AiwUsZ6+orrHK5RaAB7KHpeauf4+GbXOeAGW8TDq6trqesI QGg8EWvX06bRdQwcgJG+3X+ytrrO4RqFBrCH3/72t09KusNaW7eNW/WOLeLh1NraLy9Gnwawyz3x bk2Kr4lQsipao3NdxwiDmOsAQNgkk8k7Ojo6vuF5XkbSkZJaXGdCdT21fUq3371Vr33VcjU18YM8 DIwxmkg9rVyWZYuAJAXGaMxr0LIgw4u5sDG6pH+Nfug6RhjwdxPYh/Hx8WwymbyptbX1a57nbZV0 hDGm23UuVI8/ntMttz+pV7zkELW3c0QhDErFrHx/i+sYQGgUTEwpk9DSIMMsqrCwKiaM3n3Otdrp OkoYUGgABzAxMVH0ff8O3/cv6uzsfETSamPMIa5zoTomJ/O68ZaNeuHz+9XXy4Mt12LxBj217RHX MYBQSZu4jKRey3HPMLDSZT1r9W3XOcKCHg1gdoLR0dGfjoyMvFTSX1hrr3cdCNXBFvHwaG7uVKKh yXUMIHQe99poDg8Hm/B0nusQYcITDWCOksnksO/7l3R3d18hqdtae4QxhqK9hpVKVjfdvFFLl7Rr YGWn6zh1LZXarmymrsfSA89ljJ72mrQ4yKpBjOh2xuq6njU633WMMKHQAOYpmUw+nUwm/6u7u/v7 khKSjjLGJFznQmUEgdXNt21WU1Nczz+8z3WculUqFeQnmUAN7G1Xc/iKIMNxFUespw+ff61GXecI EwoNYIF83x/3ff/XM5Oqstbao4wxHOivUXff+5QymaJe9mIWyLnQ2NiirVsedB0DCKWCiSmjmJYw ob3qrHRT/xqd6TpH2FBoAGUyM6nqxra2tos8z3tK05OqulznQvk9/NgOje3I6OUvPUSex6yXaorF EhrbPqxikcZXYF9SXkKeteqhObyqPOmfzrtW613nCBsKDaDMZiZV3e77/te6u7sftdauNsbw9neN WT+S1PqRpI551XLFYhxUqKbJqR1KTyVdx0CdabSBmlVSu4rqsnn1BnktsjktCbK7d1mkQnJ6dodp UKctqFUl11HqgrW6q2+t1rnOEUa8FQdUweDg4F8aY9ZJepPrLCivF75gkf593TFqa21wHaVujG0f 1vrH/8d1DERYTFYNNlCDpv9J2ECNNlDClnb/XoMNnvUxBxJIujGxWFkTnvdv4zbQ6wrb1UyxUXmB /lffKfqF6xhhRKEBVNHQ0NBR1tpPSXqnMSH6iYQFGVjZqc+e8Xr199GaUw2FQlZ333mprLWuoyAk EtqjKNjjPxO7i4WSGhVMf1wQKG7K+3dni2nSPYmesl6zHDqCvF5d3KGY+FqpFCs93r9Gh7nOEVYU GoADg4ODq4wxp1prP2iMaXadBwvX19us8858o5Ye0u46Sl24/76rNTXJ4t1aZKRnPUlosKXdv07s o5hoUCDP8QvpW+N98r1wPtVcWkrrxSXfdYzaZfWhvrX6nusYYUWhATi0bNmy3oaGho9L+hdjTPje DsOcdHY06jOnv06HP6/XdZSaNzpyu7Ztfdh1DMxCTHafR5EagtL0kaVdTxpmeUwpbHyT0K2Jftcx DuiI4rgGgynXMWqP1ZbeFVpp3sX5tP2h0ABCYOnSpS0NDQ0f9jxvjaSVrvNg/hobY/rM6a/Ti45c 7DpKTfOTm/XIwze4jlGXXB9TCpt74t3a4oX7wbSxVq8s7mASVZkZq5N71+pC1znCjEIDCJfY0NDQ e6y164wxL3QdBvOTiHta+6+v1LGvpWaslFKpqDtv/zF9GgtkpD2eNjxTIDQqUCKY+e921xOHkhpt IMMrh90y8nRjYrFsBP6lNNiSjimM0RxeLlZbelNabc4US0sOIPxfGUCdGhgYeKvneeskvdF1FszP P77/RfrbE/7MdYya9eD9v1Yqtd11jFCJWasGU7vHlMLm0Vi7nohFpy+L5vCyOr1vjc5xHSLsKDSA kFu1atVLPM87Q9LfGGNY2BAx7zz+cH34Ay92HaMmbdr0Jz256T7XMSpq7+bnxpmG6OmiYXoUayJ4 poCI8wKyakoy+m1isQoR+7a8vJTWC2kOXyjfy2ug5zSNuw4SdhQaQESsXLlyKB6Pf3JmUlWT6zyY vbe+aUgf+8jLWOxXZqnUU3rw/mtcx5g1jinVlo1eix6Id7mOMS9HFn2tDNKuY0SWtTqrf63OdJ0j CvgWBkTMzKSqkyX9szGm23UezM4rXnaIPnXKMWpIsD6lXIIg0J23/0RBUHRy/5i1u48f7XrS0GhL zzyF2KNJeldRgdoQSPqfRL+mQrIJfK5oDp8/K2VieR3C04zZodAAImrp0qUtTU1N/1vSyZJWuM6D g2OLePk9/OA1Gh9/qizX4pgSZiusC/rmgubweftK3xp9wnWIqKDQAKIvPjg4+F5jzDpJR7oOgwNj i3h5bXnyfm3ccPdzfn/6mFJp91GkxpniIT5TKDTsespgS7uLC44pYbbCvKBvLjqCvF5THBOHOmfJ qmg9rew/WVtdR4kKvq0CNWTVqlXHeZ63zhjzBtdZsH9sEZ87r1SQKaRlCml5hbRMISMvn1Yxk5S/ 7RGOKaFqorCgby5WlqZ0ZIlTQLP0/b41+qDrEFFCoQHUoFWrVr0kFot9ylr7DiZVhVO9bxH3ipnd xcIzxUNayu1RSBTS039eTMs46sMA9haFBX1zRXP4LFgVE0ZHdK7RetdRooRCA6hhK1euHIrFYqca Yz4gqdF1HjxbY2NMZ5z8Gr3y6KWuoyyIscFznjSYQlrKz/xePq1YMS3lM/KKaZl8RoYnDoigKC3o mwtjrV5THFOnLbiOElrW6mf9a/Ue1zmipra+UgDs05IlS/qbmppONsb8kzEmmvMYa5TnGa37t1eF aou4KeVnioXppwqmOF0smJkCIjZTUJhdTxxKOdeRgaqI2oK+uWiyRR1TGFMjbwLsi40bHd11sp7b EIYDotAA6kh/f39be3v7RzQ9qWq56zx4RiW3iHNMCVi4qC7om4vuIKdXF3cEEv3he7myb43e4TpE FFFoAPUpPjAwcJLneZ+U9ALXYTCtElvETSGjtvsvU2LiybJeF6g3UV7QN1sNDS2ZP88Mn+qVgq+6 zhImxurVvWt1m+scUcTmKKA+Bb7v35tMJr/R3d19l7V2hTFmletQ9e7hx3ZobEdGL3/pIfK8Mr0P FEsov/hImUJa8dS28lwTqDNW0r3xLhVM7b5sMsbYjp5F73zpPzx5ybq3aFBSed/1iCgr3dS3Vp9z nSOqeDQG1Lnh4eFfjoyMvF7SyyX9wlrLAV2HrrlhWGedd7Oy2TIeX/JiSh/2Vk0d9hZZHmQDc/a0 1xTZLeCz1dbe/5vj333H1ZLUK/2TFf0IkuRJ57jOEGX8xAHwLMuXLz80kUicaoz5OzGpypnDDu3R Fz79hrJvEY8nR9T+wBUypXxZrwvUslpZ0Lc/jc1tE+/6+8e6jHlm3f2OL2lFIN1pjBa5zOaStbqr f62Odp0jyniiAeBZNm/evH5kZOTD6XR6haRzJbHJyYHH1u/UKZ/+rbaPlXe2fbF7UOMv+6BKTZ1l vS5Qq3yTqOkiw4vFbXtbz3F7FhmS1LtWmxrieq2R/l5Wn7fSTyXdKauko6hVZ4w+6zpD1PFEA8AB 9ff3t7W1tX3UGPMJSctc56k3ldoibgoZtT30CyWSo2W9LlBranFB3562ji2699Qz75lTP0byy+oq lfQ8z9PqwGq1pEOt0WpjtVpGh6gGXl9a6fH+NTrMdY6oi/xfBADVMzQ09CFr7TpjTGXmsGKfKrZF 3AZqefw6NW35U3mvC9SIWl3QJ0nWdOjGP8R0062Zs4aHh88s23UvUPPOQIOBp9We1Wo7U4RIWm2k AUnRaHax+lDfWn3PdYyoq72vHACVZgYHB99ujDlV0jGuw9SLSm4Rb9xyt1oeu057nZwA6l4tLugr 2U5de6PRH+/O/F7S50ZGRv67Wve2lyo2vkEri3GttlaHelarrdFqK62W1Wpj1FqtLAdipcf7lusI 8y6VXGeJOgoNAPM2NDR0tLX2U5JOMKYG3/ILmUpuEadJHHi2mlrQZ6VC0KVfXW/1pwey11lr/+/o 6Gjo9kJMnqcleU+HBp5W2+nCY7U0fTRLUpkf6e6flf6pf40urtb9ahkvDAAs2PLlyw+Nx+One573 Pkm12zUZEpXaIu6ld6j9gcsVS+8s+7WBqKmVBX3ZQreuvLZkH3o0d3UQBGdu2LAhkmcld3xVHUF+ ui/EzjwJkXSomS5Elqlcr2mttvSmtNqcqWxZrlfnKDQAlM3AwMASY8waY8z/ltThOk8te+fxh+sf 3/8ilf1BUjGn9gevoEkcdc1K+n2iP7K7M4yMpnJduuLXxeDx4fzlpVLprI0bNz7kOlel2K+qcUde g15Mq4Ng+imIlQ41RqtlNSgzpzfATu9bw+6McqHQAFB2PT09HR0dHR81xnzCGHOI6zy16g3HrNC6 f3uVYrEyH+2gSRx1brtp1B2Jqp3UKR/jKTXVrct+mS1t2FT8YaFQ+NzmzZvXu47lkj1Tnt+mFaWY VptgugCRpp+IzEzJ2rMJx/fyGug5jbHu5UKhAaCSEoODg++XdAqTqirjFS87RGec/Bo1NcXLfm2a xFGvbkv0aqeJzr5SYzztHO/S5b/MF5/cVvyOpC8MDw9vdJ0rCiYv1OJcSautp9U2ULJ/rX7pOlMt odAAUA1mYGDgBGPMqcaYV7sOU2sqtUVcmm4Sb3vwF/KKHFdGffBNQrcm+l3HmBXjxbR9R6cuvTKb e3pncHGpVDp3w4YNW13nAnah0ABQVUNDQ6+11q6T9HYmVZXPwMpOffaM16u/r6Xs1/ayvtrv+xlN 4qgLUVjQZ7yEtm3v0M+uyk7tTJa+lk6nv7Rt27btrnMBe+OHPAAnBgcHDzfGnCbpJEVlgVPI9fU2 67NnvF6DqyowKYcmcdSBsC/oM7GENm/p0E+vzIynJoMLgyC4cHR01HedC9ifcH4lAagbM5Oq1s5M qqqtzVgOtLYk9IVPv6H8W8QlmsRR88K6oM+LNeqJje269KqpHZmM/eLExMTXx8bGUq5zAQdDoQEg FHp6ejq6urr+2Vr7cWPMEtd5oqySW8SlmSbxx/9bxgYVuT7gQhgX9HmxJj36RKsuvXpyS6Fgzg+C 4OLR0VEaphAZFBoAwqZhcHDwA5qeVHWY6zBRVckt4pIUH9+stvsvo0kcNSNMC/qM16QHHmvVz389 NZrPB+eOjo5+R1LBdS5grig0AISVWbVq1Ts8z1tnjHmV6zBRVakt4hJN4qgdYVnQZ7wW3f1Ak666 duqxUsl+YXR09IeSSk5DAQtAoQEg9AYHB19vjFlnrT2OSVVzV7Et4hJN4qgJzhf0mVbdfm+Dfn19 5v4gCD4/Ojp6mSTOJiLy+IENIDIGBwcPl3SGMea9YlLVnFRsi7gkyar5iRvVvOm2ClwbqLw74j3a 7jVV/b5Wbbr5zoRu+H3mziAIPjc6Onpl1UMAFUShASByVqxYsTQej681xnxEUpvrPFFRyS3iktTw 1ANqfeRXNIkjUiYV1+8T/VIVH5YGatcNN8d1y+2Zm2cKjGurdnOgiig0AETW0NBQp7X2XyT9mzFm ses8UVDJLeISTeKInvtiXdocK/+iy30pBp265nfSHfdkr7fWfm50dPSmqtwYcIRCA0AtaBgYGPig 53mnSHqe6zBhV8kt4hJN4oiOqizos1K+1KVf/negex/K/dIYc9bw8PCdlbshEB4UGgBqiRkaGvob a+06Y8wrXIcJs4puEZekYk5tD1+thh2PV+b6QBlUckGfkdFUvltXXVsIHn4s/1/GmM8ODw/fX5Gb ASFFoQGgJg0MDBzred46SX/lOktYVXSL+IzmJ35HkzhCqWIL+oynVLpbl12dLW3YVPyxpM+PjIw8 Wt6bANFAoQGgpq1cufL5sVjstJlJVZXpgo6wSm8Rl2gSRziVe0GfMZ6SE9267OpccfPWwn8aYz43 PDy8sWw3ACKIQgNAXVixYsXSRCLxSUn/KCZVPYvnGX3sIy/TX715dcXuER/frLYHfy4vP1mxewCz Vc4FfcaLaWxnl372i0zuqR2lbwdBcPaGDRu2LjwlEH0UGgDqysykqo8ZYz4maZHrPGFSyS3ikmRy KbXff5nik09V7B7AbJRjQZ/xEto21qGfXZlJ79hZ+nomkzl/27Zt28sUEagJFBoA6tKhhx7aWCwW PzQzqapyb+VHTEW3iEtSqaC2h66kSRxOLWRBnxdLaNPWDv3055mJicnSV6y1F4yOjvpljgjUBAoN APXOGxwcfKcxZp2ko12HCYPKbhGfRpM4XJnvgj4v1qjhTe269MrJnVNp+6VUKnXR2NhYqkIxgZpA oQEAM1atWvVGz/NONca8xXUW1yq9RVyaaRJ/9DcyQbFi9wD29kCsUxtjrbP+eC/WpEeHW3XpVZPb CgVzXj6fv3jz5s2ZCkYEagaFBgDsZWZS1RnGmHerjidVHXZojz5z+uvU1Tm/IyazEUttU/v9l9Ek jqrIyNNNiUUKZjHS1vOa9MDjrfr5r6c2FAo61/O8765fvz5XhZhAzaDQAID9WLZs2fKGhoZPSvoH Y8zs3wKtIYcsadN5Z76xYlvEJZrEUT2zWdBnvBbd82Czrrou/XipZM8eHh6+RBKP3YB5oNAAgINY uXJldywW+9eZSVX9rvNUW8W3iEs0iaPiDrqgz7Tq9nsb9evr0w8EQfCF0dHRn0li+QuwABQaADBL hx56aGMQBP9grV1rjBlynaeaqrFFXJKaN9yq5pGbKnoP1Kf9LeizatMtdzXo+pvSd5VKpc9v2LDh F5petQFggSg0AGDuvIGBgf/P87x1kl7qOky1VGOLuCQlxh5T20NX0iSOstnXgr5A7brh5rhuuT1z a6lU+tyGDRt+4y4hUJsoNABgAYaGht5krV1njPlL11mqoRpbxCWaxFFeey7oKwaduuZ30p335n47 U2D8znE8oGZRaABAGQwNDR0l6XRr7buMMTHXeSqt0lvEJZrEUT53xHr0pF2iX/53oPsezv9K0pnD w8N3us4F1DoKDQAoo5lJVadK+ntjTOVGNYVAxbeIS1KpoNZHf6PGpx+s3D1Q01Jq0D9fM2Afebxw hTHmrOHh4ftdZwLqRc2/6wYA1ZRKpSZ83/9NR0fHNz3Py0g6UlJNFhwPP7ZDm7dM6DWvWCbPq1Cx 4cVU6D9cMjEl/A2VuQdq2g/vaLv9mvsa3zwyMvLNZDL5tOs8QD3hiQYAVNDy5cubE4nEP0haY4wZ dJ2nEqqxRVyiSRxzF1j5/UZLzRqxyRtwgCcaAFBBExMTRd/3b/d9/2udnZ0PS1ptjDnEda5yenLr pO6+7ym9+uXLKlpsBC29KvSsVsOO9TKlfMXug5pybutaXe86BFCveKIBAFU2ODj4F5LWGWPe7DpL OVVji7g03STe9uDPlZh4sqL3QbRZKZ3IaXnX6Uq6zgLUK55oAECV+b4/7Pv+Jd3d3VdYa3skHWHM /tYVR8fkZF7/84dNeskLF6u7q6lyN4o3Kr/4SHkZX/Gp7ZW7DyLNs/puzzpd7joHUM8oNADAkWQy +bTv+5d3d3d/X1JC0lHG7LFRLILSmaJuvHmj/ux5PVqyqK1yNzIeTeI4EGtjet/512iH6yBAPaPQ AADHfN8f933/162trRfH4/GstfbIKI/GLRQC3XTzRq0e6Nbype0VvVexa4WKbYvVMPa4jA0qei9E iNV1/Wv0FdcxgHpHoQEAIZFKpTLJZPLGtra2i4wxT0t6vjGmy3Wu+QgCq9/fukk93U163lBPZe81 0ySeSI7IK+Yqei9EgzH62HnXar3rHEC9o9AAgJCZmVT1R9/3L+ru7n7UWnuoMWaJ61xzZa30xzu3 qKkprucf3lfZezW2Kb/4SMXHNymWS1X0Xgg5q0f61upk1zEAUGgAQJjZZDJ5v+/7F3d2dt5mjFkq KXK7OO6+9yllMkW99EWLK7tFPJagSRyyRp8+/1rd6ToHAAoNAIgE3/efSCaTP+jo6LjKGLNrUlVk RpTv2iL+yqOXKhar4IAtmsTr3c4+r7/w6AAAD7FJREFU6QNnXSu2OgIhQKEBABEyPj6+zff9y7q7 u79vjGm01h5ljKnsSu4y2bBpQg8+MqbXvXqF4vHKTvPd3SS+4wkZW6rovRAiVl9tXatrXMcAMI1C AwAiyPf98WQy+avW1taLY7FYXtKRxphm17kO5qntU1XZIi5NN4nn+w9XYsd6msTrgJXSxujvzrtW NOkAIUGhAQARlkqlMr7v/66lpeVr8Xh8TNLzJXW6znUgO3ZmdMvtT+qYVyxXa0tl14bYRAtN4nXC s/pu31r9xHUOAM+IzPleAMCsxAcHB99jjFkn6SjXYQ6kr7dZnz3j9RpcVYUJvkFJrY/8So1PP1j5 e8EFaz0d0f8JPeo6CIBn8EQDAGpL4Pv+fclk8psdHR23G2OWGWMGXIfal6ptEZd2N4nbRLMSO0cq ey9UHwv6gFCi0ACAGjU+Pr7e9/3vz0yq6pP0Z2GbVFXNLeKSVOxYqkLnMjWMPUaTeA1hQR8QThQa AFDjZiZVXdrR0fFDz/OarLVHhmlSVTW3iEtS0NxNk3gtYUEfEFoUGgBQJ8bHx5PJZPKXTU1N347H 4wWFaFLVri3iQWD1oiMXV/5+u5rEJ7cplvUrfj9UDgv6gPCi0ACAOjM5OZn2ff+3LS0tF8Xj8R0K 0aSq+x/arrEdGb3y6KWV3SIuzWwSf4GCjK8GNolHFQv6gBCj0ACAOpVKpQrJZPK2ZDJ5UVdX1xPG mOdJWuQ61/qRZHW2iEuSMSr1H67RrY+or5RmFGPUsKAPCDUKDQBA4Pv+vclk8pvd3d13WmuXG2NW uQxUzS3ikrQ1M6knM2ktDrL8YIwKq6KMTmRBHxBefD8FAOyWTCYf933/e93d3b+S1GetPdzVpKqq bhEvFfVkcoue8prUF+TVoKCi90MZGF3St0aXuI4BYP8oNAAAz5FMJrckk8lLOzo6fmiMaTHGHCmp 6pOqdm0Rf8VLDlF7e2PF7tPQ0KytWx5UwcT0pNesTptXixh/G2LWenrP+ddoh+sgAPaPQgMAsF/j 4+NJ3/evbmxs/FYikSjNjMZtqmaGycm8brxlo45+8RJ1d1Xm1rFYQmPbh1Us5hUYoye9ZjUoUJct VOR+WCAW9AGRQKEBADioycnJdDKZvCGRSHy9oaFhpzHmBZI6qnX/XK5U8S3ik1M7lJ5KTv/CGG33 mpSTp36bo0k8ZFjQB0QDhQYAYNbS6XTe9/0/JJPJizo7O4eNMYdJ6q/GvSu9RdzaQDt3bHjW7417 DUqaBi2iSTw8WNAHREblR3kAAGpRYXR09HvDw8MvkHS8pJurctNioLPOu1m/uf6Jsl+7q2v5Pnd3 7PAadUuiX5PVb1HBPljDkSkgKniDBgCwIMlk8rFkMvmfM5OqFlV6UlWltoh7nqdkcqMK+cxz/qxo PJrEw4EFfUCEUGgAAMpiZlLVz9ra2n7keV7rzKSqiv2cqcQW8Ux6XJOTY/v8M5rEQ4AFfUCkUGgA AMpqYmJip+/7V3V2dv6HMaYk6ShJFRkXVf4t4lZjYyP7/+M9msT7aBKvLhb0AZFDoQEAqAjf9yeT yeT18Xj8aw0NDb6kFxhjyt7FXc4t4omGFm3b+rCsPfDCvnGvQWOmUYuDDD9Iq8RKl/Wv1X+6zgFg 9vj+CACoqJlJVbf6vn9Rd3f3qLX2MGNMWSdVlWuLuOd5Gh/folxu6qAfmzUxbfWa1R/k2CReedYY /cN51+pJ10EAzB6FBgCgWoJkMvkn3/e/0dXVdbcxZqWkleW6eLm2iGdzKaUmnprVx9IkXiVW1/Wt 1bmuYwCYGwoNAEDV+b7/aDKZ/G57e/v1xpg+SYeVY1JVObaIe56n7U/PfhdcYIy2xFrkWasem5/X PbF/VrrJkz503nWacJ0FwNxQaAAAnBkfH9/k+/5P29rafhSLxdolvUAL/Nm00C3iiUSLtm556KB9 Gnvb4TVqSjEtslmaxMvDyuqcvhX6YMuH5bsOA2DuKDQAAM5NTEzsTCaTV3Z2dv6HJGuMOUrSvM8/ 7doivnRJuwZWds7pc40xmph4Wrns3IcbpbwETeLlsdNI7+xbq2+ddZms6zAA5ofvgwCA0PB9f9L3 /f82xnyjoaFhXAuYVBUEVjfftlm9Pc163lDPnD63VMzK97fM57Y0iS/c7cbqz3vX6m7XQQAsDIUG ACB0MplMzvf9W3zfv6irq2uDpMNnejnmbD5bxGOJBj219ZH53E7SM03ibbaoNpZYz57VRb0pvbfl DCVdRwGwcBQaAIAwK/m+/yff97/e2dl5j6RVxpgVc73IXLeIJ+JNeuqpRxWU5l8kBMZoa6yZJvHZ sEoZ6aS+tbrgrBsZ3wXUCgoNAEAk+L7/iO/73+nq6vqtpH5Jz5vLpKq5bhFPpZ5WNrPwQUc0iR/U /QmjP+9eq1tcBwFQXhQaAIBI8X1/o+/7P+nu7v6pMaZNc5hUtWuL+KtfsUwNDQf+lFIxLz+5uQyJ aRLfL6vv9ab0jqbT9bTrKADKjzdXAACRtmLFiqXxeHyNMeYjkmbVOD6wslPn/N9j1dW5/10bhUJG d91xabliSpKabVEvLe5Up63zvg2rlIw+1rdG33cdBUDl8MYKACDSJiYmUr7vX2eM+XpTU1PKWvuC mScd++WP5w66RTwWS2hs+7CKxfL1VxSNpydNs1oDqV1127dxf8Loz3vW6HeugwCoLAoNAEBNyGQy uWQyefPMpKpNmp5U1bu/j5/NFvHJyTGl0+UbgJQrdOu/rm3SRb9pvPoth07d1tkcvLhsF48CjkoB dYWjUwCAWmWGhob+l7V2nTHmlfv7oNaWhP593TH7HH+7/en1emL9wnqUjYym8l264lfF4PHh/H+V SqUzN27c+JAkbb9AJxqr/5RRw4JuEnJWyhjpnzgqBdQXCg0AQM0bHBx8vTHmVGvtX+1rUlUi7mnt v75Sx7525bN+f0F9GsZTKt2ty67OljZsKv64UCh8ZvPmzev3/rAdX9arbaDLZbR0fjcKNys9Hivp b3o+qQdcZwFQXRQaAIC6MTg4eLikM4wx75WU2PvPP/7Ro/VXb179rN+7754rlU77s76HMZ6SE926 7OpccfPWwneNMZ8fHh7eeKDP2f5lHaJAvzJGL5n1jaLh8qBRH1r0L5p0HQRA9VFoAADqzooVK5bG YrFTPM/7sKRnNY6f+LfP1/vfc9TuX4+O3K5tWx8+6DWNF9PYzi797BeZ3FM7St8KguCcDRs2bJ1t JnuBmndIP5H017P/XxJSVnlJn+xbq6+6jgLAHQoNAEDdGhoa6rTW/oukfzPG7G7SeOubhvTxjx4t Y4ySyU169OHf7vcaxkto2/YO/eyqTHpnMvhaOp3+4rZt27bPJ4+1Mjsu0NkyOnU+nx8SGxXob/tO 0R2ugwBwi0IDAFD3Dj300MZisfhBz/NOkXSoJL3hmBVa92+vkhToztt/LGvtsz7HiyW0aUuHfvqL zERqKrgwCIIvj46Ozv6M1QFsv0AnSvp/Rmopx/Wq6PJ4Th/pOl3lG9UFILIoNAAAeIYZHBx8p6R1 xpiXv+jIRfr8p16vhx/6taYmd0qSvFijhje169Irp3akM/ZLExMTXxsbG0uVO0jyy3pxKdCvItEk zlEpAPtAoQEAwD4MDAwca4w59c8O63nrP3+wU+P+qB4dbtOlV6W2FQrmvHw+f/HmzZszlcwQkSZx jkoB2CcKDQAADmDlypXPP+Kw1nMfH84dIelLnud9d/369blq3d9eoOYdVv9PRidV656zZaXfJHI6 iaNSAPaFQgMAgAgY+5L+j4w+q3D87C5J+vfek3W2MbIH/WgAdSkM36wAAMAsbP+STpDRT1w2iVur bXGrd3efot+7ygAgGig0AACIEJdN4la6qdnTu9s+oaeqfW8A0eO5DgAAAGav+2TdYz0dLatbq3hb K6uz+5brTRQZAGaLJxoAAESQ/ZYSOyb1n5VuErdW2zyjD/Wu0TWVvA+A2kOhAQBAhFWySZyjUgAW gkIDAICIq0CTuJXVOb0r9GnzLpXKdE0AdYZCAwCAGpD8sl5csvq5pIEFXmqnkU7iqBSAhaLQAACg RoxfoJ6C1dUyes08L3G7sfrb3rXaVNZgAOoSU6cAAKgRnWu0s7dNx8rqR3P+ZKuLeif0OooMAOXC Ew0AAGrQrJvErVJG+lDvWv1XdZIBqBcUGgAA1KjtX9IJxugSSR37+ZD7E9LfdK7R+mrmAlAfKDQA AKhh2y/U4SbQNdq7Sdzqol6jU80aZZwEA1DzKDQAAKhxz2oS56gUAAAAgHIau0CfH/+Knuc6BwAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAID/vz04JAAA AAAQ9P+1I6wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFvD eNgTvNGwAgAAAABJRU5ErkJggg== "
-           id="image1587" />
-      </g>
-      <g
+           id="image1587" /></g><g
          transform="translate(-1584.2886,-1525.1556)"
-         id="g1602">
-        <g
+         id="g1602"><g
            transform="translate(1628.4971,151.51917)"
-           id="g1638">
-          <path
+           id="g1638"><path
              style="fill:#fefefe;stroke-width:0.81366"
              d="m 615.45139,161.9012 c 0.2235,-0.97046 2.06041,-9.79587 4.082,-19.61203 2.0216,-9.81616 3.80885,-17.98077 3.97167,-18.14359 0.40261,-0.40262 21.08238,28.72538 21.01503,29.60023 -0.0486,0.63152 -4.30659,2.09423 -23.17034,7.95954 l -6.30474,1.96033 z"
-             id="path1626" />
-          <path
+             id="path1626" /><path
              style="fill:#fefefe;stroke-width:0.81366"
              d="m 556.12657,196.95485 c -0.6884,-5.50606 -3.11282,-56.92855 -2.79915,-59.37098 0.30902,-2.40628 -2.63097,-4.96857 33.85936,29.50938 l 9.16555,8.6601 -19.51358,12.32978 c -10.73246,6.78138 -19.68598,12.32978 -19.8967,12.32978 -0.21072,0 -0.57769,-1.55613 -0.81548,-3.45806 z"
-             id="path1624" />
-          <path
+             id="path1624" /><path
              style="fill:#fefefe;stroke-width:0.81366"
              d="m 599.2586,648.62513 17.98275,-13.62813 6.02023,-13.49809 6.02023,-13.49808 29.17856,-14.15965 c 23.94565,-11.62024 29.3895,-14.56624 30.35477,-16.42681 1.63369,-3.14894 1.68075,-3.16757 3.59674,-1.42446 1.38146,1.25682 6.32986,2.19698 25.8387,4.90915 13.27151,1.84505 24.18505,3.30964 24.25232,3.25464 0.5321,-0.43493 39.14364,-82.34062 38.92137,-82.5629 -0.1587,-0.1587 -11.15911,2.87653 -24.44535,6.74497 -13.28624,3.86843 -24.2945,6.89581 -24.46279,6.72751 -0.1683,-0.16829 5.78679,-9.04596 13.23352,-19.72817 l 13.53952,-19.42217 -1.76071,-3.29266 c -0.96839,-1.81096 -15.60457,-28.55681 -32.52484,-59.43521 -26.88221,-49.05832 -30.55026,-56.16574 -29.06924,-56.32623 0.93219,-0.10102 22.93142,2.86118 48.88719,6.58266 25.95576,3.72148 47.34864,6.63799 47.53973,6.48113 0.19108,-0.15686 -0.25108,-0.73911 -0.9826,-1.29387 -0.7315,-0.55477 -36.48696,-28.83585 -79.45657,-62.84685 l -78.12657,-61.83818 8.37684,-7.86179 c 4.60727,-4.32398 9.52968,-8.83183 10.93869,-10.01744 l 2.56185,-2.15565 29.91682,3.65537 c 16.45426,2.01046 30.02108,3.55112 30.1485,3.42371 0.12741,-0.12742 -8.77926,-6.05202 -19.7926,-13.16578 l -20.02426,-12.93411 8.89884,-8.54344 8.89884,-8.54343 -37.3206,-77.2465 C 635.87215,68.069087 618.99381,33.230652 618.89105,33.135934 618.45237,32.731536 423.83773,11.370017 423.5399,11.693569 423.35916,11.889913 403.68684,53.9744 379.82363,105.21465 l -43.38765,93.16411 -2.07361,64.27916 c -1.14047,35.35354 -2.41931,64.81949 -2.84185,65.47989 -0.42254,0.6604 -11.4166,14.57399 -24.43125,30.91909 -21.74936,27.31503 -36.24102,45.68328 -68.06108,86.26775 -13.64415,17.40224 -51.01034,65.48176 -52.7228,67.83904 -1.37019,1.88614 -0.99579,1.68873 80.49076,-42.43976 33.78725,-18.29725 61.54323,-32.99244 61.67996,-32.65599 0.13673,0.33645 -0.50403,23.29135 -1.4239,51.01087 -0.91989,27.71953 -1.67252,53.30774 -1.67252,56.86268 v 6.46353 l 107.12426,49.50792 107.12425,49.50792 7.61261,-3.78156 c 4.18693,-2.07985 7.93777,-3.78155 8.3352,-3.78155 0.39742,0 5.96406,4.36638 12.3703,9.70307 6.40624,5.33669 12.02612,9.47568 12.48863,9.19776 0.4625,-0.27793 8.93315,-6.63798 18.82366,-14.13345 z"
-             id="path1622" />
-          <path
+             id="path1622" /><path
              style="fill:#d8cc77;stroke-width:0.81366"
              d="m 474.27953,591.19545 -63.87234,-58.10026 0.25529,-2.99884 c 0.3707,-4.35471 33.41306,-240.35348 33.69098,-240.6314 0.12862,-0.12862 13.86717,52.00457 30.53011,115.85154 39.34923,150.77343 42.69111,163.78458 42.195,164.28069 -0.2289,0.2289 -10.11156,1.20198 -21.96148,2.16241 -11.84991,0.96043 -21.76398,1.96492 -22.03127,2.2322 -0.26728,0.26728 12.83923,11.55676 29.12556,25.08775 l 29.61153,24.60178 3.31979,12.71291 c 1.82588,6.9921 3.24989,12.75534 3.16447,12.80719 -0.0854,0.0519 -28.89786,-26.05083 -64.02764,-58.00597 z m 255.33676,-8.91804 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.039 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -17.90053,-2.44098 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 325.58488,531.1658 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m 0.81366,-25.22346 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 0.83008,-24.81664 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66147 -0.19394,1.00691 -0.35262,0.18308 -0.35262,-1.83073 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35262,-1.83074 0.19394,1.00691 0.19394,2.65457 0,3.66148 -0.19394,1.0069 -0.35262,0.18307 -0.35262,-1.83074 z m 4.88197,-151.34081 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66148 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 0.81366,-25.22347 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83073 0.19395,1.0069 0.19395,2.65456 0,3.66147 -0.19393,1.0069 -0.35261,0.18307 -0.35261,-1.83074 z m 304.90099,-15.76675 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m -304.08733,-9.45671 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.0069 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18307 -0.35261,-1.83073 z m 378.54545,1.61405 c 0.28109,-0.45482 0.85192,-0.61629 1.26851,-0.35881 1.12858,0.69749 0.91814,1.18574 -0.51108,1.18574 -0.69768,0 -1.03852,-0.37212 -0.75743,-0.82693 z m -7.07688,-0.54255 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42736 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49159 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58736,-0.23505 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81366 c 0.58735,-0.23505 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -35.64849,-0.56505 c 0,-0.16896 0.64075,-0.80971 1.4239,-1.42391 1.29052,-1.01208 1.31929,-0.9833 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m 29.1392,-0.24861 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -7.37379,-0.79672 c 0.55939,-0.22571 1.47476,-0.22571 2.03415,0 0.55939,0.22572 0.10171,0.41041 -1.01708,0.41041 -1.11878,0 -1.57646,-0.18469 -1.01707,-0.41041 z m -6.45843,-0.8306 c 0.58736,-0.23505 1.28915,-0.20615 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.50928,-0.81367 c 0.58735,-0.23504 1.28914,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.21021,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z M 336.17889,203.66755 c 0,-2.01381 0.15868,-2.83764 0.35261,-1.83074 0.19395,1.00691 0.19395,2.65457 0,3.66147 -0.19393,1.00691 -0.35261,0.18308 -0.35261,-1.83073 z m 339.88838,0.50645 c 0,-0.16895 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.30721,0.3072 -1.06295,1.35536 -1.73112,1.78638 -1.73112,1.1167 z M 555.9501,200.03292 c -0.25193,-0.65651 -0.30103,-1.66342 -0.10911,-2.23757 0.19191,-0.57415 0.54183,-0.037 0.77758,1.19365 0.46032,2.40292 0.0806,2.99593 -0.66847,1.04392 z m 132.32208,-7.25016 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01208 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -133.31182,-9.45672 c 0,-1.11878 0.18469,-1.57647 0.4104,-1.01707 0.22572,0.55939 0.22572,1.47475 0,2.03415 -0.22571,0.55939 -0.4104,0.1017 -0.4104,-1.01708 z m 34.37479,-14.03564 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.8525 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -35.25268,-1.89854 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 20.60679,-11.93368 -1.55001,-1.83074 1.83073,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55002,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m -21.42045,-3.52586 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m 6.38346,-10.7132 -1.97257,-2.23756 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15264,-1.00691 -2.23756,-2.23757 z m -7.13289,-5.08537 c 0,-1.11879 0.18469,-1.57647 0.4104,-1.01708 0.22572,0.55939 0.22572,1.47476 0,2.03415 -0.22571,0.55939 -0.4104,0.10171 -0.4104,-1.01707 z"
-             id="path1616" />
-          <path
+             id="path1616" /><path
              style="fill:#cabe5e;stroke-width:0.81366"
              d="m 530.75161,642.84068 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.13661 -1.55002,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11145,-1.55002 z m -8.52772,-7.72977 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84366 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 14.60368,-6.50928 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -23.55394,-1.62732 -1.97257,-2.23757 2.23757,1.97257 c 2.09134,1.84366 2.6107,2.50256 1.97257,2.50256 -0.14575,0 -1.15265,-1.0069 -2.23757,-2.23756 z m 18.67198,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.0683 c -1.01209,-1.29052 -0.98331,-1.3193 0.30721,-0.30721 1.35535,1.06294 1.78637,1.73111 1.1167,1.73111 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.4239 z m -22.74028,-1.62732 -1.97257,-2.23757 2.23757,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97256,2.50257 -0.14574,0 -1.15265,-1.0069 -2.23756,-2.23756 z m 17.85832,-2.44098 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -4.88196,-4.06831 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -21.92663,-1.62732 -1.97256,-2.23756 2.23756,1.97256 c 2.09135,1.84367 2.61071,2.50257 1.97257,2.50257 -0.14574,0 -1.15265,-1.00691 -2.23757,-2.23757 z m 17.04466,-2.44098 c -1.01208,-1.29051 -0.9833,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73112,-1.1167 z m -4.88196,-4.0683 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.3072 0.78315,0.61419 1.4239,1.25494 1.4239,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -20.72185,-1.22049 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 15.83989,-2.84781 c -1.01209,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 1.35535,1.06295 1.78637,1.73112 1.1167,1.73112 -0.16896,0 -0.80972,-0.64076 -1.42391,-1.42391 z m -24.79015,-5.28879 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 10.95793,-6.10245 c -1.01209,-1.29052 -0.98331,-1.3193 0.3072,-0.30721 0.78315,0.61419 1.42391,1.25495 1.42391,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -19.9082,-2.03415 -1.55001,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z m 15.02624,-2.03416 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m 0.32268,-3.20825 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0968,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 9.76393,-0.81366 c 0.79166,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m -34.06311,-2.08054 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m 43.82703,1.26688 c 0.79167,-0.2063 1.89011,-0.19273 2.44098,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.00159,-0.40524 z m 10.57758,-0.81366 c 0.79167,-0.2063 1.89011,-0.19273 2.44099,0.0302 0.55087,0.22288 -0.0969,0.39167 -1.43939,0.37509 -1.34254,-0.0166 -1.79326,-0.19894 -1.0016,-0.40524 z m 8.73137,-0.56178 c 0,-0.17159 0.91537,-0.48696 2.03415,-0.70083 1.11878,-0.21387 2.03415,-0.0735 2.03415,0.31198 0,0.38545 -0.91537,0.70083 -2.03415,0.70083 -1.11878,0 -2.03415,-0.14039 -2.03415,-0.31198 z m -72.08624,-8.02804 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82384 -1.83073,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z m 89.97764,-15.94255 C 505.1846,521.1947 491.46956,468.2441 474.7119,404.26794 457.95424,340.29179 444.31937,287.9002 444.41218,287.84218 c 0.0928,-0.058 25.61597,4.07623 56.71813,9.18719 43.68682,7.17897 56.91954,9.6216 58.17671,10.73886 0.89503,0.79542 45.48591,38.30942 99.09084,83.36445 56.63281,47.59994 97.84546,81.68217 98.3752,81.35477 0.51955,-0.3211 0.68647,-0.19907 0.38809,0.28373 -0.28797,0.46596 0.0516,1.32453 0.75453,1.90794 1.07186,0.88956 -18.97326,4.83342 -124.2136,24.43885 -69.02044,12.85797 -126.16936,23.55533 -126.99759,23.77192 -1.01588,0.26566 -1.50884,-0.0448 -1.515,-0.95394 z"
-             id="path1614" />
-          <path
+             id="path1614" /><path
              style="fill:#ed8e00;stroke-width:0.81366"
              d="m 559.92226,646.50215 c -30.89503,-25.35456 -87.13957,-72.19328 -86.93957,-72.40059 0.15887,-0.16467 54.14597,-4.64838 148.16252,-12.30512 15.66296,-1.2756 28.62852,-2.19237 28.81235,-2.03726 0.30868,0.26043 -9.9116,23.5602 -26.00362,59.28193 -3.62874,8.05524 -7.13932,15.24722 -7.80127,15.98219 -1.30072,1.44416 -35.68355,27.54864 -36.28499,27.54864 -0.20024,0 -9.17568,-7.23141 -19.94542,-16.06979 z m 156.62352,-66.14344 c -11.97158,-1.69742 -22.1298,-3.20811 -22.57384,-3.35707 -1.38845,-0.46582 -32.53471,-40.08008 -31.91642,-40.59382 0.3225,-0.26796 16.14761,-4.97324 35.16692,-10.45616 19.01931,-5.48292 45.67559,-13.18256 59.23617,-17.11029 18.88877,-5.47101 24.53913,-6.83552 24.15762,-5.83385 -0.27388,0.71912 -8.9879,19.15717 -19.36447,40.97343 -17.67114,37.15274 -18.99553,39.65955 -20.90299,39.56496 -1.12007,-0.0556 -11.83141,-1.48977 -23.80299,-3.1872 z m -7.93209,-350.32516 c -0.67127,-0.16281 -25.75235,-3.23328 -55.73573,-6.82326 -29.98339,-3.58998 -55.55997,-6.80116 -56.83686,-7.13595 -2.3102,-0.60572 -2.2366,-0.70773 14.97065,-20.74681 9.51074,-11.07595 17.64526,-20.13809 18.0767,-20.13809 0.68832,0 82.78014,52.92946 84.77334,54.6584 0.75427,0.65426 -2.79799,0.77996 -5.2481,0.18571 z"
-             id="path1612" />
-          <path
+             id="path1612" /><path
              style="fill:#a99b26;stroke-width:0.81366"
              d="m 535.79842,637.95731 c -1.7419,-6.82381 -3.36664,-12.94132 -3.61053,-13.59448 -0.36714,-0.98323 16.078,12.20797 21.33503,17.11353 1.4893,1.38975 1.29999,1.55591 -5.88278,5.16332 -4.08189,2.05004 -7.70354,3.72672 -8.04812,3.72595 -0.34458,-7.8e-4 -2.05169,-5.58452 -3.7936,-12.40832 z m 95.758,-35.69954 c 1.0647,-2.40451 5.7153,-12.88731 10.33467,-23.29513 4.61938,-10.40781 8.24888,-19.05132 8.06555,-19.20781 -0.18333,-0.15647 -28.70973,2.04311 -63.392,4.88798 -34.68227,2.84487 -64.32966,5.08081 -65.88309,4.96876 l -2.82442,-0.20373 -6.00656,-23.03738 c -3.30361,-12.67055 -5.87717,-23.15577 -5.71902,-23.30048 0.54437,-0.49809 250.69056,-46.89436 251.45601,-46.63922 0.53919,0.17973 -24.23019,37.01189 -26.56024,39.49519 -0.11337,0.12083 -15.65689,4.72443 -34.54116,10.23025 -18.88427,5.5058 -34.37372,10.304 -34.42101,10.66266 -0.0473,0.35865 6.37973,8.81415 14.28226,18.78999 l 14.36824,18.1379 -1.42024,2.47462 c -1.19495,2.08208 -5.87073,4.62496 -29.47588,16.0302 -15.43061,7.45556 -28.53788,13.74062 -29.12728,13.96679 -0.70766,0.27156 -0.41416,-1.07363 0.86417,-3.96059 z m 27.37153,-210.70145 c -54.34399,-45.68306 -99.45179,-83.68476 -100.23955,-84.44823 -1.3583,-1.31643 0.48194,-2.96264 35.62584,-31.86942 20.38196,-16.7647 37.32004,-30.56596 37.64017,-30.66945 0.47911,-0.15489 60.09032,107.8891 61.11142,110.76311 0.30299,0.85279 60.42231,111.09717 63.60686,116.63969 0.83566,1.45442 1.41659,2.6444 1.29096,2.6444 -0.12564,0 -44.6917,-37.37705 -99.0357,-83.0601 z M 627.90876,220.19859 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z"
-             id="path1610" />
-          <path
+             id="path1610" /><path
              style="fill:#686464;stroke-width:0.81366"
              d="m 454.64789,574.08638 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25494 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01209,-1.29052 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.61419 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -111.12384,-18.9176 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23066 -0.33896,0.22376 -0.33896,-2.23756 z m 0.81366,-25.22347 c 0,-2.46132 0.15253,-3.46823 0.33896,-2.23757 0.18643,1.23066 0.18643,3.24447 0,4.47513 -0.18643,1.23067 -0.33896,0.22376 -0.33896,-2.23756 z m 0.80255,-24.81664 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0111 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23682 0.18203,3.06755 -0.0111,4.06831 -0.19313,1.00075 -0.34615,-0.0111 -0.34005,-2.24876 z m 0.76971,-24.00298 c 0,-1.56629 0.16746,-2.20705 0.37212,-1.4239 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37212,0.14239 -0.37212,-1.42391 z m 372.31508,-82.7355 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z m -5.69562,-0.81366 c 0.58736,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23185 -0.49159,-0.49158 z M 332.93535,312.29119 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 0.81366,-25.22347 c 0.007,-2.23756 0.16413,-3.05636 0.35115,-1.81954 0.18703,1.23681 0.18203,3.06754 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24876 z m 56.58091,-44.48117 c -29.23368,-24.2409 -53.09794,-44.47053 -53.03168,-44.95473 0.21219,-1.55069 85.8061,-184.735319 86.71374,-185.581266 0.59477,-0.554338 0.70093,-0.507211 0.33312,0.147867 -0.38389,0.683686 16.07957,233.234119 19.21461,271.411249 0.13781,1.67817 0.17672,3.05122 0.0865,3.05122 -0.0902,0 -24.08256,-19.83345 -53.31625,-44.07434 z m -55.76725,19.25771 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 0.81366,-25.22347 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00075 -0.34615,-0.0112 -0.34005,-2.24875 z m 308.14453,-2.44098 c 1.05105,-1.11879 2.09406,-2.03415 2.31782,-2.03415 0.22376,0 -0.45311,0.91536 -1.50416,2.03415 -1.05104,1.11878 -2.09406,2.03415 -2.31781,2.03415 -0.22376,0 0.45311,-0.91537 1.50415,-2.03415 z M 336.18999,211.39732 c 0.007,-2.23757 0.16413,-3.05636 0.35115,-1.81955 0.18703,1.23681 0.18203,3.06755 -0.0111,4.0683 -0.19313,1.00076 -0.34615,-0.0112 -0.34005,-2.24875 z m 343.94559,-11.39124 c 1.05104,-1.11879 2.09406,-2.03415 2.31781,-2.03415 0.22376,0 -0.45311,0.91536 -1.50415,2.03415 -1.05105,1.11878 -2.09406,2.03415 -2.31782,2.03415 -0.22376,0 0.45311,-0.91537 1.50416,-2.03415 z m 10.57758,-9.6643 c 0,-0.16896 0.64076,-0.80972 1.4239,-1.42391 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.30721 -1.06294,1.35535 -1.73111,1.78637 -1.73111,1.1167 z m -135.6925,-2.94744 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z M 554.207,171.9348 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 31.08597,-6.7127 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.89899,-2.38979 z m -31.89963,-8.74685 c 0,-1.56629 0.16745,-2.20705 0.37211,-1.4239 0.20465,0.78314 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.42391 z m 16.8543,-5.4922 -2.80401,-3.05123 3.05122,2.80401 c 1.67818,1.5422 3.05123,2.91526 3.05123,3.05123 0,0.62132 -0.68854,0.036 -3.29844,-2.80401 z m -17.66796,-9.96734 c 0,-1.5663 0.16745,-2.20706 0.37211,-1.42391 0.20465,0.78315 0.20465,2.06466 0,2.84781 -0.20466,0.78315 -0.37211,0.14239 -0.37211,-1.4239 z m 2.60786,-4.27172 -2.3898,-2.6444 2.6444,2.3898 c 1.45442,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.62861 -0.67137,0.0752 -2.89899,-2.38979 z M 610.00823,32.243072 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270372 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.20614 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58736,-0.235043 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270371 -0.2102,0.46268 -1.06793,0.42735 -0.94787,-0.03905 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55951,0.0642 0.27037,0.270379 -0.2102,0.462679 -1.06793,0.42735 -0.94787,-0.03906 -1.14067,-0.231844 -0.49158,-0.491581 z m -7.32295,-0.81366 c 0.58736,-0.235042 1.28915,-0.206141 1.55952,0.0642 0.27037,0.27038 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231844 -0.49159,-0.491581 z m -7.32294,-0.813661 c 0.58736,-0.235042 1.28915,-0.20614 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94787,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z m -7.32294,-0.81366 c 0.58735,-0.235042 1.28914,-0.206141 1.55952,0.0642 0.27037,0.270379 -0.2102,0.46268 -1.06793,0.427351 -0.94788,-0.03906 -1.14067,-0.231845 -0.49159,-0.491581 z"
-             id="path1608" />
-          <path
+             id="path1608" /><path
              style="fill:#474343;stroke-width:0.81366"
              d="m 537.33,649.5401 c -0.28109,-0.45481 -0.9085,-0.58131 -1.39424,-0.28111 -0.53983,0.33363 -0.64796,0.16528 -0.27816,-0.43307 0.46325,-0.74956 0.87394,-0.75567 1.75304,-0.0261 1.15148,0.95565 1.45946,1.5672 0.78924,1.5672 -0.19735,0 -0.5888,-0.37212 -0.86988,-0.82693 z m -9.01937,-8.32674 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.95027,-8.13661 -1.55001,-1.83073 1.83074,1.55001 c 1.0069,0.85251 1.83073,1.67634 1.83073,1.83074 0,0.65113 -0.65482,0.17042 -2.11146,-1.55002 z m -8.95026,-8.1366 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55001 c 1.72043,1.45664 2.20114,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83073 z m 143.68834,-5.08538 c 1.11878,-0.63955 2.4003,-1.16283 2.84781,-1.16283 0.44751,0 -0.10171,0.52328 -1.22049,1.16283 -1.11878,0.63955 -2.4003,1.16282 -2.84781,1.16282 -0.44751,0 0.10171,-0.52327 1.22049,-1.16282 z m -152.63861,-3.05123 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83074 1.83074,1.55002 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97824,-0.82384 -1.83074,-1.83074 z m 187.626,-1.42391 c 0.67127,-0.43381 1.58664,-0.78873 2.03415,-0.78873 0.44751,0 0.26444,0.35492 -0.40683,0.78873 -0.67127,0.43382 -1.58664,0.78874 -2.03415,0.78874 -0.44751,0 -0.26444,-0.35492 0.40683,-0.78874 z m -196.57626,-6.71269 -1.55002,-1.83074 1.83074,1.55002 c 1.0069,0.8525 1.83073,1.67633 1.83073,1.83073 0,0.65113 -0.65482,0.17042 -2.11145,-1.55001 z m -8.56992,-7.72978 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95026,-8.1366 c -1.01209,-1.29051 -0.98331,-1.31929 0.3072,-0.3072 0.78315,0.61419 1.42391,1.25495 1.42391,1.4239 0,0.66968 -0.66817,0.23866 -1.73111,-1.1167 z m -8.95027,-8.1366 c -1.01208,-1.29051 -0.98331,-1.31929 0.30721,-0.30721 0.78315,0.6142 1.4239,1.25495 1.4239,1.42391 0,0.66967 -0.66817,0.23865 -1.73111,-1.1167 z m -8.51695,-7.72977 -1.55001,-1.83074 1.83074,1.55002 c 1.72043,1.45663 2.20114,2.11145 1.55001,2.11145 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83073 z M 325.74885,541.7314 c 0.39493,-7.3419 2.15104,-62.67352 3.07267,-96.81358 0.20916,-7.74798 0.31681,-8.18782 2.2538,-9.20885 1.11878,-0.58973 10.90784,-5.86715 21.75348,-11.72759 18.43432,-9.961 19.74514,-10.81902 20.11539,-13.16682 0.47844,-3.0338 12.6638,-140.97437 12.65357,-143.24068 -0.006,-1.29008 -0.72025,-0.90295 -3.75383,2.03415 -4.87689,4.72178 -24.80153,27.83844 -38.05666,44.15349 -5.74714,7.07386 -10.58243,12.72849 -10.74508,12.56583 -0.28824,-0.28822 3.50624,-121.94487 3.92494,-125.83969 0.1847,-1.71807 6.69597,3.41796 52.86574,41.70009 28.9603,24.01271 52.82929,43.65948 53.04221,43.65948 0.21292,0 0.53698,-1.18997 0.72014,-2.64439 0.18317,-1.45442 0.26009,-0.81366 0.17095,1.4239 -0.13804,3.46458 -8.88658,23.44784 -58.95363,134.66078 -32.33535,71.82586 -58.96096,130.77015 -59.16802,130.98732 -0.20706,0.21717 -0.16012,-3.62737 0.10433,-8.54344 z m 95.97228,2.65638 -1.55001,-1.83073 1.83073,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55002,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83074,-1.83074 z m -8.95026,-8.1366 -1.55002,-1.83073 1.83074,1.55001 c 1.72044,1.45663 2.20115,2.11146 1.55001,2.11146 -0.1544,0 -0.97823,-0.82383 -1.83073,-1.83074 z M 788.35239,369.33447 c 0,-0.17589 0.56824,-0.53783 1.26275,-0.80435 0.7241,-0.27786 1.0507,-0.14145 0.76564,0.31978 -0.47783,0.77315 -2.02839,1.14356 -2.02839,0.48457 z M 442.75196,271.60818 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18724,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z M 441.9383,261.0306 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 192.08986,-4.86752 c 0,-0.66333 0.94588,-2.03638 2.10196,-3.05123 l 2.10195,-1.84517 -2.03415,2.30311 c -1.11878,1.26672 -1.9121,2.48721 -1.76293,2.71221 0.14917,0.22499 0.11866,0.56164 -0.0678,0.7481 -0.18647,0.18647 -0.33903,-0.2037 -0.33903,-0.86702 z m -192.90352,-6.52372 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 206.87135,-7.72977 c 0.80999,-0.89503 1.65579,-1.62732 1.87954,-1.62732 0.22376,0 -0.25588,0.73229 -1.06588,1.62732 -0.80999,0.89502 -1.65578,1.62732 -1.87953,1.62732 -0.22376,0 0.25588,-0.7323 1.06587,-1.62732 z m -207.68501,-2.84781 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 193.2934,-6.65828 c 0.58735,-0.23504 1.28915,-0.20614 1.55952,0.0642 0.27037,0.27037 -0.2102,0.46268 -1.06793,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -194.10706,-4.73297 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77794 -0.3629,-0.0502 -0.35386,-1.84022 z m 160.74699,0.66467 c 0.58735,-0.23504 1.28914,-0.20614 1.55951,0.0642 0.27038,0.27037 -0.2102,0.46268 -1.06792,0.42735 -0.94788,-0.0391 -1.14067,-0.23184 -0.49159,-0.49158 z m -6.35672,-1.11952 c 0,-0.47393 0.36614,-0.63539 0.81366,-0.35881 0.44751,0.27658 0.81366,0.66434 0.81366,0.86168 0,0.19735 -0.36615,0.35881 -0.81366,0.35881 -0.44752,0 -0.81366,-0.38776 -0.81366,-0.86168 z m 3.25464,-4.32749 c 0,-0.16895 0.64075,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z M 437.87,204.88804 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.3629,-0.0502 -0.35386,-1.84022 z m 163.34053,0.91328 c 0,-0.16895 0.64076,-0.80971 1.4239,-1.4239 1.29052,-1.01209 1.3193,-0.98331 0.30721,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 4.88196,-5.69562 c 0,-0.16896 0.64076,-0.80971 1.42391,-1.4239 1.29051,-1.01209 1.31929,-0.98331 0.3072,0.3072 -1.06294,1.35536 -1.73111,1.78638 -1.73111,1.1167 z m 77.70456,-3.7611 c 0.80999,-0.89502 1.65578,-1.62732 1.87954,-1.62732 0.22375,0 -0.25589,0.7323 -1.06588,1.62732 -0.80999,0.89503 -1.65579,1.62733 -1.87954,1.62733 -0.22376,0 0.25589,-0.7323 1.06588,-1.62733 z m -246.74071,-2.03415 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35386,-1.84023 z m 117.83979,-3.32244 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z m -118.65345,-8.0688 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77794 -0.3629,-0.0502 -0.35387,-1.84022 z m 117.83979,-7.39074 c 0.0391,-0.94788 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z m 40.9483,-1.35611 -1.55001,-1.83073 1.83073,1.55001 c 1.00691,0.85251 1.83074,1.67634 1.83074,1.83074 0,0.65113 -0.65483,0.17042 -2.11146,-1.55002 z m -159.60175,-2.64439 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41441 0.19462,1.01212 0.18723,2.4767 -0.0164,3.25464 -0.20366,0.77793 -0.3629,-0.0502 -0.35387,-1.84023 z m 145.79564,-0.61024 -2.38979,-2.6444 2.6444,2.3898 c 1.45441,1.31438 2.64439,2.50436 2.64439,2.64439 0,0.6286 -0.67137,0.0752 -2.899,-2.38979 z m -27.14219,-0.27122 c 0.0391,-0.94787 0.23185,-1.14067 0.49158,-0.49159 0.23504,0.58736 0.20614,1.28915 -0.0642,1.55952 -0.27037,0.27037 -0.46268,-0.2102 -0.42735,-1.06793 z M 433.8017,149.55914 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m 131.54619,-3.45806 -1.97256,-2.23756 2.23756,1.97256 c 2.09134,1.84367 2.6107,2.50257 1.97257,2.50257 -0.14575,0 -1.15265,-1.00691 -2.23757,-2.23757 z m -12.89274,-1.4917 c 0.0391,-0.94788 0.23184,-1.14067 0.49158,-0.49159 0.23504,0.58735 0.20614,1.28914 -0.0642,1.55951 -0.27037,0.27038 -0.46268,-0.2102 -0.42735,-1.06792 z M 432.98804,138.1679 c 0.009,-1.79006 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-10.57759 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25465 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z m -0.81366,-11.39124 c 0.009,-1.79005 0.17566,-2.42654 0.37028,-1.41442 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84022 z m -0.81366,-11.39125 c 0.009,-1.79005 0.17566,-2.42653 0.37028,-1.41441 0.19462,1.01212 0.18723,2.47671 -0.0164,3.25464 -0.20365,0.77793 -0.36289,-0.0502 -0.35386,-1.84023 z M 429.7334,94.230241 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391244 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 427.29242,60.87017 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414419 0.19462,1.012121 0.18723,2.476709 -0.0164,3.254642 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z M 425.6651,38.087683 c 0.009,-1.790053 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-10.577584 c 0.009,-1.790052 0.17566,-2.426538 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476709 -0.0164,3.254641 -0.20365,0.777933 -0.36289,-0.0502 -0.35386,-1.840223 z m -0.81366,-11.391243 c 0.009,-1.790053 0.17566,-2.426539 0.37028,-1.414418 0.19462,1.01212 0.18723,2.476708 -0.0164,3.254641 -0.20365,0.777932 -0.36289,-0.0502 -0.35386,-1.840223 z"
-             id="path1606" />
-          <path
+             id="path1606" /><path
              style="fill:#212121;stroke-width:0.81366"
              d="M 431.32579,600.8968 C 330.01805,554.11766 326.13757,552.24573 326.41154,550.28682 c 0.28417,-2.03182 116.28364,-260.49411 116.7169,-260.06083 0.20821,0.20821 -32.53324,235.67376 -33.45866,240.62347 -0.36185,1.93543 5.28726,7.28799 63.43218,60.10243 56.19895,51.04686 64.56575,58.74763 63.62599,58.56111 -0.11188,-0.0222 -47.54285,-21.8995 -105.40216,-48.6162 z M 187.87111,512.45482 c 0,-0.4171 20.70122,-27.22253 52.47148,-67.94383 26.33584,-33.75579 75.58157,-95.95614 102.7006,-129.71709 12.63865,-15.73408 33.66382,-40.22181 38.7966,-45.18587 3.03769,-2.93782 3.75213,-3.32455 3.75797,-2.03415 0.0102,2.27047 -12.17563,140.21031 -12.65472,143.24682 -0.37241,2.36037 -1.70365,3.22416 -21.31772,13.83222 -11.50629,6.22305 -21.85828,11.72213 -23.00443,12.22019 -2.08092,0.90425 -130.7428,70.32107 -137.29173,74.07286 -1.90193,1.08959 -3.45805,1.76857 -3.45805,1.50885 z M 741.97376,362.55905 693.56097,355.6059 663.13353,299.93669 c -20.74911,-37.96203 -30.76865,-55.53829 -31.50018,-55.25757 -0.59001,0.22641 -17.63334,14.03966 -37.87408,30.69613 l -36.80134,30.28447 -56.18851,-9.18258 c -30.90367,-5.05043 -56.25792,-9.24203 -56.34279,-9.31469 -0.0849,-0.0727 -4.67032,-61.81947 -10.18991,-137.21516 L 424.20111,12.864215 426.25442,12.6415 c 2.09207,-0.226922 191.97524,20.598542 192.40443,21.101978 0.12937,0.151747 16.80892,34.693733 37.06566,76.759972 20.25674,42.06623 36.95473,76.70669 37.10665,76.97878 0.15192,0.2721 -3.68412,4.18419 -8.52453,8.69355 l -8.80074,8.19882 -23.11205,-14.99803 c -12.71161,-8.24891 -23.3574,-14.90711 -23.6573,-14.79599 -0.29989,0.11112 -6.70746,7.35849 -14.23905,16.10526 -20.81761,24.17645 -21.67874,25.20578 -21.33593,25.50313 0.17556,0.15227 13.31742,1.81335 29.20414,3.69129 15.88671,1.87793 29.53692,3.6679 30.3338,3.97771 1.17093,0.45522 -0.58035,2.43253 -9.1296,10.30792 -5.81814,5.35956 -10.31467,9.97916 -9.99228,10.26579 0.32238,0.28663 35.00398,27.72184 77.07022,60.96714 83.92398,66.32581 81.36767,64.28536 80.41138,64.1844 -0.36997,-0.0391 -22.45843,-3.19993 -49.08546,-7.02417 z M 577.80361,188.0883 l 19.3281,-12.22641 -8.33476,-7.92393 c -34.7879,-33.07314 -35.99219,-34.14534 -36.24379,-32.26837 -0.13453,1.00355 0.50623,15.68949 1.4239,32.6354 0.91767,16.94593 1.66849,31.32487 1.66849,31.95323 0,1.74538 1.2152,1.07795 22.15806,-12.16992 z m 53.25426,-28.85635 c 7.97344,-2.51144 14.62777,-4.68638 14.78742,-4.83321 0.15965,-0.14683 -4.74154,-7.26919 -10.89153,-15.82746 -6.14999,-8.55829 -11.45822,-15.26241 -11.79608,-14.89806 -0.33786,0.36435 -2.43505,9.54152 -4.66042,20.39371 -2.99865,14.62311 -3.77305,19.73126 -2.99133,19.73126 0.58015,0 7.57852,-2.05481 15.55194,-4.56624 z"
-             id="path1604" />
-        </g>
-      </g>
-    </g>
-    <g
+             id="path1604" /></g></g></g><g
        sodipodi:insensitive="true"
        inkscape:groupmode="layer"
        id="g2214"
        inkscape:label="haskell (unused)"
-       style="display:none">
-      <path
+       style="display:none"><path
          id="path2200"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#e5c6ed;fill-opacity:0.996078;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z" />
-      <g
+         d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z" /><g
          transform="matrix(5.5840401,0,0,5.5840401,208.09978,81.722271)"
-         id="g2258">
-        <path
+         id="g2258"><path
            d="M 1.842,77.722 26.586,40.63 1.842,3.537 H 20.4 L 45.144,40.63 20.4,77.722 Z m 0,0"
            fill="#453a62"
-           id="path2238" />
-        <path
+           id="path2238" /><path
            d="M 26.586,77.722 51.33,40.63 26.586,3.537 H 45.144 L 94.63,77.722 H 76.074 L 60.61,54.54 45.143,77.722 Z m 0,0"
            fill="#5e5086"
-           id="path2240" />
-        <path
+           id="path2240" /><path
            d="M 86.384,56.085 78.136,43.72 h 28.868 V 56.086 H 86.384 Z M 74.012,37.54 65.764,25.175 h 41.24 V 37.54 Z m 0,0"
            fill="#8f4e8b"
-           id="path2242" />
-      </g>
-      <path
+           id="path2242" /></g><path
          d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z"
          style="color:#000000;display:inline;overflow:visible;fill:#db83ed;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path1561-9" />
-    </g>
-    <g
+         id="path1561-9" /></g><g
        style="display:none"
        inkscape:label="systemd"
        id="g2287"
        inkscape:groupmode="layer"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:0.996078;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path2275" />
-      <path
+         id="path2275" /><path
          id="path2285"
          style="color:#000000;display:inline;overflow:visible;fill:#30d475;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-      <g
+         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><g
          transform="matrix(9.3023256,0,0,9.3023256,112,242.9331)"
-         id="g2309">
-        <path
+         id="g2309"><path
            overflow="visible"
            font-weight="400"
            d="M 0,0 V 26 H 10 V 22 H 4 V 4 h 6 V 0 Z m 76,0 v 4 h 6 v 18 h -6 v 4 H 86 V 0 Z"
@@ -1600,185 +1248,158 @@
            color="#000000"
            font-family="sans-serif"
            fill="#201a26"
-           id="path2289" />
-        <path
+           id="path2289" /><path
            d="M 45,13 63,3 v 20 z"
            fill="#30d475"
-           id="path2293" />
-        <circle
+           id="path2293" /><circle
            cx="30.000999"
            cy="13.001"
            r="9"
            fill="#30d475"
-           id="circle2295" />
-      </g>
-    </g>
-    <g
+           id="circle2295" /></g></g><g
        inkscape:label="marketing"
        id="g762"
        inkscape:groupmode="layer"
        style="display:none"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          d="m 0,0 v 576 h 832 a 256,256 0 0 1 192,86.67188 V 0 Z"
          style="color:#000000;overflow:visible;opacity:1;fill:#ffc4fc;fill-opacity:1;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path752" />
-      <g
+         id="path752" /><g
          style="display:inline;opacity:0.994;fill:#ff0000"
-         id="g754" />
-      <path
+         id="g754" /><path
          id="path756"
          style="color:#000000;overflow:visible;fill:#ff23f2;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-      <path
+         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><path
          style="fill:none;stroke:#000000;stroke-width:27.1412;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 356.31934,340.98112 c 4.55061,31.17569 16.58723,61.26678 27.51834,91.51803"
          id="path12056"
-         sodipodi:nodetypes="cc" />
-      <path
+         sodipodi:nodetypes="cc" /><path
          style="fill:#ff23f2;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="M 283.18673,254.45063 713.27319,149.03854 712.82846,437.47344 283.62524,331.68547 Z"
          id="path12058"
-         sodipodi:nodetypes="ccccc" />
-      <path
+         sodipodi:nodetypes="ccccc" /><path
          style="fill:none;stroke:#000000;stroke-width:28;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 283.80219,254.04431 v 77.7373"
-         id="path11804" />
-      <path
+         id="path11804" /><path
          style="fill:none;stroke:#000000;stroke-width:28;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M 712.91645,151.49743 V 434.32848"
-         id="path11806" />
-    </g>
-    <g
+         id="path11806" /></g><g
        inkscape:groupmode="layer"
        id="layer21"
        inkscape:label="WSL"
        style="display:none"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          d="m 0,0 v 512 64 H 640.00195 832 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15625,3.41993 256,256 0 0 1 2.05078,1.74218 256,256 0 0 1 1.01758,0.87891 256,256 0 0 1 0.002,0 256,256 0 0 1 1.01177,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024,576.00195 V 0 Z"
          style="color:#000000;display:inline;overflow:visible;fill:#ffffff;fill-opacity:0.996078;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path2414" />
-      <path
+         id="path2414" /><path
          id="path2416"
          style="color:#000000;display:inline;overflow:visible;fill:#0078d4;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" />
-      <g
+         d="m 0,512 v 64 H 640.00195 832 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 832,512 h -0.23828 z" /><g
          fill="#0078d4"
          id="g3925"
          transform="matrix(6.9344011,0,0,6.9344011,342.99131,107.21391)"
-         style="display:inline">
-        <rect
+         style="display:inline"><rect
            x="2.2848e-15"
            y="-0.00011033"
            width="23.105"
            height="23.105"
-           id="rect3917" />
-        <rect
+           id="rect3917" /><rect
            x="25.639999"
            y="-0.00011033"
            width="23.105"
            height="23.105"
-           id="rect3919" />
-        <rect
+           id="rect3919" /><rect
            x="2.2848e-15"
            y="25.642"
            width="23.105"
            height="23.105"
-           id="rect3921" />
-        <rect
+           id="rect3921" /><rect
            x="25.639999"
            y="25.642"
            width="23.105"
            height="23.105"
            id="rect3923"
-           style="display:inline" />
-      </g>
-    </g>
-    <g
+           style="display:inline" /></g></g><g
        inkscape:groupmode="layer"
        id="layer22"
        inkscape:label="Python"
        style="display:none"
-       sodipodi:insensitive="true">
-      <path
+       sodipodi:insensitive="true"><path
          d="m 0.4062493,-18.35156 v 512 64 H 640.4082 832.40625 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15623,3.41993 256,256 0 0 1 2.0508,1.74218 256,256 0 0 1 1.0176,0.87891 256,256 0 0 1 1.0117,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024.4062,557.65039 V -18.35156 Z"
          style="color:#000000;display:inline;overflow:visible;fill:#ffffff;fill-opacity:0.996078;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
-         id="path2275-7" />
-      <g
+         id="path2275-7" /><g
          id="g48"
          transform="matrix(3.8994884,0,0,3.8994884,294.36608,44.423764)"
-         style="display:inline">
-        <path
+         style="display:inline"><path
            style="fill:url(#linearGradient1478);fill-opacity:1"
            d="M 54.918785,9.1927389e-4 C 50.335132,0.02221727 45.957846,0.41313697 42.106285,1.0946693 30.760069,3.0991731 28.700036,7.2947714 28.700035,15.032169 v 10.21875 h 26.8125 v 3.40625 h -26.8125 -10.0625 c -7.792459,0 -14.6157588,4.683717 -16.7499998,13.59375 -2.46181998,10.212966 -2.57101508,16.586023 0,27.25 1.9059283,7.937852 6.4575432,13.593748 14.2499998,13.59375 h 9.21875 v -12.25 c 0,-8.849902 7.657144,-16.656248 16.75,-16.65625 h 26.78125 c 7.454951,0 13.406253,-6.138164 13.40625,-13.625 v -25.53125 c 0,-7.2663386 -6.12998,-12.7247771 -13.40625,-13.9374997 C 64.281548,0.32794397 59.502438,-0.02037903 54.918785,9.1927389e-4 Z m -14.5,8.21875012611 c 2.769547,0 5.03125,2.2986456 5.03125,5.1249996 -2e-6,2.816336 -2.261703,5.09375 -5.03125,5.09375 -2.779476,-1e-6 -5.03125,-2.277415 -5.03125,-5.09375 -10e-7,-2.826353 2.251774,-5.1249996 5.03125,-5.1249996 z"
-           id="path1948" />
-        <path
+           id="path1948" /><path
            style="fill:url(#linearGradient1475);fill-opacity:1"
            d="m 85.637535,28.657169 v 11.90625 c 0,9.230755 -7.825895,16.999999 -16.75,17 h -26.78125 c -7.335833,0 -13.406249,6.278483 -13.40625,13.625 v 25.531247 c 0,7.266344 6.318588,11.540324 13.40625,13.625004 8.487331,2.49561 16.626237,2.94663 26.78125,0 6.750155,-1.95439 13.406253,-5.88761 13.40625,-13.625004 V 86.500919 h -26.78125 v -3.40625 h 26.78125 13.406254 c 7.792461,0 10.696251,-5.435408 13.406241,-13.59375 2.79933,-8.398886 2.68022,-16.475776 0,-27.25 -1.92578,-7.757441 -5.60387,-13.59375 -13.406241,-13.59375 z m -15.0625,64.65625 c 2.779478,3e-6 5.03125,2.277417 5.03125,5.093747 -2e-6,2.826354 -2.251775,5.125004 -5.03125,5.125004 -2.76955,0 -5.03125,-2.29865 -5.03125,-5.125004 2e-6,-2.81633 2.261697,-5.093747 5.03125,-5.093747 z"
-           id="path1950" />
-        <ellipse
+           id="path1950" /><ellipse
            style="opacity:0.44382;fill:url(#radialGradient1480);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.4174;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path1894"
            cx="55.816761"
            cy="127.70079"
            rx="35.930977"
-           ry="6.9673119" />
-      </g>
-      <path
+           ry="6.9673119" /></g><path
          id="path2285-5"
          style="color:#000000;display:inline;overflow:visible;fill:#ffdd6c;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m -2.8125008,512.60156 v 64 H 637.18945 829.1875 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 829.1875,512.60156 h -0.23828 z" />
-    </g>
-    <g
+         d="m -2.8125008,512.60156 v 64 H 637.18945 829.1875 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 829.1875,512.60156 h -0.23828 z" /></g><g
+       inkscape:groupmode="layer"
+       id="g4"
+       inkscape:label="KDE"
+       style="display:none"
+       sodipodi:insensitive="true"><path
+         d="m 0.4062493,-18.35156 v 512 64 H 640.4082 832.40625 a 256,256 0 0 1 8.07031,0.12695 256,256 0 0 1 0.002,0 256,256 0 0 1 18.78711,1.28516 256,256 0 0 1 2.67382,0.29687 256,256 0 0 1 8.00391,1.0586 256,256 0 0 1 2.6582,0.4082 256,256 0 0 1 21.09375,4.26953 256,256 0 0 1 2.60938,0.65821 256,256 0 0 1 3.90039,1.0371 256,256 0 0 1 2.58984,0.72657 256,256 0 0 1 3.87305,1.14062 256,256 0 0 1 3.85351,1.20117 256,256 0 0 1 2.55665,0.83399 256,256 0 0 1 0.002,0 256,256 0 0 1 5.08789,1.75 256,256 0 0 1 3.79297,1.38281 256,256 0 0 1 1.25976,0.47266 256,256 0 0 1 2.50977,0.96875 256,256 0 0 1 4.99023,2.01367 256,256 0 0 1 2.47852,1.04687 256,256 0 0 1 3.69922,1.61915 256,256 0 0 1 2.44922,1.11132 256,256 0 0 1 1.2207,0.56446 256,256 0 0 1 0.002,0 256,256 0 0 1 3.64453,1.73437 256,256 0 0 1 2.41407,1.1875 256,256 0 0 1 2.40039,1.21289 256,256 0 0 1 0.002,0 256,256 0 0 1 1.19531,0.61719 256,256 0 0 1 2.38281,1.25 256,256 0 0 1 1.18555,0.63477 256,256 0 0 1 2.36328,1.28906 256,256 0 0 1 2.34766,1.3125 256,256 0 0 1 2.33398,1.33789 256,256 0 0 1 0.002,0 256,256 0 0 1 1.16015,0.67773 256,256 0 0 1 0.002,0 256,256 0 0 1 2.3125,1.375 256,256 0 0 1 2.29882,1.39844 256,256 0 0 1 1.14454,0.70898 256,256 0 0 1 3.4082,2.16016 256,256 0 0 1 10.01758,6.80274 256,256 0 0 1 2.17968,1.57421 256,256 0 0 1 0.002,0 256,256 0 0 1 1.08398,0.79688 256,256 0 0 1 2.15625,1.60937 256,256 0 0 1 2.13867,1.63282 256,256 0 0 1 2.12305,1.65429 256,256 0 0 1 2.10352,1.67578 256,256 0 0 1 4.15623,3.41993 256,256 0 0 1 2.0508,1.74218 256,256 0 0 1 1.0176,0.87891 256,256 0 0 1 1.0117,0.88477 256,256 0 0 1 2.0118,1.78515 256,256 0 0 1 0.9981,0.90039 256,256 0 0 1 1.9863,1.81641 256,256 0 0 1 0.9844,0.91601 256,256 0 0 1 1.957,1.84766 256,256 0 0 1 1.9375,1.86719 256,256 0 0 1 1.916,1.88867 256,256 0 0 1 0.9512,0.95117 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8867,1.91602 256,256 0 0 1 0,0.002 256,256 0 0 1 1.8672,1.9375 256,256 0 0 1 0.9258,0.97461 256,256 0 0 1 2.7461,2.95899 256,256 0 0 1 1.8046,1.99609 256,256 0 0 1 0.8946,1.00391 256,256 0 0 1 0,0.002 256,256 0 0 1 32.7676,46.56445 h 70.9179 A 320,320 0 0 0 1024.4062,557.65039 V -18.35156 Z"
+         style="color:#000000;display:inline;overflow:visible;fill:#1d99f3;fill-opacity:1;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round"
+         id="path1" /><path
+         id="path4"
+         style="color:#000000;display:inline;overflow:visible;fill:#e8fbff;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.8125008,512.60156 v 64 H 637.18945 829.1875 a 256,256 0 0 1 224.4434,132.87109 h 70.9179 A 320,320 0 0 0 829.1875,512.60156 h -0.23828 z" /><path
+         d="m 544.50249,72.295295 -68.95856,6.601399 V 362.83975 l 68.22816,-10.27193 V 231.50527 l 91.7122,134.27479 71.8987,-22.74914 L 613.47034,213.89691 708.11819,92.099315 634.75405,75.230795 543.77209,197.02374 Z M 388.1902,141.48947 c -0.77864,0.0801 -1.53082,0.42474 -2.11553,1.01296 l -27.0651,27.06031 c -1.13799,1.14118 -1.35227,2.91081 -0.51337,4.29258 l 31.68738,52.18893 c -5.62016,9.44843 -10.12463,19.63556 -13.34399,30.38225 l -58.17309,12.10007 c -1.6185,0.33498 -2.78469,1.76931 -2.78469,3.43028 v 38.27002 c 0,1.61849 1.10736,3.0203 2.66687,3.39727 l 56.46261,13.8011 c 3.011,12.44644 7.67686,24.24503 13.84358,35.08946 l -32.68176,49.83766 c -0.91183,1.39282 -0.72125,3.22769 0.4568,4.40093 l 27.05565,27.06047 c 1.13798,1.13477 2.91435,1.35755 4.30205,0.52251 l 51.21348,-31.10319 c 10.05988,5.80513 20.90898,10.37339 32.37545,13.47143 l 11.94926,57.452 c 0.33626,1.62795 1.77525,2.78483 3.42563,2.78483 h 38.27483 c 1.60905,0 3.01324,-1.0979 3.39728,-2.67648 l 14.07437,-57.56981 c 11.81974,-3.18987 22.99869,-7.94421 33.30364,-14.01315 l 50.46898,33.09158 c 1.3877,0.91359 3.22305,0.73087 4.40094,-0.44718 l 27.06512,-27.06047 c 1.14486,-1.14438 1.34986,-2.91418 0.50872,-4.29242 l -18.42354,-30.36348 -5.9606,1.88471 c -0.86887,0.27408 -1.81643,-0.0481 -2.32756,-0.8062 0,0 -11.75147,-17.20302 -26.92856,-39.4149 -18.14305,35.50875 -55.05601,59.8315 -97.68225,59.8315 -60.56075,0 -109.65986,-49.10021 -109.65986,-109.6645 0,-44.55327 26.57403,-82.86913 64.72258,-100.03337 v -28.29011 c -6.94296,2.42885 -13.6551,5.3573 -20.03035,8.83005 -0.004,-0.004 -0.009,-0.016 -0.0273,-0.032 L 390.4714,142.03482 c -0.69577,-0.4552 -1.50197,-0.63632 -2.2806,-0.55617 z"
+         fill="#fcfcfc"
+         stroke-width="4.24738"
+         id="path2-7" /></g><g
        sodipodi:insensitive="true"
        inkscape:groupmode="layer"
        id="g1278"
        inkscape:label="NixOS"
-       style="display:none;opacity:0.98">
-      <rect
+       style="display:none;opacity:0.98"><rect
          style="color:#000000;overflow:visible;fill:#5277c3;fill-opacity:0.980392;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
          id="rect1206"
          width="1024"
          height="1024"
          x="0"
-         y="0" />
-      <circle
+         y="0" /><circle
          r="384"
          cy="512"
          cx="512"
          id="path1434"
-         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:0.980392;stroke:none;stroke-width:199.999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <g
+         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:0.980392;stroke:none;stroke-width:199.999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><g
          id="g1276"
          transform="matrix(1.1486953,0,0,1.1486953,196.53936,233.61163)"
-         style="stroke-width:0.928591">
-        <g
+         style="stroke-width:0.928591"><g
            style="display:none;stroke-width:0.928591"
            inkscape:label="bg"
-           id="g1210">
-          <rect
+           id="g1210"><rect
              y="-957.77832"
              x="132.5822"
              height="483.7439"
              width="1543.4283"
              id="rect1208"
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-             transform="translate(-132.5822,958.04022)" />
-        </g>
-        <g
+             transform="translate(-132.5822,958.04022)" /></g><g
            transform="translate(-132.5822,958.04022)"
            style="display:none;opacity:0.516;stroke-width:0.928591"
            inkscape:label="guide"
-           id="g1218">
-          <rect
+           id="g1218"><rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect1212"
              width="1543.4283"
              height="483.7439"
              x="132.5822"
-             y="-957.77832" />
-          <rect
+             y="-957.77832" /><rect
              inkscape:export-ydpi="17.971878"
              inkscape:export-xdpi="17.971878"
              y="-933.38721"
@@ -1786,21 +1407,17 @@
              height="435.68069"
              width="1496.443"
              id="rect1214"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <rect
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              id="rect1216"
              width="1492.5731"
              height="272.58423"
              x="159.02695"
-             y="-851.65918" />
-        </g>
-        <g
+             y="-851.65918" /></g><g
            transform="translate(-132.5822,958.04022)"
            style="display:none;stroke-width:0.928591"
            inkscape:label="logo-guide"
-           id="g1226">
-          <rect
+           id="g1226"><rect
              inkscape:export-ydpi="22.07"
              inkscape:export-xdpi="22.07"
              inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
@@ -1809,8 +1426,7 @@
              width="550.41602"
              height="484.30399"
              x="132.65129"
-             y="-958.02759" />
-          <rect
+             y="-958.02759" /><rect
              inkscape:export-ydpi="212.2"
              inkscape:export-xdpi="212.2"
              inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
@@ -1819,68 +1435,56 @@
              height="434.30405"
              width="501.94415"
              id="rect1222"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <rect
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
              y="-958.04022"
              x="658.02826"
              height="24.939611"
              width="24.939611"
              id="rect1224"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-        </g>
-        <g
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
            transform="translate(-132.5822,958.04022)"
            style="display:inline;stroke-width:0.928591"
            id="g1258"
-           inkscape:label="print-logo">
-          <path
+           inkscape:label="print-logo"><path
              sodipodi:nodetypes="cccccccccc"
              inkscape:connector-curvature="0"
              id="path1228"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <path
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
              sodipodi:nodetypes="cccccccccc"
              inkscape:connector-curvature="0"
              id="path1230"
              d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <path
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
              sodipodi:nodetypes="cccccccccc"
              inkscape:connector-curvature="0"
              id="path1232"
              d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <path
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
              sodipodi:nodetypes="cccccccccc"
              inkscape:connector-curvature="0"
              id="path1234"
              d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <path
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
              id="path1236"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
-          <path
+             sodipodi:nodetypes="cccccccccc" /><path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
              id="path1238"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
-          <path
+             sodipodi:nodetypes="cccccccccc" /><path
              style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
              id="path1240"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
-          <g
+             sodipodi:nodetypes="cccccccccc" /><g
              transform="translate(72.039038,-1799.4476)"
              style="display:none;stroke-width:0.928591"
              inkscape:label="guides"
-             id="g1256">
-            <path
+             id="g1256"><path
                sodipodi:type="star"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                id="path1242"
@@ -1894,8 +1498,7 @@
                inkscape:flatsided="true"
                inkscape:rounded="0"
                inkscape:randomized="0"
-               d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
-            <path
+               d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" /><path
                d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
                inkscape:randomized="0"
                inkscape:rounded="0"
@@ -1910,23 +1513,20 @@
                id="path1244"
                style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                sodipodi:type="star"
-               transform="translate(0,-308.26772)" />
-            <path
+               transform="translate(0,-308.26772)" /><path
                style="fill:url(#linearGradient1342);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                id="path1246"
                inkscape:connector-curvature="0"
                sodipodi:nodetypes="ccccccccc"
-               transform="translate(0,-308.26772)" />
-            <rect
+               transform="translate(0,-308.26772)" /><rect
                transform="rotate(-30)"
                y="446.17056"
                x="-34.74221"
                height="226.22897"
                width="48.834862"
                id="rect1248"
-               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            <path
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
                inkscape:randomized="0"
                inkscape:rounded="0"
@@ -1941,8 +1541,7 @@
                id="path1250"
                style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                sodipodi:type="star"
-               transform="translate(0,-308.26772)" />
-            <use
+               transform="translate(0,-308.26772)" /><use
                height="100%"
                width="100%"
                transform="rotate(60,268.29786,489.4515)"
@@ -1950,29 +1549,23 @@
                xlink:href="#rect5884"
                y="0"
                x="0"
-               style="stroke-width:0.928591" />
-            <rect
+               style="stroke-width:0.928591" /><rect
                transform="rotate(30,575.23539,-154.13386)"
                y="467.07007"
                x="545.71014"
                height="115.12564"
                width="5.3947482"
                id="rect1254"
-               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          </g>
-        </g>
-        <g
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></g><g
            transform="translate(-132.5822,958.04022)"
            style="display:inline;opacity:1;stroke-width:0.928591"
            inkscape:label="gradient-logo"
-           id="g1274">
-          <path
+           id="g1274"><path
              style="opacity:1;fill:url(#linearGradient1344);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
              id="path1260"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccccccc" />
-          <use
+             sodipodi:nodetypes="cccccccccc" /><use
              x="0"
              y="0"
              xlink:href="#path3336-6-7"
@@ -1982,8 +1575,7 @@
              transform="rotate(60,407.11155,-715.78724)"
              width="100%"
              height="100%"
-             style="stroke-width:0.928591" />
-          <use
+             style="stroke-width:0.928591" /><use
              x="0"
              y="0"
              xlink:href="#path3336-6-7"
@@ -1993,8 +1585,7 @@
              transform="rotate(-60,407.31177,-715.70016)"
              width="100%"
              height="100%"
-             style="stroke-width:0.928591" />
-          <use
+             style="stroke-width:0.928591" /><use
              x="0"
              y="0"
              xlink:href="#path3336-6-7"
@@ -2004,14 +1595,12 @@
              transform="rotate(180,407.41868,-715.7565)"
              width="100%"
              height="100%"
-             style="stroke-width:0.928591" />
-          <path
+             style="stroke-width:0.928591" /><path
              sodipodi:nodetypes="cccccccccc"
              inkscape:connector-curvature="0"
              id="path1268"
              d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1346);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-          <use
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1346);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
              style="display:inline;stroke-width:0.928591"
              x="0"
              y="0"
@@ -2019,8 +1608,7 @@
              id="use1270"
              transform="rotate(120,407.33916,-716.08356)"
              width="100%"
-             height="100%" />
-          <use
+             height="100%" /><use
              style="display:inline;stroke-width:0.928591"
              x="0"
              y="0"
@@ -2028,71 +1616,52 @@
              id="use1272"
              transform="rotate(-120,407.28823,-715.86995)"
              width="100%"
-             height="100%" />
-        </g>
-      </g>
-    </g>
-  </g>
-  <g
+             height="100%" /></g></g></g></g><g
      sodipodi:insensitive="true"
      style="display:none"
      inkscape:label="Space"
      id="layer7"
-     inkscape:groupmode="layer">
-    <g
+     inkscape:groupmode="layer"><g
        style="display:none;opacity:0.998"
        inkscape:groupmode="layer"
        id="g1042"
-       inkscape:label="NixOS">
-      <rect
+       inkscape:label="NixOS"><rect
          style="color:#000000;overflow:visible;fill:#405d99;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
          id="rect1014"
          height="1024"
          x="0"
          y="0"
-         width="1024" />
-      <g
+         width="1024" /><g
          id="g1040"
          transform="matrix(1.838739,0,0,1.838739,51.000003,111.99999)"
-         style="stroke-width:0.580107">
-        <g
+         style="stroke-width:0.580107"><g
            style="display:none;stroke-width:0.580107"
            transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
-           id="g1018">
-          <rect
+           id="g1018"><rect
              y="-2102.4253"
              x="-1045.6049"
              height="7145.4614"
              width="7947.0356"
              id="rect1016"
-             style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:6.01021" />
-        </g>
-        <g
+             style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:6.01021" /></g><g
            transform="translate(-156.48372,537.56136)"
            style="display:inline;opacity:1;stroke-width:0.580107"
-           id="g1038">
-          <g
+           id="g1038"><g
              style="stroke-width:6.41089"
              transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
-             id="g1036">
-            <g
+             id="g1036"><g
                transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"
                id="g1034"
-               style="stroke-width:6.41089">
-              <g
+               style="stroke-width:6.41089"><g
                  transform="rotate(-60,226.35754,-449.37199)"
                  id="g1022"
-                 style="stroke-width:6.41089">
-                <path
+                 style="stroke-width:6.41089"><path
                    id="path1020"
                    d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                   style="opacity:1;fill:url(#linearGradient1713);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-              </g>
-              <path
+                   style="opacity:1;fill:url(#linearGradient1713);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><path
                  id="path1024"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1299);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <use
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1299);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6"
@@ -2100,8 +1669,7 @@
                  transform="rotate(60,728.23563,-692.24036)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:6.41089" />
-              <use
+                 style="stroke-width:6.41089" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6"
@@ -2109,8 +1677,7 @@
                  transform="rotate(180,477.5036,-570.81898)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:6.41089" />
-              <use
+                 style="stroke-width:6.41089" /><use
                  style="display:inline;stroke-width:6.41089"
                  x="0"
                  y="0"
@@ -2118,8 +1685,7 @@
                  id="use1030"
                  transform="rotate(120,407.33916,-716.08356)"
                  width="100%"
-                 height="100%" />
-              <use
+                 height="100%" /><use
                  style="display:inline;stroke-width:6.41089"
                  x="0"
                  y="0"
@@ -2127,72 +1693,54 @@
                  id="use1032"
                  transform="rotate(-120,407.28823,-715.86995)"
                  width="100%"
-                 height="100%" />
-            </g>
-          </g>
-        </g>
-      </g>
-    </g>
-  </g>
-  <g
-     sodipodi:insensitive="true"
+                 height="100%" /></g></g></g></g></g></g><g
      inkscape:groupmode="layer"
      id="layer18"
      inkscape:label="DO NOT PRINT"
-     style="display:inline">
-    <g
+     style="display:inline"
+     sodipodi:insensitive="true"><g
        sodipodi:insensitive="true"
        style="display:none"
        inkscape:groupmode="layer"
        id="layer11"
-       inkscape:label="[ graveyard ]">
-      <g
+       inkscape:label="[ graveyard ]"><g
          inkscape:groupmode="layer"
          id="layer19"
-         inkscape:label="Space (unused)">
-        <g
+         inkscape:label="Space (unused)"><g
            sodipodi:insensitive="true"
            style="display:none"
            inkscape:label="Blue on White"
            id="layer9"
-           inkscape:groupmode="layer">
-          <rect
+           inkscape:groupmode="layer"><rect
              y="0"
              x="0"
              height="1024"
              width="1024"
              id="rect1080"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-          <g
+             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><g
              style="stroke-width:0.580463"
              transform="matrix(1.837615,0,0,1.837615,7.3446717,66.585973)"
-             id="g1202">
-            <g
+             id="g1202"><g
                id="layer7-5"
                inkscape:label="bg"
-               style="display:none;stroke-width:0.580463">
-              <rect
+               style="display:none;stroke-width:0.580463"><rect
                  transform="translate(-132.5822,958.04022)"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect5389"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-            </g>
-            <g
+                 y="-957.77832" /></g><g
                id="layer5-6"
                inkscape:label="guide"
                style="display:none;opacity:0.516;stroke-width:0.580463"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect5350"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect5346"
                  width="1496.443"
@@ -2200,21 +1748,17 @@
                  x="155.77646"
                  y="-933.38721"
                  inkscape:export-xdpi="17.971878"
-                 inkscape:export-ydpi="17.971878" />
-              <rect
+                 inkscape:export-ydpi="17.971878" /><rect
                  y="-851.65918"
                  x="159.02695"
                  height="272.58423"
                  width="1492.5731"
                  id="rect5348"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                id="layer6-2"
                inkscape:label="logo-guide"
                style="display:none;stroke-width:0.580463"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-958.02759"
                  x="132.65129"
                  height="484.30399"
@@ -2223,8 +1767,7 @@
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
                  inkscape:export-xdpi="22.07"
-                 inkscape:export-ydpi="22.07" />
-              <rect
+                 inkscape:export-ydpi="22.07" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect5372"
                  width="501.94415"
@@ -2233,68 +1776,56 @@
                  y="-933.02759"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
                  inkscape:export-xdpi="212.2"
-                 inkscape:export-ydpi="212.2" />
-              <rect
+                 inkscape:export-ydpi="212.2" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect5381"
                  width="24.939611"
                  height="24.939611"
                  x="658.02826"
-                 y="-958.04022" />
-            </g>
-            <g
+                 y="-958.04022" /></g><g
                inkscape:label="print-logo"
                id="layer1-9"
                style="display:inline;stroke-width:0.580463"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path4861"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
                  id="use4863"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
                  id="use4865"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
                  id="use4867"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path4873"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="use4875"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="use4877"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><g
                  id="layer2-1"
                  inkscape:label="guides"
                  style="display:none;stroke-width:0.580463"
-                 transform="translate(72.039038,-1799.4476)">
-                <path
+                 transform="translate(72.039038,-1799.4476)"><path
                    d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -2308,8 +1839,7 @@
                    sodipodi:sides="6"
                    id="path6032"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                   sodipodi:type="star" />
-                <path
+                   sodipodi:type="star" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
@@ -2324,23 +1854,20 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
-                <path
+                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:nodetypes="ccccccccc"
                    inkscape:connector-curvature="0"
                    id="path5851"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
-                   style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-                <rect
+                   style="fill:url(#linearGradient5855);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect5884"
                    width="48.834862"
                    height="226.22897"
                    x="-34.74221"
                    y="446.17056"
-                   transform="rotate(-30)" />
-                <path
+                   transform="rotate(-30)" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -2355,8 +1882,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
-                <use
+                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" /><use
                    style="stroke-width:0.580463"
                    x="0"
                    y="0"
@@ -2364,29 +1890,23 @@
                    id="use4252"
                    transform="rotate(60,268.29786,489.4515)"
                    width="100%"
-                   height="100%" />
-                <rect
+                   height="100%" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.580463px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect4254"
                    width="5.3947482"
                    height="115.12564"
                    x="545.71014"
                    y="467.07007"
-                   transform="rotate(30,575.23539,-154.13386)" />
-              </g>
-            </g>
-            <g
+                   transform="rotate(30,575.23539,-154.13386)" /></g></g><g
                id="layer3-2"
                inkscape:label="gradient-logo"
                style="display:inline;opacity:1;stroke-width:0.580463"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path3336-6-7"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                 style="opacity:1;fill:url(#linearGradient5384);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-              <use
+                 style="opacity:1;fill:url(#linearGradient5384);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><use
                  style="stroke-width:0.580463"
                  height="100%"
                  width="100%"
@@ -2396,8 +1916,7 @@
                  inkscape:transform-center-x="124.43045"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.580463"
                  height="100%"
                  width="100%"
@@ -2407,8 +1926,7 @@
                  inkscape:transform-center-x="-168.20651"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.580463"
                  height="100%"
                  width="100%"
@@ -2418,14 +1936,12 @@
                  inkscape:transform-center-x="59.669705"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <path
+                 x="0" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5386);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.74139;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
                  id="path4260-0-3"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(120,407.33916,-716.08356)"
@@ -2433,8 +1949,7 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.580463" />
-              <use
+                 style="display:inline;stroke-width:0.580463" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(-120,407.28823,-715.86995)"
@@ -2442,65 +1957,48 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.580463" />
-            </g>
-          </g>
-        </g>
-        <g
+                 style="display:inline;stroke-width:0.580463" /></g></g></g><g
            style="display:none"
            sodipodi:insensitive="true"
            inkscape:label="White on Black"
            id="layer8"
-           inkscape:groupmode="layer">
-          <rect
+           inkscape:groupmode="layer"><rect
              width="1024"
              y="0"
              x="0"
              height="1024"
              id="rect1002"
-             style="color:#000000;overflow:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-          <g
+             style="color:#000000;overflow:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><g
              style="stroke-width:0.580107"
              transform="matrix(1.838739,0,0,1.838739,51.000003,111.99999)"
-             id="g1000">
-            <g
+             id="g1000"><g
                id="layer1-7"
                transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
-               style="display:none;stroke-width:0.580107">
-              <rect
+               style="display:none;stroke-width:0.580107"><rect
                  style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:6.01021"
                  id="rect995"
                  width="7947.0356"
                  height="7145.4614"
                  x="-1045.6049"
-                 y="-2102.4253" />
-            </g>
-            <g
+                 y="-2102.4253" /></g><g
                id="layer3-5"
                style="display:inline;opacity:1;stroke-width:0.580107"
-               transform="translate(-156.48372,537.56136)">
-              <g
+               transform="translate(-156.48372,537.56136)"><g
                  id="g955"
                  transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
-                 style="stroke-width:6.41089">
-                <g
+                 style="stroke-width:6.41089"><g
                    style="stroke-width:6.41089"
                    id="g869"
-                   transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)">
-                  <g
+                   transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"><g
                      style="stroke-width:6.41089"
                      id="g932"
-                     transform="rotate(-60,226.35754,-449.37199)">
-                    <path
+                     transform="rotate(-60,226.35754,-449.37199)"><path
                        style="opacity:1;fill:url(#linearGradient1044);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                        d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                       id="path3336-6" />
-                  </g>
-                  <path
+                       id="path3336-6" /></g><path
                      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1046);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.2326;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                      d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                     id="path4260-0" />
-                  <use
+                     id="path4260-0" /><use
                      style="stroke-width:6.41089"
                      height="100%"
                      width="100%"
@@ -2508,8 +2006,7 @@
                      id="use3439-6"
                      xlink:href="#path3336-6"
                      y="0"
-                     x="0" />
-                  <use
+                     x="0" /><use
                      style="stroke-width:6.41089"
                      height="100%"
                      width="100%"
@@ -2517,8 +2014,7 @@
                      id="use3449-5"
                      xlink:href="#path3336-6"
                      y="0"
-                     x="0" />
-                  <use
+                     x="0" /><use
                      height="100%"
                      width="100%"
                      transform="rotate(120,407.33916,-716.08356)"
@@ -2526,8 +2022,7 @@
                      xlink:href="#path4260-0"
                      y="0"
                      x="0"
-                     style="display:inline;stroke-width:6.41089" />
-                  <use
+                     style="display:inline;stroke-width:6.41089" /><use
                      height="100%"
                      width="100%"
                      transform="rotate(-120,407.28823,-715.86995)"
@@ -2535,68 +2030,48 @@
                      xlink:href="#path4260-0"
                      y="0"
                      x="0"
-                     style="display:inline;stroke-width:6.41089" />
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-      <g
+                     style="display:inline;stroke-width:6.41089" /></g></g></g></g></g></g><g
          sodipodi:insensitive="true"
          inkscape:label="White on Dark Blue"
          id="g1338"
          inkscape:groupmode="layer"
-         style="display:none;opacity:0.998">
-        <rect
+         style="display:none;opacity:0.998"><rect
            width="1024"
            y="0"
            x="0"
            height="1024"
            id="rect1310"
-           style="color:#000000;overflow:visible;fill:#405d99;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-        <g
+           style="color:#000000;overflow:visible;fill:#405d99;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><g
            style="stroke-width:0.681349"
            transform="matrix(1.5655207,0,0,1.5655207,51.000003,111.99999)"
-           id="g1336">
-          <g
+           id="g1336"><g
              id="g1314"
              transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
-             style="display:none;stroke-width:0.681349">
-            <rect
+             style="display:none;stroke-width:0.681349"><rect
                style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:7.05913"
                id="rect1312"
                width="7947.0356"
                height="7145.4614"
                x="-1045.6049"
-               y="-2102.4253" />
-          </g>
-          <g
+               y="-2102.4253" /></g><g
              id="g1334"
              style="display:inline;opacity:1;stroke-width:0.681349"
-             transform="translate(-156.48372,537.56136)">
-            <g
+             transform="translate(-156.48372,537.56136)"><g
                id="g1332"
                transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
-               style="stroke-width:7.52973">
-              <g
+               style="stroke-width:7.52973"><g
                  style="stroke-width:7.52973"
                  id="g1330"
-                 transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)">
-                <g
+                 transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"><g
                    style="stroke-width:7.52973"
                    id="g1318"
-                   transform="rotate(-60,226.35754,-449.37199)">
-                  <path
+                   transform="rotate(-60,226.35754,-449.37199)"><path
                      style="opacity:1;fill:url(#linearGradient1352);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:22.5891;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                      d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                     id="path1316" />
-                </g>
-                <path
+                     id="path1316" /></g><path
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1354);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:22.5891;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                   id="path1320" />
-                <use
+                   id="path1320" /><use
                    style="stroke-width:7.52973"
                    height="100%"
                    width="100%"
@@ -2604,8 +2079,7 @@
                    id="use1322"
                    xlink:href="#path3336-6"
                    y="0"
-                   x="0" />
-                <use
+                   x="0" /><use
                    style="stroke-width:7.52973"
                    height="100%"
                    width="100%"
@@ -2613,8 +2087,7 @@
                    id="use1324"
                    xlink:href="#path3336-6"
                    y="0"
-                   x="0" />
-                <use
+                   x="0" /><use
                    height="100%"
                    width="100%"
                    transform="rotate(120,407.33916,-716.08356)"
@@ -2622,8 +2095,7 @@
                    xlink:href="#path4260-0"
                    y="0"
                    x="0"
-                   style="display:inline;stroke-width:7.52973" />
-                <use
+                   style="display:inline;stroke-width:7.52973" /><use
                    height="100%"
                    width="100%"
                    transform="rotate(-120,407.28823,-715.86995)"
@@ -2631,67 +2103,48 @@
                    xlink:href="#path4260-0"
                    y="0"
                    x="0"
-                   style="display:inline;stroke-width:7.52973" />
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-      <g
+                   style="display:inline;stroke-width:7.52973" /></g></g></g></g></g><g
          sodipodi:insensitive="true"
          inkscape:groupmode="layer"
          id="g1308"
          inkscape:label="White on Black"
-         style="display:none">
-        <rect
+         style="display:none"><rect
            style="color:#000000;overflow:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
            id="rect1280"
            height="1024"
            x="0"
            y="0"
-           width="1024" />
-        <g
+           width="1024" /><g
            id="g1306"
            transform="matrix(1.1493974,0,0,1.1493974,223.82849,262.00605)"
-           style="stroke-width:0.928022">
-          <g
+           style="stroke-width:0.928022"><g
              style="display:none;stroke-width:0.928022"
              transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
-             id="g1284">
-            <rect
+             id="g1284"><rect
                y="-2102.4253"
                x="-1045.6049"
                height="7145.4614"
                width="7947.0356"
                id="rect1282"
-               style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:9.61479" />
-          </g>
-          <g
+               style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:9.61479" /></g><g
              transform="translate(-156.48372,537.56136)"
              style="display:inline;opacity:1;stroke-width:0.928022"
-             id="g1304">
-            <g
+             id="g1304"><g
                style="stroke-width:10.2558"
                transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
-               id="g1302">
-              <g
+               id="g1302"><g
                  transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"
                  id="g1300"
-                 style="stroke-width:10.2558">
-                <g
+                 style="stroke-width:10.2558"><g
                    transform="rotate(-60,226.35754,-449.37199)"
                    id="g1288"
-                   style="stroke-width:10.2558">
-                  <path
+                   style="stroke-width:10.2558"><path
                      id="path1286"
                      d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                     style="opacity:1;fill:url(#linearGradient1348);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:30.7672;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-                </g>
-                <path
+                     style="opacity:1;fill:url(#linearGradient1348);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:30.7672;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><path
                    id="path1290"
                    d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1350);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:30.7672;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-                <use
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1350);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:30.7672;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
                    x="0"
                    y="0"
                    xlink:href="#path3336-6"
@@ -2699,8 +2152,7 @@
                    transform="rotate(60,728.23563,-692.24036)"
                    width="100%"
                    height="100%"
-                   style="stroke-width:10.2558" />
-                <use
+                   style="stroke-width:10.2558" /><use
                    x="0"
                    y="0"
                    xlink:href="#path3336-6"
@@ -2708,8 +2160,7 @@
                    transform="rotate(180,477.5036,-570.81898)"
                    width="100%"
                    height="100%"
-                   style="stroke-width:10.2558" />
-                <use
+                   style="stroke-width:10.2558" /><use
                    style="display:inline;stroke-width:10.2558"
                    x="0"
                    y="0"
@@ -2717,8 +2168,7 @@
                    id="use1296"
                    transform="rotate(120,407.33916,-716.08356)"
                    width="100%"
-                   height="100%" />
-                <use
+                   height="100%" /><use
                    style="display:inline;stroke-width:10.2558"
                    x="0"
                    y="0"
@@ -2726,74 +2176,57 @@
                    id="use1298"
                    transform="rotate(-120,407.28823,-715.86995)"
                    width="100%"
-                   height="100%" />
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-      <g
+                   height="100%" /></g></g></g></g></g><g
          style="display:inline"
          inkscape:label="Channels [abandoned]"
          id="layer10"
-         inkscape:groupmode="layer">
-        <g
+         inkscape:groupmode="layer"><g
            sodipodi:insensitive="true"
            style="display:none"
            inkscape:label="⇊ Template for community"
            id="layer12"
-           inkscape:groupmode="layer">
-          <rect
+           inkscape:groupmode="layer"><rect
              y="0"
              x="0"
              height="1024"
              width="1024"
              id="rect1705"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:23.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
+             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:23.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><rect
              y="0"
              x="0"
              height="1024"
              width="1024"
              id="rect1206-2"
-             style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:url(#linearGradient1714);fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-          <ellipse
+             style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:url(#linearGradient1714);fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><ellipse
              ry="505.99619"
              rx="501.10742"
              style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:#ffffff;fill-opacity:0.980392;stroke:#5277c3;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="path1434-2"
              cx="512.00018"
-             cy="76.053795" />
-          <g
+             cy="76.053795" /><g
              style="display:inline;opacity:0.98;stroke-width:0.928591"
              transform="matrix(1.1486953,0,0,1.1486953,196.53936,3.6116383)"
-             id="g1276-8">
-            <g
+             id="g1276-8"><g
                id="g1210-9"
                inkscape:label="bg"
-               style="display:none;stroke-width:0.928591">
-              <rect
+               style="display:none;stroke-width:0.928591"><rect
                  transform="translate(-132.5822,958.04022)"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect1208-7"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-            </g>
-            <g
+                 y="-957.77832" /></g><g
                id="g1218-3"
                inkscape:label="guide"
                style="display:none;opacity:0.516;stroke-width:0.928591"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect1212-6"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect1214-1"
                  width="1496.443"
@@ -2801,21 +2234,17 @@
                  x="155.77646"
                  y="-933.38721"
                  inkscape:export-xdpi="17.971878"
-                 inkscape:export-ydpi="17.971878" />
-              <rect
+                 inkscape:export-ydpi="17.971878" /><rect
                  y="-851.65918"
                  x="159.02695"
                  height="272.58423"
                  width="1492.5731"
                  id="rect1216-2"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                id="g1226-9"
                inkscape:label="logo-guide"
                style="display:none;stroke-width:0.928591"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-958.02759"
                  x="132.65129"
                  height="484.30399"
@@ -2824,8 +2253,7 @@
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
                  inkscape:export-xdpi="22.07"
-                 inkscape:export-ydpi="22.07" />
-              <rect
+                 inkscape:export-ydpi="22.07" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect1222-1"
                  width="501.94415"
@@ -2834,68 +2262,56 @@
                  y="-933.02759"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
                  inkscape:export-xdpi="212.2"
-                 inkscape:export-ydpi="212.2" />
-              <rect
+                 inkscape:export-ydpi="212.2" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect1224-9"
                  width="24.939611"
                  height="24.939611"
                  x="658.02826"
-                 y="-958.04022" />
-            </g>
-            <g
+                 y="-958.04022" /></g><g
                inkscape:label="print-logo"
                id="g1258-4"
                style="display:inline;stroke-width:0.928591"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path1228-7"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
                  id="path1230-8"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
                  id="path1232-4"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
                  id="path1234-5"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path1236-0"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path1238-3"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path1240-6"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><g
                  id="g1256-1"
                  inkscape:label="guides"
                  style="display:none;stroke-width:0.928591"
-                 transform="translate(72.039038,-1799.4476)">
-                <path
+                 transform="translate(72.039038,-1799.4476)"><path
                    d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -2909,8 +2325,7 @@
                    sodipodi:sides="6"
                    id="path1242-0"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                   sodipodi:type="star" />
-                <path
+                   sodipodi:type="star" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
@@ -2925,23 +2340,20 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
-                <path
+                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:nodetypes="ccccccccc"
                    inkscape:connector-curvature="0"
                    id="path1246-3"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
-                   style="fill:url(#linearGradient1659);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-                <rect
+                   style="fill:url(#linearGradient1659);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect1248-2"
                    width="48.834862"
                    height="226.22897"
                    x="-34.74221"
                    y="446.17056"
-                   transform="rotate(-30)" />
-                <path
+                   transform="rotate(-30)" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -2956,8 +2368,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
-                <use
+                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" /><use
                    style="stroke-width:0.928591"
                    x="0"
                    y="0"
@@ -2965,29 +2376,23 @@
                    id="use1252-6"
                    transform="rotate(60,268.29786,489.4515)"
                    width="100%"
-                   height="100%" />
-                <rect
+                   height="100%" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect1254-1"
                    width="5.3947482"
                    height="115.12564"
                    x="545.71014"
                    y="467.07007"
-                   transform="rotate(30,575.23539,-154.13386)" />
-              </g>
-            </g>
-            <g
+                   transform="rotate(30,575.23539,-154.13386)" /></g></g><g
                id="g1274-5"
                inkscape:label="gradient-logo"
                style="display:inline;opacity:1;stroke-width:0.928591"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path1260-5"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                 style="opacity:1;fill:url(#linearGradient1661);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-              <use
+                 style="opacity:1;fill:url(#linearGradient1661);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><use
                  style="stroke-width:0.928591"
                  height="100%"
                  width="100%"
@@ -2997,8 +2402,7 @@
                  inkscape:transform-center-x="124.43045"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.928591"
                  height="100%"
                  width="100%"
@@ -3008,8 +2412,7 @@
                  inkscape:transform-center-x="-168.20651"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.928591"
                  height="100%"
                  width="100%"
@@ -3019,14 +2422,12 @@
                  inkscape:transform-center-x="59.669705"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <path
+                 x="0" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1663);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
                  id="path1268-5"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(120,407.33916,-716.08356)"
@@ -3034,8 +2435,7 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.928591" />
-              <use
+                 style="display:inline;stroke-width:0.928591" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(-120,407.28823,-715.86995)"
@@ -3043,67 +2443,53 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.928591" />
-            </g>
-          </g>
-        </g>
-        <g
+                 style="display:inline;stroke-width:0.928591" /></g></g></g><g
            sodipodi:insensitive="true"
            inkscape:groupmode="layer"
            id="g2322"
            inkscape:label="⇊ Template for community II"
-           style="display:none">
-          <rect
+           style="display:none"><rect
              style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:23.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="rect2246"
              width="1024"
              height="1024"
              x="0"
-             y="0" />
-          <rect
+             y="0" /><rect
              style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:#81bbe5;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
              id="rect2248"
              width="1024"
              height="1024"
              x="0"
-             y="0" />
-          <rect
+             y="0" /><rect
              y="0"
              x="-2"
              height="432"
              width="1024"
              id="rect2330"
-             style="color:#000000;overflow:visible;opacity:0.99;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <g
+             style="color:#000000;overflow:visible;opacity:0.99;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><g
              id="g2320"
              transform="matrix(0.78111278,0,0,0.78111278,295.48677,20.695916)"
-             style="display:inline;opacity:0.98;stroke-width:1.36557">
-            <g
+             style="display:inline;opacity:0.98;stroke-width:1.36557"><g
                style="display:none;stroke-width:1.36557"
                inkscape:label="bg"
-               id="g2254">
-              <rect
+               id="g2254"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect2252"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-                 transform="translate(-132.5822,958.04022)" />
-            </g>
-            <g
+                 transform="translate(-132.5822,958.04022)" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;opacity:0.516;stroke-width:1.36557"
                inkscape:label="guide"
-               id="g2262">
-              <rect
+               id="g2262"><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2256"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-              <rect
+                 y="-957.77832" /><rect
                  inkscape:export-ydpi="17.971878"
                  inkscape:export-xdpi="17.971878"
                  y="-933.38721"
@@ -3111,21 +2497,17 @@
                  height="435.68069"
                  width="1496.443"
                  id="rect2258"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2260"
                  width="1492.5731"
                  height="272.58423"
                  x="159.02695"
-                 y="-851.65918" />
-            </g>
-            <g
+                 y="-851.65918" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;stroke-width:1.36557"
                inkscape:label="logo-guide"
-               id="g2270">
-              <rect
+               id="g2270"><rect
                  inkscape:export-ydpi="22.07"
                  inkscape:export-xdpi="22.07"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
@@ -3134,8 +2516,7 @@
                  width="550.41602"
                  height="484.30399"
                  x="132.65129"
-                 y="-958.02759" />
-              <rect
+                 y="-958.02759" /><rect
                  inkscape:export-ydpi="212.2"
                  inkscape:export-xdpi="212.2"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
@@ -3144,68 +2525,56 @@
                  height="434.30405"
                  width="501.94415"
                  id="rect2266"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  y="-958.04022"
                  x="658.02826"
                  height="24.939611"
                  width="24.939611"
                  id="rect2268"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;stroke-width:1.36557"
                id="g2302"
-               inkscape:label="print-logo">
-              <path
+               inkscape:label="print-logo"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2272"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2274"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2276"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2278"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path2280"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
                  id="path2282"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
                  id="path2284"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <g
+                 sodipodi:nodetypes="cccccccccc" /><g
                  transform="translate(72.039038,-1799.4476)"
                  style="display:none;stroke-width:1.36557"
                  inkscape:label="guides"
-                 id="g2300">
-                <path
+                 id="g2300"><path
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    id="path2286"
@@ -3219,8 +2588,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
-                <path
+                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" /><path
                    d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3235,23 +2603,20 @@
                    id="path2288"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <path
+                   transform="translate(0,-308.26772)" /><path
                    style="fill:url(#linearGradient2324);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                    id="path2290"
                    inkscape:connector-curvature="0"
                    sodipodi:nodetypes="ccccccccc"
-                   transform="translate(0,-308.26772)" />
-                <rect
+                   transform="translate(0,-308.26772)" /><rect
                    transform="rotate(-30)"
                    y="446.17056"
                    x="-34.74221"
                    height="226.22897"
                    width="48.834862"
                    id="rect2292"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-                <path
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                    d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3266,8 +2631,7 @@
                    id="path2294"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <use
+                   transform="translate(0,-308.26772)" /><use
                    height="100%"
                    width="100%"
                    transform="rotate(60,268.29786,489.4515)"
@@ -3275,29 +2639,23 @@
                    xlink:href="#rect5884"
                    y="0"
                    x="0"
-                   style="stroke-width:1.36557" />
-                <rect
+                   style="stroke-width:1.36557" /><rect
                    transform="rotate(30,575.23539,-154.13386)"
                    y="467.07007"
                    x="545.71014"
                    height="115.12564"
                    width="5.3947482"
                    id="rect2298"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:1.36557px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              </g>
-            </g>
-            <g
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:1.36557px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;opacity:1;stroke-width:1.36557"
                inkscape:label="gradient-logo"
-               id="g2318">
-              <path
+               id="g2318"><path
                  style="opacity:1;fill:url(#linearGradient2326);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
                  id="path2304"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3307,8 +2665,7 @@
                  transform="rotate(60,407.11155,-715.78724)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:1.36557" />
-              <use
+                 style="stroke-width:1.36557" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3318,8 +2675,7 @@
                  transform="rotate(-60,407.31177,-715.70016)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:1.36557" />
-              <use
+                 style="stroke-width:1.36557" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3329,14 +2685,12 @@
                  transform="rotate(180,407.41868,-715.7565)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:1.36557" />
-              <path
+                 style="stroke-width:1.36557" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2312"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <use
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.09675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
                  style="display:inline;stroke-width:1.36557"
                  x="0"
                  y="0"
@@ -3344,8 +2698,7 @@
                  id="use2314"
                  transform="rotate(120,407.33916,-716.08356)"
                  width="100%"
-                 height="100%" />
-              <use
+                 height="100%" /><use
                  style="display:inline;stroke-width:1.36557"
                  x="0"
                  y="0"
@@ -3353,69 +2706,54 @@
                  id="use2316"
                  transform="rotate(-120,407.28823,-715.86995)"
                  width="100%"
-                 height="100%" />
-            </g>
-          </g>
-          <path
+                 height="100%" /></g></g><path
              id="path2334"
              d="M 0,448 H 1024"
-             style="fill:none;fill-rule:evenodd;stroke:#5277c3;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-        <g
+             style="fill:none;fill-rule:evenodd;stroke:#5277c3;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><g
            sodipodi:insensitive="true"
            inkscape:groupmode="layer"
            id="g2243"
            inkscape:label="⇊ Template for community [nope 2]"
-           style="display:none">
-          <rect
+           style="display:none"><rect
              style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:23.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="rect2167"
              width="1024"
              height="1024"
              x="0"
-             y="0" />
-          <rect
+             y="0" /><rect
              style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:#81bbe5;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
              id="rect2169"
              width="1024"
              height="1024"
              x="0"
-             y="0" />
-          <path
+             y="0" /><path
              sodipodi:nodetypes="csssssc"
              d="M 512.00018,582.04998 C 221.51116,563.99284 -23.6827,232.2101 224.53982,62.897739 425.90307,-74.451953 63.687857,-186.84685 157.66373,-281.73954 c 93.97587,-94.89269 235.45115,-207.61004 354.33645,-148.20285 212.59187,106.23254 283.91116,84.70481 354.33645,148.20285 99.18751,89.43111 -192.49425,258.230378 -78.80645,329.534872 384.17722,240.954258 38.925,549.231168 -275.53,534.254648 z"
              style="color:#000000;display:inline;overflow:visible;opacity:0.98;fill:#ffffff;fill-opacity:0.980392;stroke:#5277c3;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="ellipse2171" />
-          <g
+             id="ellipse2171" /><g
              id="g2241"
              transform="matrix(1.1486953,0,0,1.1486953,196.53936,3.6116383)"
-             style="display:inline;opacity:0.98;stroke-width:0.928591">
-            <g
+             style="display:inline;opacity:0.98;stroke-width:0.928591"><g
                style="display:none;stroke-width:0.928591"
                inkscape:label="bg"
-               id="g2175">
-              <rect
+               id="g2175"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect2173"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-                 transform="translate(-132.5822,958.04022)" />
-            </g>
-            <g
+                 transform="translate(-132.5822,958.04022)" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;opacity:0.516;stroke-width:0.928591"
                inkscape:label="guide"
-               id="g2183">
-              <rect
+               id="g2183"><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2177"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-              <rect
+                 y="-957.77832" /><rect
                  inkscape:export-ydpi="17.971878"
                  inkscape:export-xdpi="17.971878"
                  y="-933.38721"
@@ -3423,21 +2761,17 @@
                  height="435.68069"
                  width="1496.443"
                  id="rect2179"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2181"
                  width="1492.5731"
                  height="272.58423"
                  x="159.02695"
-                 y="-851.65918" />
-            </g>
-            <g
+                 y="-851.65918" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;stroke-width:0.928591"
                inkscape:label="logo-guide"
-               id="g2191">
-              <rect
+               id="g2191"><rect
                  inkscape:export-ydpi="22.07"
                  inkscape:export-xdpi="22.07"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
@@ -3446,8 +2780,7 @@
                  width="550.41602"
                  height="484.30399"
                  x="132.65129"
-                 y="-958.02759" />
-              <rect
+                 y="-958.02759" /><rect
                  inkscape:export-ydpi="212.2"
                  inkscape:export-xdpi="212.2"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
@@ -3456,68 +2789,56 @@
                  height="434.30405"
                  width="501.94415"
                  id="rect2187"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  y="-958.04022"
                  x="658.02826"
                  height="24.939611"
                  width="24.939611"
                  id="rect2189"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;stroke-width:0.928591"
                id="g2223"
-               inkscape:label="print-logo">
-              <path
+               inkscape:label="print-logo"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2193"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2195"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2197"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2199"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path2201"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
                  id="path2203"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
                  id="path2205"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <g
+                 sodipodi:nodetypes="cccccccccc" /><g
                  transform="translate(72.039038,-1799.4476)"
                  style="display:none;stroke-width:0.928591"
                  inkscape:label="guides"
-                 id="g2221">
-                <path
+                 id="g2221"><path
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    id="path2207"
@@ -3531,8 +2852,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
-                <path
+                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" /><path
                    d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3547,23 +2867,20 @@
                    id="path2209"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <path
+                   transform="translate(0,-308.26772)" /><path
                    style="fill:url(#linearGradient1665);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                    id="path2211"
                    inkscape:connector-curvature="0"
                    sodipodi:nodetypes="ccccccccc"
-                   transform="translate(0,-308.26772)" />
-                <rect
+                   transform="translate(0,-308.26772)" /><rect
                    transform="rotate(-30)"
                    y="446.17056"
                    x="-34.74221"
                    height="226.22897"
                    width="48.834862"
                    id="rect2213"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-                <path
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                    d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3578,8 +2895,7 @@
                    id="path2215"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <use
+                   transform="translate(0,-308.26772)" /><use
                    height="100%"
                    width="100%"
                    transform="rotate(60,268.29786,489.4515)"
@@ -3587,29 +2903,23 @@
                    xlink:href="#rect5884"
                    y="0"
                    x="0"
-                   style="stroke-width:0.928591" />
-                <rect
+                   style="stroke-width:0.928591" /><rect
                    transform="rotate(30,575.23539,-154.13386)"
                    y="467.07007"
                    x="545.71014"
                    height="115.12564"
                    width="5.3947482"
                    id="rect2219"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              </g>
-            </g>
-            <g
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;opacity:1;stroke-width:0.928591"
                inkscape:label="gradient-logo"
-               id="g2239">
-              <path
+               id="g2239"><path
                  style="opacity:1;fill:url(#linearGradient1667);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
                  id="path2225"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3619,8 +2929,7 @@
                  transform="rotate(60,407.11155,-715.78724)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <use
+                 style="stroke-width:0.928591" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3630,8 +2939,7 @@
                  transform="rotate(-60,407.31177,-715.70016)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <use
+                 style="stroke-width:0.928591" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3641,14 +2949,12 @@
                  transform="rotate(180,407.41868,-715.7565)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <path
+                 style="stroke-width:0.928591" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2233"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1669);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <use
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1669);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
                  style="display:inline;stroke-width:0.928591"
                  x="0"
                  y="0"
@@ -3656,8 +2962,7 @@
                  id="use2235"
                  transform="rotate(120,407.33916,-716.08356)"
                  width="100%"
-                 height="100%" />
-              <use
+                 height="100%" /><use
                  style="display:inline;stroke-width:0.928591"
                  x="0"
                  y="0"
@@ -3665,61 +2970,48 @@
                  id="use2237"
                  transform="rotate(-120,407.28823,-715.86995)"
                  width="100%"
-                 height="100%" />
-            </g>
-          </g>
-        </g>
-        <g
+                 height="100%" /></g></g></g><g
            sodipodi:insensitive="true"
            inkscape:groupmode="layer"
            id="g2137"
            inkscape:label="⇊ Template for community [nope]"
-           style="display:none">
-          <rect
+           style="display:none"><rect
              style="color:#000000;overflow:visible;fill:#81bbe5;fill-opacity:1;stroke:none;stroke-width:23.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="rect2061"
              width="1024"
              height="1024"
              x="0"
-             y="0" />
-          <path
+             y="0" /><path
              sodipodi:nodetypes="ccccccc"
              d="M 858.58387,488.19869 511.99999,688.29898 165.41611,488.19868 -177.97958,286.25769 851.95796,-308.37702 858.58388,87.998094 Z"
              transform="matrix(0.92831429,0.53534503,-0.53596252,0.9272448,199.20721,-273.25951)"
              inkscape:transform-center-y="82.542361"
              inkscape:transform-center-x="47.710841"
              style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#5277c3;stroke-width:56.0063;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="path2143" />
-          <g
+             id="path2143" /><g
              id="g2135"
              transform="matrix(1.1486953,0,0,1.1486953,196.53936,3.6116383)"
-             style="display:inline;opacity:0.98;stroke-width:0.928591">
-            <g
+             style="display:inline;opacity:0.98;stroke-width:0.928591"><g
                style="display:none;stroke-width:0.928591"
                inkscape:label="bg"
-               id="g2069">
-              <rect
+               id="g2069"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect2067"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-                 transform="translate(-132.5822,958.04022)" />
-            </g>
-            <g
+                 transform="translate(-132.5822,958.04022)" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;opacity:0.516;stroke-width:0.928591"
                inkscape:label="guide"
-               id="g2077">
-              <rect
+               id="g2077"><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2071"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-              <rect
+                 y="-957.77832" /><rect
                  inkscape:export-ydpi="17.971878"
                  inkscape:export-xdpi="17.971878"
                  y="-933.38721"
@@ -3727,21 +3019,17 @@
                  height="435.68069"
                  width="1496.443"
                  id="rect2073"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2075"
                  width="1492.5731"
                  height="272.58423"
                  x="159.02695"
-                 y="-851.65918" />
-            </g>
-            <g
+                 y="-851.65918" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:none;stroke-width:0.928591"
                inkscape:label="logo-guide"
-               id="g2085">
-              <rect
+               id="g2085"><rect
                  inkscape:export-ydpi="22.07"
                  inkscape:export-xdpi="22.07"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
@@ -3750,8 +3038,7 @@
                  width="550.41602"
                  height="484.30399"
                  x="132.65129"
-                 y="-958.02759" />
-              <rect
+                 y="-958.02759" /><rect
                  inkscape:export-ydpi="212.2"
                  inkscape:export-xdpi="212.2"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
@@ -3760,68 +3047,56 @@
                  height="434.30405"
                  width="501.94415"
                  id="rect2081"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  y="-958.04022"
                  x="658.02826"
                  height="24.939611"
                  width="24.939611"
                  id="rect2083"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;stroke-width:0.928591"
                id="g2117"
-               inkscape:label="print-logo">
-              <path
+               inkscape:label="print-logo"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2087"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2089"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2091"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2093"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path2095"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
                  id="path2097"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
                  id="path2099"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <g
+                 sodipodi:nodetypes="cccccccccc" /><g
                  transform="translate(72.039038,-1799.4476)"
                  style="display:none;stroke-width:0.928591"
                  inkscape:label="guides"
-                 id="g2115">
-                <path
+                 id="g2115"><path
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    id="path2101"
@@ -3835,8 +3110,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" />
-                <path
+                   d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z" /><path
                    d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3851,23 +3125,20 @@
                    id="path2103"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <path
+                   transform="translate(0,-308.26772)" /><path
                    style="fill:url(#linearGradient1342-6);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
                    id="path2105"
                    inkscape:connector-curvature="0"
                    sodipodi:nodetypes="ccccccccc"
-                   transform="translate(0,-308.26772)" />
-                <rect
+                   transform="translate(0,-308.26772)" /><rect
                    transform="rotate(-30)"
                    y="446.17056"
                    x="-34.74221"
                    height="226.22897"
                    width="48.834862"
                    id="rect2107"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-                <path
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                    d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -3882,8 +3153,7 @@
                    id="path2109"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    sodipodi:type="star"
-                   transform="translate(0,-308.26772)" />
-                <use
+                   transform="translate(0,-308.26772)" /><use
                    height="100%"
                    width="100%"
                    transform="rotate(60,268.29786,489.4515)"
@@ -3891,29 +3161,23 @@
                    xlink:href="#rect5884"
                    y="0"
                    x="0"
-                   style="stroke-width:0.928591" />
-                <rect
+                   style="stroke-width:0.928591" /><rect
                    transform="rotate(30,575.23539,-154.13386)"
                    y="467.07007"
                    x="545.71014"
                    height="115.12564"
                    width="5.3947482"
                    id="rect2113"
-                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              </g>
-            </g>
-            <g
+                   style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.928591px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></g><g
                transform="translate(-132.5822,958.04022)"
                style="display:inline;opacity:1;stroke-width:0.928591"
                inkscape:label="gradient-logo"
-               id="g2133">
-              <path
+               id="g2133"><path
                  style="opacity:1;fill:url(#linearGradient1344-8);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
                  id="path2119"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3923,8 +3187,7 @@
                  transform="rotate(60,407.11155,-715.78724)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <use
+                 style="stroke-width:0.928591" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3934,8 +3197,7 @@
                  transform="rotate(-60,407.31177,-715.70016)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <use
+                 style="stroke-width:0.928591" /><use
                  x="0"
                  y="0"
                  xlink:href="#path3336-6-7"
@@ -3945,14 +3207,12 @@
                  transform="rotate(180,407.41868,-715.7565)"
                  width="100%"
                  height="100%"
-                 style="stroke-width:0.928591" />
-              <path
+                 style="stroke-width:0.928591" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2127"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1346-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <use
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1346-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.78578;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><use
                  style="display:inline;stroke-width:0.928591"
                  x="0"
                  y="0"
@@ -3960,8 +3220,7 @@
                  id="use2129"
                  transform="rotate(120,407.33916,-716.08356)"
                  width="100%"
-                 height="100%" />
-              <use
+                 height="100%" /><use
                  style="display:inline;stroke-width:0.928591"
                  x="0"
                  y="0"
@@ -3969,32 +3228,23 @@
                  id="use2131"
                  transform="rotate(-120,407.28823,-715.86995)"
                  width="100%"
-                 height="100%" />
-            </g>
-          </g>
-        </g>
-        <g
+                 height="100%" /></g></g></g><g
            style="display:inline"
            inkscape:label="Off-Topic"
            id="layer13"
-           inkscape:groupmode="layer">
-          <g
+           inkscape:groupmode="layer"><g
              transform="rotate(13.097353,667.68439,-4.408383)"
-             id="g1733">
-            <ellipse
+             id="g1733"><ellipse
                style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:#727272;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                id="path1723"
                cx="659.63055"
                cy="830.2522"
                rx="431.36444"
-               ry="266.5979" />
-            <path
+               ry="266.5979" /><path
                style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#727272;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="M 342.29022,657.41174 C 271.32799,575.27519 391.06962,472.79543 461.08753,382.44815 449.39549,459.84454 363.12479,601.33746 497.506,585.54867"
                id="path1725"
-               sodipodi:nodetypes="ccc" />
-          </g>
-          <text
+               sodipodi:nodetypes="ccc" /></g><text
              transform="matrix(0.95394398,0.13672176,-0.14721811,1.0271799,0,0)"
              id="text1729"
              y="779.45374"
@@ -4005,8 +3255,7 @@
                y="779.45374"
                x="513.2229"
                id="tspan1727"
-               sodipodi:role="line">chat</tspan></text>
-          <image
+               sodipodi:role="line">chat</tspan></text><image
              mask="url(#mask1786)"
              transform="rotate(8.2933216,-3283.2744,16605.403)"
              id="image1745"
@@ -4015,138 +3264,100 @@
              height="784"
              width="1060"
              x="-4.8608909"
-             y="492.96091" />
-        </g>
-        <g
+             y="492.96091" /></g><g
            style="display:none"
            sodipodi:insensitive="true"
            inkscape:label="GNOME"
            id="layer14"
-           inkscape:groupmode="layer">
-          <g
+           inkscape:groupmode="layer"><g
              transform="translate(-12.182683,-22.415685)"
-             id="g2053">
-            <g
+             id="g2053"><g
                style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:0.683659;filter:url(#filter2033)"
                id="g15041-5"
-               transform="matrix(1.891639,0,0,1.891639,-6787.5298,-1678.2939)">
-              <g
+               transform="matrix(1.891639,0,0,1.891639,-6787.5298,-1678.2939)"><g
                  id="g15043-4"
                  style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.683659;stroke-miterlimit:4"
-                 transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)">
-                <g
+                 transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"><g
                    id="g15045-7"
-                   style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659">
-                  <path
+                   style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"><path
                      id="path15047-4"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"
-                     d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" />
-                  <path
+                     d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" /><path
                      id="path15049-4"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"
-                     d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" />
-                  <path
+                     d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" /><path
                      id="path15051-3"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"
-                     d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" />
-                  <path
+                     d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" /><path
                      id="path15053-0"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"
-                     d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" />
-                  <path
+                     d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" /><path
                      id="path15055-7"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.683659"
-                     d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" />
-                </g>
-              </g>
-            </g>
-            <g
+                     d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" /></g></g></g><g
                transform="matrix(1.891639,0,0,1.891639,-6787.8882,-1677.6037)"
                id="g15041"
-               style="stroke-width:0.683659">
-              <g
+               style="stroke-width:0.683659"><g
                  transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"
                  style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.683659;stroke-miterlimit:4"
-                 id="g15043">
-                <g
+                 id="g15043"><g
                    style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                   id="g15045">
-                  <path
+                   id="g15045"><path
                      d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                     id="path15047" />
-                  <path
+                     id="path15047" /><path
                      d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                     id="path15049" />
-                  <path
+                     id="path15049" /><path
                      d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                     id="path15051" />
-                  <path
+                     id="path15051" /><path
                      d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                     id="path15053" />
-                  <path
+                     id="path15053" /><path
                      d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.683659"
-                     id="path15055" />
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-      <g
+                     id="path15055" /></g></g></g></g></g></g><g
          style="display:none"
          inkscape:label="Channels [abandoned] (2)"
          id="layer15"
          inkscape:groupmode="layer"
-         sodipodi:insensitive="true">
-        <g
+         sodipodi:insensitive="true"><g
            sodipodi:insensitive="true"
            style="display:inline;opacity:0.995"
            inkscape:label="⇊ Template for community III"
            id="g2414"
-           inkscape:groupmode="layer">
-          <rect
+           inkscape:groupmode="layer"><rect
              transform="rotate(60)"
              style="color:#000000;overflow:visible;opacity:0.99;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="rect2340"
              width="1430.0167"
              height="695.49402"
              x="131.97935"
-             y="-914.89905" />
-          <g
+             y="-914.89905" /><g
              style="display:inline;opacity:0.98;stroke-width:0.858126"
              transform="matrix(1.243015,0,0,1.243015,267.84901,66.785357)"
-             id="g2410">
-            <g
+             id="g2410"><g
                id="g2344"
                inkscape:label="bg"
-               style="display:none;stroke-width:0.858126">
-              <rect
+               style="display:none;stroke-width:0.858126"><rect
                  transform="translate(-132.5822,958.04022)"
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2342"
                  width="1543.4283"
                  height="483.7439"
                  x="132.5822"
-                 y="-957.77832" />
-            </g>
-            <g
+                 y="-957.77832" /></g><g
                id="g2352"
                inkscape:label="guide"
                style="display:none;opacity:0.516;stroke-width:0.858126"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-957.77832"
                  x="132.5822"
                  height="483.7439"
                  width="1543.4283"
                  id="rect2346"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <rect
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d4d4d4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9b9b9b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2348"
                  width="1496.443"
@@ -4154,21 +3365,17 @@
                  x="155.77646"
                  y="-933.38721"
                  inkscape:export-xdpi="17.971878"
-                 inkscape:export-ydpi="17.971878" />
-              <rect
+                 inkscape:export-ydpi="17.971878" /><rect
                  y="-851.65918"
                  x="159.02695"
                  height="272.58423"
                  width="1492.5731"
                  id="rect2350"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-            </g>
-            <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#848484;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g><g
                id="g2360"
                inkscape:label="logo-guide"
                style="display:none;stroke-width:0.858126"
-               transform="translate(-132.5822,958.04022)">
-              <rect
+               transform="translate(-132.5822,958.04022)"><rect
                  y="-958.02759"
                  x="132.65129"
                  height="484.30399"
@@ -4177,8 +3384,7 @@
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5c201e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nix-wiki.png"
                  inkscape:export-xdpi="22.07"
-                 inkscape:export-ydpi="22.07" />
-              <rect
+                 inkscape:export-ydpi="22.07" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c24a46;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2356"
                  width="501.94415"
@@ -4187,68 +3393,56 @@
                  y="-933.02759"
                  inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-logo-only-hires-print.png"
                  inkscape:export-xdpi="212.2"
-                 inkscape:export-ydpi="212.2" />
-              <rect
+                 inkscape:export-ydpi="212.2" /><rect
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d98d8a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  id="rect2358"
                  width="24.939611"
                  height="24.939611"
                  x="658.02826"
-                 y="-958.04022" />
-            </g>
-            <g
+                 y="-958.04022" /></g><g
                inkscape:label="print-logo"
                id="g2392"
                style="display:inline;stroke-width:0.858126"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
                  id="path2362"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 353.50926,-797.4433 -122.21756,211.6631 -28.53477,-48.37 32.93839,-56.6875 -65.41521,-0.1719 -13.9414,-24.1698 14.23637,-24.721 93.11177,0.2939 33.46371,-57.6903 z"
                  id="path2364"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 362.88537,-628.243 244.41439,0.012 -27.62229,48.8968 -65.56199,-0.1817 32.55876,56.7371 -13.96098,24.1585 -28.52722,0.032 -46.3013,-80.7841 -66.69317,-0.1353 z"
                  id="path2366"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7ebae4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 505.14318,-720.9886 -122.19683,-211.6751 56.15706,-0.5268 32.6236,56.8692 32.85645,-56.5653 27.90237,0.011 14.29086,24.6896 -46.81047,80.4902 33.22946,57.8256 z"
                  id="path2368"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <path
+                 sodipodi:nodetypes="cccccccccc" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2370"
                  d="m 309.40365,-710.2521 122.19683,211.6751 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4902 -33.22946,-57.8256 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2372"
                  d="m 451.3364,-803.53264 -244.4144,-0.012 27.62229,-48.89685 65.56199,0.18175 -32.55875,-56.73717 13.96097,-24.15851 28.52722,-0.0315 46.3013,80.78414 66.69317,0.13524 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <path
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2374"
                  d="m 460.87178,-633.8425 122.21757,-211.66304 28.53477,48.37003 -32.93839,56.68751 65.4152,0.1718 13.9414,24.1698 -14.23636,24.7211 -93.11177,-0.294 -33.46371,57.6904 z"
-                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-              <g
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><g
                  id="g2390"
                  inkscape:label="guides"
                  style="display:none;stroke-width:0.858126"
-                 transform="translate(72.039038,-1799.4476)">
-                <path
+                 transform="translate(72.039038,-1799.4476)"><path
                    d="M 460.60629,594.72881 209.74183,594.7288 84.309616,377.4738 209.74185,160.21882 l 250.86446,1e-5 125.43222,217.255 z"
                    inkscape:randomized="0"
                    inkscape:rounded="0"
@@ -4262,8 +3456,7 @@
                    sodipodi:sides="6"
                    id="path2376"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.236;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                   sodipodi:type="star" />
-                <path
+                   sodipodi:type="star" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4e4d52;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
@@ -4278,23 +3471,20 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" />
-                <path
+                   d="m 385.59154,773.06721 -100.83495,0 -50.41747,-87.32564 50.41748,-87.32563 100.83495,10e-6 50.41748,87.32563 z" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:nodetypes="ccccccccc"
                    inkscape:connector-curvature="0"
                    id="path2380"
                    d="m 1216.5591,938.53395 123.0545,228.14035 -42.6807,-1.2616 -43.4823,-79.7725 -39.6506,80.3267 -32.6875,-19.7984 53.4737,-100.2848 -37.1157,-73.88955 z"
-                   style="fill:url(#linearGradient2416);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-                <rect
+                   style="fill:url(#linearGradient2416);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.415;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c53a3a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect2382"
                    width="48.834862"
                    height="226.22897"
                    x="-34.74221"
                    y="446.17056"
-                   transform="rotate(-30)" />
-                <path
+                   transform="rotate(-30)" /><path
                    transform="translate(0,-308.26772)"
                    sodipodi:type="star"
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.509;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -4309,8 +3499,7 @@
                    inkscape:flatsided="true"
                    inkscape:rounded="0"
                    inkscape:randomized="0"
-                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
-                <use
+                   d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" /><use
                    style="stroke-width:0.858126"
                    x="0"
                    y="0"
@@ -4318,29 +3507,23 @@
                    id="use2386"
                    transform="rotate(60,268.29786,489.4515)"
                    width="100%"
-                   height="100%" />
-                <rect
+                   height="100%" /><rect
                    style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.650794;fill-rule:evenodd;stroke:none;stroke-width:0.858126px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                    id="rect2388"
                    width="5.3947482"
                    height="115.12564"
                    x="545.71014"
                    y="467.07007"
-                   transform="rotate(30,575.23539,-154.13386)" />
-              </g>
-            </g>
-            <g
+                   transform="rotate(30,575.23539,-154.13386)" /></g></g><g
                id="g2408"
                inkscape:label="gradient-logo"
                style="display:inline;opacity:1;stroke-width:0.858126"
-               transform="translate(-132.5822,958.04022)">
-              <path
+               transform="translate(-132.5822,958.04022)"><path
                  sodipodi:nodetypes="cccccccccc"
                  inkscape:connector-curvature="0"
                  id="path2394"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-                 style="opacity:1;fill:url(#linearGradient2418);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-              <use
+                 style="opacity:1;fill:url(#linearGradient2418);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><use
                  style="stroke-width:0.858126"
                  height="100%"
                  width="100%"
@@ -4350,8 +3533,7 @@
                  inkscape:transform-center-x="124.43045"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.858126"
                  height="100%"
                  width="100%"
@@ -4361,8 +3543,7 @@
                  inkscape:transform-center-x="-168.20651"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <use
+                 x="0" /><use
                  style="stroke-width:0.858126"
                  height="100%"
                  width="100%"
@@ -4372,14 +3553,12 @@
                  inkscape:transform-center-x="59.669705"
                  xlink:href="#path3336-6-7"
                  y="0"
-                 x="0" />
-              <path
+                 x="0" /><path
                  style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2420);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5744;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
                  d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
                  id="path2402"
                  inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccccccc" />
-              <use
+                 sodipodi:nodetypes="cccccccccc" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(120,407.33916,-716.08356)"
@@ -4387,8 +3566,7 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.858126" />
-              <use
+                 style="display:inline;stroke-width:0.858126" /><use
                  height="100%"
                  width="100%"
                  transform="rotate(-120,407.28823,-715.86995)"
@@ -4396,349 +3574,291 @@
                  xlink:href="#path4260-0-3"
                  y="0"
                  x="0"
-                 style="display:inline;stroke-width:0.858126" />
-            </g>
-          </g>
-          <rect
+                 style="display:inline;stroke-width:0.858126" /></g></g><rect
              y="-205.33731"
              x="131.46283"
              height="695.49402"
              width="1409.8817"
              id="rect2340-8"
              style="color:#000000;display:inline;overflow:visible;opacity:0.99;fill:#000000;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             transform="rotate(60)" />
-          <path
+             transform="rotate(60)" /><path
              id="path2534"
              d="m 269.85547,-3.4042969 -27.71094,15.9999999 512,886.808597 27.71094,-16 z"
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
-        </g>
-        <g
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#5277c3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /></g><g
            inkscape:groupmode="layer"
            id="g2512"
            inkscape:label="GNOME copy"
            style="display:none"
-           sodipodi:insensitive="true">
-          <rect
+           sodipodi:insensitive="true"><rect
              transform="rotate(60)"
              style="color:#000000;display:inline;overflow:visible;opacity:0.99;fill:#8ff0a4;fill-opacity:1;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="rect2340-8-6"
              width="1409.8817"
              height="695.49402"
              x="131.46284"
-             y="-205.3373" />
-          <g
+             y="-205.3373" /><g
              style="stroke-width:0.870562"
              id="g2510"
-             transform="matrix(1.1503045,0,0,1.1470639,-47.225667,-187.64358)">
-            <g
+             transform="matrix(1.1503045,0,0,1.1470639,-47.225667,-187.64358)"><g
                transform="matrix(1.891639,0,0,1.891639,-6787.5298,-1678.2939)"
                id="g2492"
-               style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:0.595168;filter:url(#filter2033)">
-              <g
+               style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:0.595168;filter:url(#filter2033)"><g
                  transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"
                  style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.595168;stroke-miterlimit:4"
-                 id="g2490">
-                <g
+                 id="g2490"><g
                    style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                   id="g2488">
-                  <path
+                   id="g2488"><path
                      d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                     id="path2478" />
-                  <path
+                     id="path2478" /><path
                      d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                     id="path2480" />
-                  <path
+                     id="path2480" /><path
                      d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                     id="path2482" />
-                  <path
+                     id="path2482" /><path
                      d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                     id="path2484" />
-                  <path
+                     id="path2484" /><path
                      d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z"
                      style="fill:#ffffff;fill-opacity:1;stroke-width:0.595168"
-                     id="path2486" />
-                </g>
-              </g>
-            </g>
-            <g
+                     id="path2486" /></g></g></g><g
                style="stroke-width:0.595168"
                id="g2508"
-               transform="matrix(1.891639,0,0,1.891639,-6787.8882,-1677.6037)">
-              <g
+               transform="matrix(1.891639,0,0,1.891639,-6787.8882,-1677.6037)"><g
                  id="g2506"
                  style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.595168;stroke-miterlimit:4"
-                 transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)">
-                <g
+                 transform="matrix(2.438586,0,0,2.438586,3659.952,1113.451)"><g
                    id="g2504"
-                   style="fill:#000000;fill-opacity:1;stroke-width:0.595168">
-                  <path
+                   style="fill:#000000;fill-opacity:1;stroke-width:0.595168"><path
                      id="path2494"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.595168"
-                     d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" />
-                  <path
+                     d="M 86.068,0 C 61.466,0 56.851,35.041 70.691,35.041 84.529,35.041 110.671,0 86.068,0 Z" /><path
                      id="path2496"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.595168"
-                     d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" />
-                  <path
+                     d="M 45.217,30.699 C 52.586,31.149 60.671,2.577 46.821,4.374 32.976,6.171 37.845,30.249 45.217,30.699 Z" /><path
                      id="path2498"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.595168"
-                     d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" />
-                  <path
+                     d="M 11.445,48.453 C 16.686,46.146 12.12,23.581 3.208,29.735 -5.7,35.89 6.204,50.759 11.445,48.453 Z" /><path
                      id="path2500"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.595168"
-                     d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" />
-                  <path
+                     d="M 26.212,36.642 C 32.451,35.37 32.793,9.778 21.667,14.369 10.539,18.961 19.978,37.916 26.212,36.642 Z" /><path
                      id="path2502"
                      style="fill:#000000;fill-opacity:1;stroke-width:0.595168"
-                     d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" />
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
+                     d="m 58.791,93.913 c 1.107,8.454 -6.202,12.629 -13.36,7.179 C 22.644,83.743 83.16,75.088 79.171,51.386 75.86,31.712 15.495,37.769 8.621,68.553 3.968,89.374 27.774,118.26 52.614,118.26 c 12.22,0 26.315,-11.034 28.952,-25.012 C 83.58,82.589 57.867,86.86 58.791,93.913 Z" /></g></g></g></g></g></g></g><g
        sodipodi:insensitive="true"
        style="display:inline"
        inkscape:label="⇒ Mattes"
        id="layer2"
-       inkscape:groupmode="layer">
-      <g
+       inkscape:groupmode="layer"><g
          sodipodi:insensitive="true"
          inkscape:label="canvas"
          id="layer17"
-         inkscape:groupmode="layer">
-        <path
+         inkscape:groupmode="layer"><path
            d="M -568.84961,-351.6543 V 1449.2793 H 1768.9102 V -351.6543 Z M 0,0 H 1024 V 1024 H 0 Z"
            style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:0.988098;stroke:none;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3073" />
-      </g>
-      <g
+           id="rect3073" /></g><g
          sodipodi:insensitive="true"
          style="display:inline"
          inkscape:label="Circle [channel]"
          id="layer3"
-         inkscape:groupmode="layer">
-        <path
+         inkscape:groupmode="layer"><path
            sodipodi:nodetypes="cccccsssssssss"
            d="M -813.74019,-551.48012 V 1987.6791 H 1905.1503 V -551.48012 Z M 512,0 C 647.79084,0 778.02005,53.942702 874.03867,149.96133 970.0573,245.97995 1024,376.20916 1024,512 1024,647.79084 970.0573,778.02005 874.03867,874.03867 778.02005,970.0573 647.79084,1024 512,1024 376.20916,1024 245.97995,970.0573 149.96133,874.03867 53.942702,778.02005 0,647.79084 0,512 0,376.20916 53.942702,245.97995 149.96133,149.96133 245.97995,53.942702 376.20916,0 512,0 Z"
            style="color:#000000;overflow:visible;fill:#ebeaea;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-           id="rect854" />
-      </g>
-      <g
+           id="rect854" /></g><g
          sodipodi:insensitive="true"
          style="display:inline"
          inkscape:label="Roundrect [space]"
          id="layer4"
-         inkscape:groupmode="layer">
-        <path
+         inkscape:groupmode="layer"><path
            d="M -579.02539,-314.67383 V 1461.5566 H 1791.6309 V -314.67383 Z M 258.12305,0 h 507.7539 C 908.87663,0 1024,115.12337 1024,258.12305 v 507.7539 C 1024,908.87663 908.87663,1024 765.87695,1024 H 258.12305 C 115.12337,1024 0,908.87663 0,765.87695 V 258.12305 C 0,115.12337 115.12337,0 258.12305,0 Z"
            style="color:#000000;overflow:visible;fill:#ebeaea;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-           id="rect898" />
-      </g>
-    </g>
-    <g
-       sodipodi:insensitive="true"
+           id="rect898" /></g></g><g
        style="display:inline;opacity:0.999"
        inkscape:label="⇒ Widgets"
        id="layer5"
-       inkscape:groupmode="layer">
-      <g
-         sodipodi:insensitive="true"
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true"><g
          style="display:inline"
          inkscape:label="Public Room [channel]"
          id="layer6"
-         inkscape:groupmode="layer">
-        <circle
+         inkscape:groupmode="layer"
+         sodipodi:insensitive="true"><circle
            r="192.00002"
            cy="832"
            cx="832"
            id="path921"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.89135;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
-        <image
-           mask="url(#mask953)"
-           id="image894-3"
-           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQUAAAFJCAIAAAAdbq/RAAAAA3NCSVQICAjb4U/gAAAgAElEQVR4 nO2deXhdVbn/1z7zPGZOkzZNmzRNbBNKextKByqlCIgighSv+AOr6PW5DAo//KH3esV7nUEEFa5A UdQK96kC4rVQwAClpUPaBpqkaZu2mZOTnJx5nvbvj5csds85OeMeT/bn6dMn55y913r33uu71/Su dxE22xTKDJHhE4cUZ0ihZ9N6+fMnVkQ2BZ2a7ST6E80txTzzLSpHAiGEJPllyCNIrg0QKUGEq4cS QJQ07xD1ICLyEdn0wJvugogICwi6fhDbG3TB/p3k6bPLWw88vQ4REToQdP2AhC9PodtfaghdDyKl Cxd9V1EPIqVDxto2p6pY1EOpIbbAiqEE9CAWABHaKEQPYgGkFZ7cTp6YwTElUD+UHHybA2XKHj4q MKMe+PZg5oWPd1ZEiIj1g4jIR4h6EBH5iJLRg6CbTII2vqQoGT2IFI8oy0L1IN45ETpguRxlz66U 6gdRpCLFUkp6EPkQ8cVQMKIeeEIJlmEhXpKoBxFewtFccInpQYivJH4jGB8FephfD9luhFj0REqP EqsfRIpkob/lSk8Pwn2iwrW8dCg9PQicBdZe59tbQNSDiMhHiHoQEfkIUQ8iC4oszTNRD/nBr9au CN2UpB7EQitSIEXpQSx3pciCfqrz6KG0R/1K++qEBw8UOFckSrK9JFx4UDIWNqIeRBYamV46oh5E 5mfhNSxLVQ9iw0PIcKfDUtWDMFl472O+IepBROQjFp4exHewyPwsPD0Ujdg1YQC+3NRi9cCX6xAR oQOxfhBJZeG+5UpYDwv3oYpkY96yUcJ6ECiijLlE1IOIyEeIeuAN4kAwDxD1IDIPbOuTu4Yi5UrT 6aF0XlQpt7h0Lq104fQZifVDIYh93lJF1INIWkpe8ukvUNSDiMhHyLg2oCAIQi6XSwiJVCqVSCQS iYT48G+CIESFswFJkgkykYjHSZJMJBIkScbj8QSZiEWjgq5ZhKQHiVSqkCtUKpVcLhe7xtxCEISU kEol0tSfIpFINBaJRiLxRIJ9w4qEBj2QDJdNuVyhUCgUCqVMJiT1LljgaSENisfj4Ug4Go3EYzGu jcoVXpcwpVKl1eqk0jQvIRH+I5VKNWoNUmviiXgwEIhEwlxblB2e6kEuV+h0OplMzrUhIjQglUh1 On0spg4E/bFodP4DmW5qZId3epBKZTqdXqFQcG2ICM3IZDKD3hiNRYMBf4yvLSge6UEqlWq1eqVS ybUhIgwil8nlBlMkEgkE/Yl4nFNb0lRHfNGDUqkyGAycV5ci7AB9bp/Py32n4uISx4vReo1GazAY RTEsNHQ6vVqt4dqKi+C4fiAIQqfTq1Rqbs0Q4Qq1WiORSPx+H9eGfEiKHlh8RxOExGg0yeXiINKC RqlUSaRSn89L8mD+jrP2kkQiNZnMohhEEEJymdygNxCEBBEce3twoweCkJhMJnG+WQQjlcr0eu4H VLjRg9FolEpFMYhchEwm02l17OaZXB3Ro4e8KjmtVieXi9NtImlQKJQaTkec2K4flEqVRqNlOVMR AaFSqRXcvS5Z1YNUKjMYDGzmKCJEdDp9Wk9yFmBPDxKJ1GQycd5hEhEEer1BQnBQVNjTg06nk3Ak ehHBIZFIOGlXs6QHmUymVKrYyUukNFAolOy3mljSg06nZycjkVKCfe8mNiYBFArFgh1g9fv9Z8+e HRoaGhoaGh8fHxwcnJiYGBwcdDgc1MPUarVKpYL/4Q+1Wl1XV9fW1rZy5crW1tbly5dzdQkcolAo ZGEZm4slCJtt6uIvCk1o/p9MJsvC8cs4e/ZsT09PT0/P8ePHT5w4YbPZ6Ep59erVra2t7e3tl19+ eWdnJ13J8pxYLObxunM/Pr/ySySfxLgelEqlwWAqMFEh4HK53njjjQMHDhw7dqynp8fr9bKQqVqt 7uzs3LJly+WXX37FFVewkCOH+HzeSDSS48F814PZbC1JP6VDhw69/PLL+/btO378ONe2oM2bN19/ /fU333zzokWLuLaFfuLxuNvjyvFgWvVQxIBv2lOlUqnFUlZ4ovyjp6fnD3/4w549e4aHh7m2JQ1r 16694YYbbrrppmXLlnFtC5243c4coznxWg8ajVbLtocWI4RCod27dz/xxBPd3d1c25ITbW1tO3bs uPPOO61WK9e20EAgGAiFgrkcyQs9zN9Ysgg9ZozL5frxj3/8xBNPuN159Or4w5133nnfffcJvbrI vVfNXz1IJBKrtbzAFHnAzMzMT3/60yeeeMLn48tqxoK5/vrr77///ssvv5xrQwrH5XImyOxNJvr0 QHdjSa3WCHQazm63/+QnP3n88cdDoRDXttBJe3v7d7/73U9/+tNcG1IIgYA/FM7+OPirB5PJLLhp uNnZ2R/+8Ie//vWvg8GcWqtCZPPmzY8++mh7ezvXhuRHJBLx+bOPZedRiok0f9Hgr5HWAoKQCGsO zuPx/Pu//3tDQ8PDDz9cwmJACL399tsdHR233XbbxMQE17bkgVwuJ5j3eGXKf0kikQjItftnP/tZ fX3997//fXZm0/jA73//+9ra2gcffFAol0wQhIT5zT3m2kt0N5aEMi09PDx86623Hjx4kGtDOKOy svIPf/jDlVdeybUh2cllorqg9tJHH5irHwSw1OGZZ55pa2tbyGJACNlstm3btt1+++38H1CWSBiv HxhtL/EXl8t1/fXX79y5swTGUmnht7/97cqVK9966y2uDckEW/0HuhtLiN96eOedd1paWl555RWu DeEXExMTV1xxxZ133hkIBLi2JT0Crh94G17pW9/61ubNm6emprIfuiD5zW9+09HRMTIywrUhaWCh UC2g9tLk5GRnZ+ePf/xjrg3hO2fOnFmzZs3hw4e5NiQZiYS+9tI8KTFVagkaTaeDt99+u7W19dCh Q1wbIgzsdvv69ev37NnDtSEXwcJmyhImOg8IIRaGinPnueee27Jli9Pp5NoQgXHTTTfxqjoV8Hwc f/j2t7/9xS9+kWsrhMq3vvWtnTt3cm0Fe/C010sXX/nKV5566imurRA2zzzzjMPh+Mtf/sK1IWxQ yvWDKAa6ePHFF6+77jqurchO8c2pktXDl7/8ZVEMNPK///u/1157LddWME7heuDX+NHFfOlLX3r6 6ae5tqLU+Pvf/37VVVdxbQWzlGD9cO+99+7atYtrK0qT119/fevWrdFolGtDimP+d3mp6eE///M/ H330Ua6tKGW6urpuvfVWrq1gipLSw5///Od/+7d/49qK0mfPnj3/8R//wbUVjEDYpgvx5MnaeSgv rywg2WLo7u5eu3Yty5kuZPbs2XPjjTeynKnDOZvh11z7tGmOY3j9A8uMj49fc801XFuxsPjsZz97 5MgRrq2giw+3QCwRPVx//fUzMzNcW7HguPbaa2kM2MwHSkEPX/rSl/gQRHUBYrfbt23bxrUVdCJ4 PTz33HPi6CqHnDx58u677+baCtoopD+dS6+Fnf706OhoS0uL3+9nIS+RDLz++uvsRCRgrD/94bfC rh9uvvlmUQx8YMeOHYJxp88oGgHr4eGHHxbX9/AEu91+8803c20FDQhVD8PDwwVPvREEIZFIJBIJ kT/4LHovpwR44403SsAzIO/+Q44Fgen+w8aNG999993Czi2+NJMkWWQKJYlKpZqYmDCbzcxlQUP/ Yd6DBNt/2LVrV8FiQAiRRUPjtZQSoVDorrvu4tqKohBe/eDxeBYvXuxy5bqhGBWJRKLVas1mM27z 5FW44ZREIhEOh91ud4lFw6eL3t7e1tZWhhJnun4Q3nrRBx54oDAxEAQhk8mqqqo6OjqgG1BYIpFI xOFw9Pb2RiKRRG6bmi0ovvKVrxw4cIBrKwpEYHro7e198sknCztXIpGoVKq1a9c+8MADMplMKi0w wqzf7+/t7f31r3/tdDpFPaRy8ODBv/3tbzxdX5rtHSgwPRQ2FUoQBEmSBEFIpVKTydTY2KhQKPLd BRhSQAh5PB6n06lWq8VRpvn45je/yVM9ZCO//jS3z//AgQP/+Mc/ikyEJMlEIpFIJPLqHMORUBvA 6UWaUdqcOXPm2Wef5dqKfCGRsMaXvvGNbxSfCNZDEvMJI9/jRYCHHnqIaxMKQTB6OHDgAC3e9nhO DX9DLdlJs2+pp5MkiefyqGcVb1iJMTQ09Oqrr3JtRd4Ipv9Ay/sGhpg0Gk3uc8zUkVn4Q6VSabVa 3P3A89agK/gfjoR+S9pWGZyS9GXSwfPJMvWwrElxwv3333/11VdzaEAB5KEHDt+BQ0ND+/btKzIR kiTj8bjT6RwYGKC+4EmSNJlMBoNBqVQmDTpFIhG/3+/1eqk7LIbD4eHhYb/fj0tb2j9ADPCR+jc+ IJfCmuMx/Gy89fb2HjlyZN26dVwbkgfCqB++/e1vF58ISZKRSGR4eHjfvn0ymQxe8FCYVqxY0dTU VFZWJpVKqYXY7/ePjo6eP39+YmICv6oDgcDw8LDdboe2E/StU0tkajMs6cusnXJqhZMZ3vbv77vv vnfeeYdrK/JAAHoIhUK7d+8uJgVcsKLR6Llz51566aWk+uGqq67S6XQ6nU6pVELZghLscrn6+vre e++93t5efHwsFvN4PDMzM/F4nCRJo9FYVlZWVVVVVlZmNBphZiMWiwUCAY/HMzU1NTU15XQ6kyaz y8vLly5dCgfjJpbP53M6nTabDXboKSsrKy8vNxqNCoWCqlK32z01NeX1egOBAEEQZWVlDQ0NoHCc lN/vdzqdU1NT3G72s3///pmZmfLycg5tyAsB6IGukTuSJGOx2MTEBN53Gb+z6+rq2tvbI5EI9WCE kM/nGx4ePnHixIEDB5J6ESRJajQas9nc0NDQ1NTU2NhYV1dXUVGhUCikUmk0GvV4PHa7/dy5c2fO nDl37tz4+LjD4cDpV1dXb9myRavVKpVKyEsikdhstsHBwcOHD0Mhrqur6+joqK2t1el01AsZGRk5 fvz40NBQMBiUSqV1dXVXXXWVSqWSy+U4qfHx8bNnz/p8PtAMhw2qhx566PHHH+cq93wRgB7o9SKm 9j5xyZZKpVKpNLXnKpVKYeZOKpXCWYlEAp/V0NDw8Y9/fM2aNW1tbTqdTq1WK5VKqHkSiUQsFoPu x9TU1Pvvv//WW2+99tprsVgM6p+qqqqtW7darVaDwYCNGR0dPXLkyJkzZ2A7r+bm5u3bty9dutRo NFKt6u/vJ0nS7/fbbDaFQrF8+fKbbrpJLpdTu/gffPABQmhgYGBmZgYadVxJ4plnnnnsscd4MQSX gwm56oGrq5mYmDhz5gyNCeLeJ7W9lGG4Ke3QjVarXbJkycaNGz/5yU8uX768rq4O/4QPwwnW19dX VFSoVKpwOHz69Onh4WHoeCiVyoqKitraWtAYQRByuXx8fFytVsOJFRUVy5cvb2hoMBgM1PZSKBRq aGg4efIkJGK1WpctWyaXy6lNr6GhodQr5YRgMDgwMNDS0sKhDbnD9/qBiSUmuPeJX/m5zMfhjyRJ 6vX6TZs2XXvttRs3boSRViro4qFSlUrV1NSkUCgMBsMf//jH4eFhhJDX6z1//rzFYqmqqorH4wgh mUwGw8G4+CqVSvAKgY4KbgvJ5XKLxQJ1kVKphGYSWBiPx8EtxW63j42N8cQD96GHHvrTn/7EtRU5 wff5uOeee47R9HNvRWBnb6vV2tLSsmHDhtbWVplMBg0kmKSTSqXQr4X2FUYqlVZUVKxfv37NmjUr VqzQ6XTBYNBmswWDQerpKpVKo9FAy0elUun1epPJpFAoJBej0WgqKipgFgU0A50WyAj+8Hq9s7Oz uEfEbRXx/PPP83YELAle1w+jo6P8CXeFi1RNTc3q1avb2tpqa2vj8TgeqorFYsFgMBQKxWIxKKZa rRY7Pul0OqPR2N7ePjg46PF4QqEQ6AHPl4MetFqtQqFQKBRqtdpgMOj1erlcjqsghBBVD3AKtSeN jfT5fA6HA/TAhwmK3t7eVatWMZoFLYrPqX7g6t3yzDPPcJRzJhoaGlavXm00GpOm4WBw9s0333z5 5ZcPHDgA7SIASjxJkkuWLFm9erXBYAgGgzAYSvUfkcvl8LIHMcDoE3WKEA5TKBS4vaRSqRQKBZor 9JBLNBr1er0ulysWi4EaOdfDww8/zK0BOcLr+oE/G/xAqYKyW1tb29TUpNVqqb3wRCIxPDz817/+ dXh42OVyVVVVbdmyJWmGASFUXV29bNkyg8HgcrnGx8e9Xi+ivNTlcjm877Varclk0mg0IIakd79C oYBfQTlKpRLN6QGGen0+n8vl8ng80Wg01V8r62UyIZ7nnnvud7/7He3J0g5/9eD3+/FEAR9IJBIS iUQmk5WVldXU1EBPF3suxWKxwcHBF154we12B4NBpVIpk8k++clPQpnG7kwmk6mqqkqr1UYikcnJ SXD6wIUVhneVSiUsaoWCjkefsCVyuVyv12s0GuhvwGEAVA5ut9vj8fj9fmjOKRSKHP214vE4bmLR e/cQQh6PBw8u85bseuCqsXT48GGOck4PSZJyuVyn04GzEwz24052OByGt3IoFIpEIjCH7fF4ZDIZ Lq8EQSgUCp1OZ7FY5HK53W7H4pFKpVDupVKpSqUyGAxlZWUw8EoQRDgcDgaDMplMLpdD91omk0Ed otfrVSoVonQSQqHQzMwMiIEkyebm5m3btoF+sg6/nj59uqury+l0er3eVAeTIjl69OjHP/5xulJj CP7WD4899hjXJiQjk8nArQO3ZADwjAqHw9FoFIp1IpGAyTi9Xo8o7n24uCsUiunpaXiLwyAV1D/Q JdDr9VarFQo6Qgg632q1WqfTwRirVCrFeqD2H9CcHgKBAHxcvHjxjTfeWFFRYTab59MD/v6NN97o 7e0NhUKgB3priccee4xLPeT2XuevHl577TWuTUhGKpVCqz1pMpskyXg8HovF4vF4IpGA+QSYoqZO XCCEoAbQarUqlSqRSECVAmOsuH+i1WotFguMIMEpHo/n1KlTZrO5srJSqVRChaPT6cBjCs/fQRaB QABaYmiuRjLOkfUCwY89dQqSFv76179SG4f8JIseuLIdRiQ5ynxeYC4Mlxjq6xOPq1IFkLZvCvPQ 0NwCB77y8nL8dpdKpTqdzmw2Q/2APWrHx8djsZharY7FYpAO1gO1/4AQCoVCU1NTOKwt2AzdkqwX yJwYALvdznPfPp7Oxw0NDXFtQhoyj9UkFf35Rv1hEhqaW+DzR50lkMlkRqOxvLwc1w8IoVAoZLfb nU6n3+/HejAYDJWVlWazGdcPQCAQmJiY4GeY57Nnz3JtQhZ42l46ePAg1yakAcaR5huRTFrOlmFI Jx6PQ5sqaRYZISSVSvV6PagCOgYIoWAwODk5CUNbeK9bnU5ntVqNRiN0M7CfYjAYnJ6exm7eMEsI ZO4/IIQikQj0wgu4Obnw5ptvXnbZZQwlTguZ9MBhQ++FF17gLvN5icfjuNOc1K5Iu6gae8VSga42 vObdbvfMzEw4HMa/yuVyq9UaiUTMZjPuT/v9/rGxMblcXlVVFY1GobwaDIaqqiqNRgPe4HhlEp7p QwiRJOnz+YaGhvx+v8PhwEs75rvAiYmJUCgEWmVCFU8//TTPN4Dlaf3w1ltvcW1CGmKxmN/vDwaD kUgExj3he2gCQeMbO1fDZAJVDzBiA0uFoHeE6wfcElOpVIsXL47FYni8FSEUDodnZmZ0Op3L5cL1 g9VqbWhoUCqVED8YqqN4PO73+2dnZ/EC1zNnzjz11FMqlQovtMgwvjQxMTE+Pg5tLSb0MDIyQnua 9MJHPfDW9ysWi3m9Xq/X6/P5DAYD1WtIoVDAAKjH40kkEkqlUq/X63Q6uVwO50IpjEajfr/f7XZD mYN1dlA/wJiVUqmsq6sDfyeVSgWdimAwaLfb9Xo91gNJkuCyAUNe5NwCwGAw6PV6HQ4HHo2w2Wwu lyvH+bhYLBYOhxl17ojH4wVHRmSBefXAYWOJn31BiUQSj8fBT87pdIIXHf5JpVJZLJZFixYNDw9H o1Gr1VpRUQHzbtRBxkAg4HA47HY7eGpA/QB6gJpELpdXVlYiSvcjkUiEQiGn02k0GkEPIBKDwQDT vcRc9EEwz+l0ut1uaPMghOLxeO5LRllwc/J4PEwExKeruPKxfuCPTysG+2UkEgmbzTY0NGQymcB9 Ff/a2Nj4+c9/fnR01O12V1ZWrlu3DhwlEKVBYrfbR0ZGPB4PlNdgMOhyuXw+XzgcVqvVZMrKJCjN fr8f5si8Xi+4JGGrEGUgKxaLud1ur9dL7RNz7smXxOTkJKMbRBRJej1wO2XCrdsSLrtJJQmXwrGx sYGBgcbGRqvVSv21sbGxsrJyenra7/dbrVaLxYK98XAVMT4+PjAwAO9vgiCCwaDb7Xa5XIFAALtd YDPwK9/r9YbDYa/X63a7Iag41QMcHxyLxaBywC5PfBMDQujChQsrV67k2op54eP8A4c7q6fOIaT+ feHChRMnTtjtdvCWQ5SpA71eX1tbu3TpUjx7QBUDSZKDg4Pd3d1utxt3f0ESPp8PIUQdycWvfI/H A7+Ci5Tf76eOz+IswJPP4XC43W74np8zwefOneMg15zvBB/bSxyOQmTud0LJttlsvb29x48fN5lM TU1NaK7swugq7lRQ00QIOZ3O0dHRnp6e06dP+3w+yAgcAR0OB3QnUonFYi6XC36FKsLj8QSDQTwU iz1nEULRaHR2dhY2x8CTIXyrIqanp7k2IRNp9MD5W4X9yWmCslEidRQVlzbcOCEIIhQKjYyM7Nu3 T6fTNTU14cOwgwbIJmnnxZGRkRdffPH48eMQyAx/DyXe4/EghKAVBD/B6fF4HLoECKFoNBoIBCBY IGxxlGR8LBaj1g/8ZHJykmsTMsHH+oHegBq5AL530WgUj95AIQP/POr4L/zq8Xh6enpgRB9CYIAf EY7iiube2R6PZ3p6+ty5cwcPHnz11VdHR0ehJ42FF41GZ2ZmZmdnIS9q4wq0NzMzA698qExmZ2ed TmdlZSUcTM2RejAegWXzNuYCr9a0pJKsB84rB4TQfI0H5giHwx6Px+VygQbgS5lMBhMFMJeMSxhB EOFwGMKBTU1Nbdu2bfPmzfX19RCcD6cJ1cX4+HhfX19XV9fBgwfff/993EzCCUYiEZvNNjEx4XA4 YFwIdALj9Ha7HX7CdtpstsnJyYqKCurBYNXs7Oz09DTP6wf2H25e8LF+YO2J4hf/sWPHnE6nxWIB N2w09/52uVxjY2PQn0nq6RIE4Xa7+/v7Z2dn33nnnZqaGlhjAMv/YSYbFoWOjY1BDYDnExClceXz +Xp6elwu1+HDh6mdbxhECgaDQ0NDo6OjkLXD4Xjttdf6+/uxSyy1t+PxePr6+mA0gjr6xCt4Ltfk /UXpqh+K2V/UaDRCe5o1wJ0hydsZWuSw0Ad7laKLVzPD3wqFAjy0LRYL+GjEYjGYGoNFcEnHUwFf D6VSiaeZqcBkHDYAFgOB83bqweCsEYlE+KkEwGAwFCOJ+fYXzVJucy3WxEV6oLGxVIwe2B8oxKMx qT+l+vzg8U3qAI50DmrfGvxYqSEu5zMggxt5kjttBlNTD+YnxVjItB742F5in8yti6TCRz0YDz3B 4jjq8Uk92syFAGsm1bC0puZ4cIbLSWukyEd64ENPmhOIufB41Fdv0jsYSgy8ffEWcohSkqgn4m+g lOfSlJ/vfZ+2YslwcC4ZUS8Nn1LKksinZPOxfqirq8M9SKaRyWRqtbqqqqqyslKr1Wo0GojgolKp YBUbFOtoNAoeRC6Xa2ZmZnp6enZ2NhQKUVtNaVtWOZqRV3EspuymVi8sK4HnIWf4qIempiYW9ACF WKVSlZWVtbe3Q8x6iJ2Bg0DClDNEJQoGgzAma7PZxsbGxsbGJiYm7HY7LIfAyfL8RatUKsELHeL4 KxQKiHzjdDrBM4ppA+rr65nOohjmdgzg1oqLYWHJOX6pGwyGZcuWXXfddZ/4xCdwq4k6tUxQ9kSE zjH4FA0PDx88eHDv3r1DQ0NTU1NZe8x8gCAICMZstVohFoHVarVara+//vr+/ftB20y7eOQS5oND +Fg/lJWVsZYXhK8zGAxWqzWpwUNtWFMb3Aghk8kEm2uZzeaurq7Dhw87HI5wOMx0YSoGgiBg85TP fe5zOp3OYDBAQCedTnf69GkcUYppYUNAKnqh8W0uozc5WsDbi7AAefF264iyAQrUCXjkh6CgUCig y3HZZZdpNBqPx/PBBx+AHhD/agliLhSaWq3+2Mc+dscddySNFkBYJ1wrMmp/TU0Nc4kXDx/rh6qq KpZzhJYS/ht/D8UIf6SOIOFp7I6ODljy5nQ68ZArD4HITtgLnbptZOYdYeilurqahVwKho96YHkI IvX1j+ZCUIZCIWhSy+VyHJkvaXZs+fLlfr//3XffhcjeLLxi8wK6Q4lEQiaTQQx9lDLfkjoyxhwV FRUs5FIwMr41lhBC1HVnLIPHIqPRqNPpnJiYGBkZgWhIS5cuhQ2q4Ui8fBRGqOrq6srLy/Hag9QZ ZZQuTkJS2yyzbVStps5IzPcTmpv8lsvlsMEKjkyD9Z86kMCcnnGQNX7Cx/phyZIlHOYOHYZgMHjm zJnu7u6jR49KpVKj0djU1LRmzZrOzk7JxXtXQ7u8urq6rKwsNf5cUo+CWtrwVAB+PWcuhWk1kBQf Nm0KOP6NwWDQ6XTUoTMgHo9DUCk8kpb3XcuZhoYG5hIvHj7qgdv6ASFEEEQgEDh16tSbb765d+9e hJBGo1myZInb7V63bh1CiLpNCUmSsMEhjCTiQkaSJH4TY4i5ZQ9JhQ+3anKXBO7zpJ5FzReGiSEL av+BvHhNUjgchtHkIm5eTjQ3NzOdRTHwUQ94MSS34L0J4Q06OTk5MjIyMzNjNBp1Oh31lQ+Dtkkr ReHlbbFYqqurGxoaamtrYdddhUJBkmQ4HA4EAjMzM2NjY+fOnbPZbOors/kAACAASURBVHivoPkk UVdX19DQALv3gmO5VCqFABxut3tiYmJ4ePjChQtOpzMWi+F6qb6+/tJLL9VqtRUVFS0tLStWrEAp Xhvt7e233HKLx+NxOBwzMzOnT59mbskuz+MZ81EPjIaYzhHiYqemeDzucrkgojB0SbOertForFbr ihUr2traVqxY0dDQUF1dDdvDIYRCoRBsgHT+/Pm+vr6+vr6BgQGfz5cUKwlyN5vNNTU1q1atam9v b2xsrK2tLSsrw3qAoPlDQ0MDAwMffPDBwMAAxICCaqG2tnb79u0QQL+8vByKI3HxdEpzc7NOp4tE IlNTU4ODg16vd2RkhKGx41zCjNNJnv1jPuoBIbR58+a3336baysQSgkAk7TzA5prkITDYfDawM36 mpqaTZs2XXHFFWvXrtVqtaAEaiMnHo8vWrSora1t06ZNhw4deumll/r7+y9cuEDtYxAEoVAoWltb b7rpppUrVy5fvhyWasjlcnyYxWKpqalZunTpJZdcsmHDhjfffPP555+HPX4QQhaLpb29vby8HKoU HCOZSlVVlcViSSQSExMTcrkcdmZiolfNc2cNxFs9bN++nXM9kJT4AAqForKysra2FsJuJxWUaDQK Hn4IoUQioVarKysrOzs7b7jhhhUrVmQYHtBoNAaDoaKiAnZS/Nvf/ub3+z0eD0R0BXeS9vb2bdu2 bd26FZpJ+LWdJEvYyMtisUBttn///uPHj8fjcZlMBjGP9Xp9UrWAwQLzeDxJO5rSy5VXXslQynTB Uz1cfvnl3BqA562h6KtUqqVLlzY2NloslqQjCYKAzRHxQk2VStXS0rJp06ZrrrkGK2q+XBBCMpms ubm5ubnZ5XINDg4ODg6Gw2FoC5nN5iuvvPITn/jEypUrk5YWUdszeLstq9W6bt26xYsXe73evr4+ 2AwbPA4hAlratiisWyIIAtx4qYsB6aWzs5OhlOmCp3poaWnhJF88EKnT6drb2+VyeVtbG+xv29DQ 0NzcTH3Fwit8eHj42LFjZ86csdvtCCGISn/FFVdceuml1GH+DJmC9iQSSUdHx+TkJATki8fj1dXV 0Geoq6uDLnKGNzdMFJIkqVQqKysrOzo6BgcHP/jgA5lMBp14qntS6rmgE9iykbn6Yf369QylTBc8 1QOHQ65QMlQqVUNDg9lsbm1thR0Qy8vLYY9dNFeCwQP8/fffP3To0MjICIRh1mq1UI6XLl2K+wDQ holEIhCwgyAI2CQOCiIeeG1sbFy7di3s5R4Khaqrq1tbW5cuXWqxWOD9DblDYDJ464P/tslkAuNh HlqpVDY1Na1evXp4eJikrFydb1Uqrgkz7PZCC42NjbSnSe+EMk/1QBDEunXrjhw5wn6+8IdMJgMn 1qqqKolEIpVKoYUNv4I3x9mzZ/fv39/V1XXkyBG32w0tnOrq6hUrVpSXlyeNGvt8vvHx8bfeeuvE iRNyubyjo+NTn/qUXq8HjYEezGbzkiVLFi9ePDg4OD4+3tjYeMkllxiNxqQ+/eTk5JEjR/r7+202 W21t7bp167Zt20a1nyTJJUuWrFq16u2334a9heBXiKGf2mTy+/1+vz+RSNjtdmqsfHoBj1omUqYR nuoBIXTvvffu2LGD/XypkpBKpUm7neMCB2/TYDAIzRu8bU95eXl9fT1sjIuntwiCcDgcPT09hw8f PnLkiEwmi8fjra2tDQ0NENYbzc3r6fV6GO0ZHx8vLy9fvHgx3vgd2zAxMfHmm2+ePXt2enq6vLxc oVB0dnZCnxibajaba2trTSbT7Ozsq6++ajab6+vr161bV19fr9frk9xJzp4929vb6/F4bDbb+Pg4 hAyjvZa4/fbb6U2QCfirhy1btnBrQGpXGLc3oIDqdLq6urra2try8vKpqSkYbwU94FKO5grW5OTk W2+9dfz48dOnTyOEtFrtsWPHNBoN+HtSR1erqqpgBYjVaq2trQU9QNYwtjs0NPTKK694PB6YrLBa rTfddJPVaoWBLzgYdlssLy8/efLkL3/5S4lE0tLScv/991ssllQ9HDt2rKenJxaLabXa5ubm9evX l5eXm0wmxxwjIyODg4NnzpwpZp7ulltuKfjcAsm/LcVfPXDuCJkUU57a8iYIAjYuueSSSwwGQ319 /d///veBgQGYrTObzbDzAy7laC44EnQD0NxWQ3jzKwwECdfr9eAWpdVqUzd+h8Eiaso+nw+vsyHn 1myAA59Wq4WOPo6HSc0OUrjzzjtzvCdut/svf/nL3r179+7dC1HHc2f16tV5Hc8J/NWDRCJpampi OZYrFgDeiAS6v7DUWKPRwCg+DPWYzWaTyVRfX19dXT01NeV0Os+fPw+7ZkHThSohaFxhTwoIWJaq B1iloNPpFAqFWq1Wq9VJeoAgs7FYDPsCwoZ0SRHTINK4TqeDmiptEKcC7o/RaLz99tuh5bNr165d u3YdOHAglxMF0XlAfNYDQuiHP/zhjTfeyHKmMPQZCAT6+/t7e3v7+/txs76lpWXt2rXQvUZzc8wy mayiomLt2rWTk5Pnz5+Xy+Ww1iwpWXJu+TV0KuDcVP85aDJBQAMYJKUWXJBrfA5qUkkvfpAEBPND FAFAd6gwMSRxxx133HHHHb29vffee+8bb7yR+eCvfe1rxefIArzWw/bt21nOEXdtIah9d3f3O++8 I5PJtFptWVnZ1NSUTqerqakpKyvDNQnsGN3S0nLy5EmEEKgltcAlvaTnm6SDmoe6Wym6uGtLUkib clJSuHqpqanZunUr7QPZbW1tr7/++p///Od77703Q1SUr371q/TmyxC81oNWq21oaLhw4QL7WcPe IsPDw6dOncJf2mw2nU63efNm0ANCCAJ6w6aguGecYQg/l0EbeJdniGCZOziFBx988Dvf+Q5zvnQ3 3njj9u3bd+7cmXbjcPCWZyhreuHekzQzTz75JCf5Qp8BgnVDE0gmk0GlkRSxHV7D4GaHEIIQyGkb QtRV2vOVeOghhMNh2Pg9tSFEUBxvc0mqubn55MmT3//+95l2LNXpdM8///xTTz2V+tN3vvMdRrOm Eb7rYfPmzZzki4sdtH+AaDTq8Xhge1xEaZRDSx0m7GBhA4z/UFs1oCtq1ALqRwxsehIKhUKhUCQS gQnjJKtgVpuaVGpkcpgRb2lp2b17d1tbGyP3KB07d+48fvx4UqtMKJ0HxH89KJXKVatWsZ8vdFsh SjGEvI9Go0qlsrq6WqfTpT0FtAE7oqfGx4c1Q7jUQpWS5CkEmfr9fp/Ph6MZJOlBLpfDRCH+EkZm k+KAkCSp1+u/+MUv0nAv8qSjo+PQoUM4jkZFRQV2J+E/fNcDQui///u/2c8UXvnYU9pqtTY2Nq5a tWrt2rXUiRE84APrH0iSdLvdMzMzuA5BczrR6XRLliyBRQhKpdJkMtXV1SUF5wIPU9gTMZFIeL1e CCOJO9CgBzgXduiyWCywtiFph8V4PM5+2B7MsmXLsCR+8YtfcGVGAfC6Pw3AkmWWgdX3EM4R4vAt W7Zsy5YtmzZtgpJHdbeGl3owGEQIQYDXpC1xEUImk6mtra2/vx8iJVdUVDQ3N8PO5NSeQCwWgx3i EEIej8dut5tMJhi5Bz3IZDKr1drW1gYdlUWLFtXX11utVrlcTlIWRaRuc5qVcCRim3bYpu0DgxeG RycRQq3NjYvra6xmY1VlmTLdQqIM1NfXd3V1rV+//tOf/nS+lnCIAPQgkUjuueeeRx99lIW8iDl0 Ot2qVauMRuOll14KMcDNZnNdXR04JqG55dF4V6vBwcHh4WGEECy59Hg8Sc7eZWVla9euVSqVl112 mUwma2xsbGhowPUDHAMrqmGVNkJodHS0v7+/srLSaDRCRnDYsmXLvvCFL2zatMnhcJSXl7e0tOCW GG6b5X7Jdofr7YPd7x15P/WnA0d6DhzpwR8vX9+xqXONxZxrANbm5ub9+/czuho+0wBcQYNzAtAD QugHP/gBc3pIO3ELC4AaGho2bdqUYegTGkter/f06dOgB7vdPjQ0NDMzEwgEqCutDQaDwWCorq4O hULgJkiNRASvdtiubnx8HOI4jY2NnTp1qqOjIymmXXV1dU1NjdvtDofDWq0Wr2iDNhV1T8fMTNpm fv3M/wQv9mZdumQR9ePE5HQo/GFd9+6hE+8eOmExG3d+4TMVZcnrotLCZleeFoShB7Vafdtttz33 3HMMpU+d4UryU6IWNfLiVZrQenE4HOfOnTtw4EBfX59EIvH7/aOjo4cOHTKZTP/0T/8Ek8dYUXhY VjK3Ty5OliCI3t7erq6uycnJWCwmkUhgpVFnZ2dNTQ2sb6aucYO4/DKZjKBEIM9xKY/H6//l039y OD/ax+3S9ta1Ha2NDWki5567MNp7anD/oePw0eF0/+SxZy1m479+eYdelz20grAQhh4QQr/4xS8Y 0gOuE9J69RCUZfVJv8IOKSdPnty/f39/fz+4zUEH4OjRo+Xl5UuWLIFIAviUpA158d8+n292dvbE iROw0yl4W3g8ngsXLhw9etRsNlP9ROZLKkevpLEJ26NP/gF/bF3R+KlrtlpM88YIbWyoa2yoq6mu eOHFV/GXDqf7ez958p6v/vOimsI3CuQh0vvvv4+JdLXa9IOSBaNSqfbt2zc2NkZLalB0SJI0mUw1 NTVr1qyBtaBp9YAo/Qoqdru9t7d3z549e/bsGR8fx/G9I5HI+Pg4SZKLFi0Cd1d8ClVaGIlEMjIy 0tXVtXfv3oMHD0LEWJhACIVCk5OTUql01apVMDCF7aHWZjidrBfe3dP39O//gj9u29L52eu3qVXZ p+pqqyvMJmPfwCD1y0PdH0gkkqQmFqMEQ0HqR7r7D4Rg9IAQuvbaax9++GFaksKlU6PRmEym5cuX 19TUQMxG+B4XVjTnghGNRvGW0qdPn+7u7u7q6nr99ddPnDgxNjYWDoeTQuLByCnM34FbK0zYQdsJ EnQ6nSMjIydOnPjHP/6xb9++gYEBGFlClNoDZj8cDgfED08kEuDghObEAEEAfD5f1tCo3Sf6nqe8 47dt6dy+9bLcb1ptdUUwGB4Zm6R+OXhh1Gox1VSxFGWMaT0Ipr2EEKqqqtqwYUOODsaZwaUtHA7P zs4ODg729PTodDrYQg670+GxfChzEMFufHz8/Pnzp06dOnXqVFLAVpxsPB4fnGNkZGT16tWNjY1V VVUQxg88KQKBwNTU1NmzZ7u7u7u7u3t6eqhjuEAsFnM6nd3d3WfOnNmwYcOGDRuamppqa2th7TVI F5ZxZ40DOTZho4qhdUVjXmIAnK40+4L/6c97rWbTknpeb+yQI8T0xfux00Ux+09nwOl0pkZ8KQYI fFRRUWG1WlUqFSw5gFILXVWEEDgUwTvY6/XCtLHP54PVEZnTNxqNZrNZr9dbLJaysjK1Wg1bqUNq TqfT4XC43W6PxzPfFvTEnI+G2WyGKLFmsxmWHEml0lgs5vf729ravvvd72YwIxyOfPu/Hqd+8+A3 vpyhz5CWl//ehXvVqXz//31drWY80Ch1/+ksFUDe9QOBBNSfBsxm83333fezn/2MrgRheY3X64Wl C3ijQWrYlVgsFo1God0CE8+pL/L5cLvdbrcbzW1kCNs0kiQJGzQGg0HqTPZ8wGoHm802PT0N3hmw JyLoIRQK7dy5M3MKP/vV76gfL21vzVcMR0/0ZRADQujnT/7hwXuzmMEehXoGC6x+QAjFYrECJl9z hDpVTP0ej40iyirqXEKzQCckbSAmat96vuUQqUkldaNJkrRardPT0xlOTBpQQgh942tfqKnOYznu 0RN91MGl+fjXL+9YXMdsqynX+qGgzgMShP9SEjKZ7KWXXmIocTIj+Ji8Npgi063moca7z0UMac2D RD7/+c9nPuux3+ymfjQbDUyIASH09O9fzD1ZfiI8PSCEPvWpT1VWMjjsnXbUFX9ZQAnOnEW+SSWZ d80112Q4a2zClrQYo61lWS7ZYY6e6M3xyGAoNDZhyytxviFIPSCEGA1Vlrl+oCtZutLBwcjSsv+9 5Ea/av7ZhnNDY8FQ9v5MBt5853Axp3OOwPrTmPr6+rvvvltYvsRMsHHjxgy/kiR57P3+HJPCw0c1 VeU11RW1VRU11RXBUOj8UB5zoCf7zyZIUsLK1oxMIFQ9IIQeeeSR3//+9w6Hg2tDuCRz4GefP5D6 Ze08nYfxqQ875RNTMxNTM92orzCTPF6fyUD/puvsINT2EkJIIpFASIuFDOx/NR+j42la8/O1iLZf cdnSJYvgn0qZ32oHKiOjk9kP4isCrh8QQjU1NU888YSAlufSTl1dGo9UjG1mNvXLl/d2tbUsS/VZ amyo+5eGz8HfDpfnB4+kiQyQC6MTtlWtTYWdyzkCrh+Ar371q5dccgnXVnBG5qmYvlPnUr8MhcJP 7Hohc78539k6KhOTmSZD6IKhDorg9YAQeu+99wQRC5EJMq/+mbDNpP9+auaJXS840jkjYS5tby3M pLSVEqsUoRVht5cAhUIxMDCwePFirg3hHRq1MnUlNzAxNYNbRCqVclPnmo2dl1AbUbd85upbPnM1 9ZRzF0af3f0SXi5XkpRC/YAQqq+vf+2117i2ggOSgqMl0bgkU+8CEwqF93Ud/K9Hnjp6ItOYUmND 3b/c8TmzMUtTqrKcs72diqdE9IAQuuqqqxbgdAQ4C85H3aI8Qs6EQuGsU9E11RXf+Ppt27Z0ZhiA yssZhDd82MYqHT0ghO6666577rmHaytYJbMeDAysb1arlNu3Xvbtb35lvg5GnZBXkJaUHhBCP//5 z++44w6urWCPDCG1EUINi2sZyletUt7ymavTSqK+rjr1S6FQanpACD3zzDM333wz11awRG9vphaO TptlBWmRrO1IoweDnv6lwqxRgnpACL3wwgvXXXcd11awQeYZeoIg1qxemXtqaZeD5sXHWpaz4LzE XAalqQeE0CuvvHLrrbdybQXjzM7Ojo+PZzhg68Y8on06XZ5zFzI1wJLALk+Yq7Z25n46IxSnlZLV A0Loj3/849133821FYyzb9++DL9WVljNpjy86/Z1vZf7wd0Xj8+qVIrqSpYCbTBEKesBIfToo4/+ 6Ec/4toKZnnllVcyH3DnF2/KPbVzQ6P73zueyyoIh8szMXXR/PdX/4/gu21MzU+TZIIgeCG2Bx54 oKmp6TOf+QzXhjDFq69mWcxZZjVXVVinpnN1o3h5b9fLe7sQQiqV8l9uv3m++YTeUxfF2qkotzId q6/4JVlZYarIJhKMm547N9xww4kTJ7i2gimCweCuXbsyH3PXV7KssU5LKBT+9bP/M59/XtLKu3/9 8o4CssgLkkzehYx2mNMD46bnRXt7u8PhmG9rH6GTNQCPQiG//1//TwEpzyeJ5198lToY9c2v35ZL 0MsiYeEly5we4gylXDBms9nlcm3YsIFrQ+jn1KlTWd23Ksut12zLtLh0PkAS1B7F8y++Su1Jf+a6 K9npRrNQqBZK/QBIpdJ33333kUce4doQ+nnwwQezHrN147otl19aQOKhUPidg8fg7yQxdKxquWzd 6gLSLIAE8+0lpuKRaTRaJkIa08W5c+eampr4KdqC2b17944d2Rvxw6OTjz+1O+thqWzsvMTp9PRS Qnx/fectDfVMuYSkEgwGgqEg3WEqLzqNKT2o1Gq9rvA1ViwQjUY3b9783nt5DLfznPr6+tOnT+ey P1UwGPrRL3b5A8GsR86HVqP+v3fdrtWwugwrEPCFwmFB6kGhVBoNAthldf/+/Vu3bqVujyto7rrr rtyd3gcvjOz644uRSH7XLpPJvvTPNyxfWp+/dcXi83ki0Sjte8ZRz2RKDxKJxGoVxlRlIpF46KGH vve973FtCD289tprV111Ve7Hj09O//ZPLzldmdYVAVaz8bZbrp8vXA0LuNyORIIUpB4QQmazRSZj KvAw7TidzquvvprRsH/sUFlZefz48Zqa/OIKxxOJ2VnXqTPnR8anpmdmnW4PQshsNJSXWRYvql65 otFqNkkkXEYZi8WiHq8HMbCnKPU0BvXA8y51Wt5///1LL71U6M2n5ubmo0ePJm32LnQCAX8oHEIM 64FBl4pwOJT9IJ6xevXqaDT63nvvmUwC6PzMx+nTp6+99lquraCZSJSNOAYM6gF28WAufeZYv369 0+ns7+9vbGzk2pYC2b9/f2dn5+SkgEPlUYnFYuwMjjPrcifEKgLT0tIyODg4Ojq6adMmrm0phEOH Dq1evbqvr8AwrLwiOlc5MN2DYVgPkaKCp/OBRYsWvf3224FAYPfu3YsWsbexbJEsWrTohRdeGB4e bm0tMKwYr4iwVZCY1UMsGmXBJ5EF1Gr1jh07RkdHXS7Xr371K976Bep0up/+9KcOh2N0dPTmm28u jbCFiUQ8zpYnAYPjS4BQJubyZWpq6vHHH//BD37AtSEIISSRSL75zW/ec889+Q6zCgKfzxvJpb1U 9OQDYkEPCCGTycLcDoicEwgE+vr6nn322d/97neBQJr9FhhCo9HccsstO3bsWLt2rdFoZC1flonF Yh7vRzGmSkEPcrnCZDIznQsfCAaDZ8+efffdd7u6uvbs2UNv4iaTafv27Zs2bdq4ceOyZctKoy2U FY/XTZ0OKgU9IIQMBpNSyfh6Eb6RSCR8Pt/IyEh3d3dPT4/L5fJ6vV6v1+VyeTwet9s9NfXRza+q qjIajQaDwWQy6fV6vV5vMpna2trWrFnT0NBgMBgkEl6sv2WTSCTs8/uo35SIHmQymdks4DC3Ipzg cjuTph2Y1gNLr5xYLBYKFe5dLLIACYdDeYiBJtirgv1+Hw8XkYrwk0QiHgyyMzhxkcrY00OCTHg8 boR4FHdDhJ+QJOn1ehLMR5dJhdUuWnTOZVdEJAM+n4e1Cbgk2B6yCIdDgYCf5UxFBEQgGIhy52/P lh4ojTR/wMeaO4qIsIhEIgWOu9DU1+ZmSNvr9QjUFVyEOeLxuN+ffdkqo3CjhwSZcLtdpeHqJ0IL iUTC6/OQ8w+3sLNWlRU9pLuUeCI2O2sPh8WGkwiKRiNut5MPw/FcugCQiPR4XYGg2L1e0ARDgcw1 A5tw7xLj9/s8XnFeYoHi83nYmnfLCeb1kEO7LxwOOZ0OsTuxoEgkEm63MyVKAJchbRAf6gcgFo/N OmaDwYBYUSwEQqGg2+OM86DDkART+wMVAEkmfH5vMBjQanVKZfYgpCJCJBIJB4IBPnSd08KwHvKv /eKJuMfrlgcDWq2+hFfVLUBisWgg4I/FeR3rjUf1A5VoLOpyOxRypU6nl0qlXJsjUhSJRDwQCESi PBxbT35hM7keqNiu0Yfny2UyhVKlkCtkMp6qVyQt8XgsGo1GopFYLJrzSekLTfaiVHSkSkAAJSwa i0VjPj9CUolEqVQqFCqxHcVbSJKMxWPRSCQSDQtxuxne6iGN3uOJRCAYDASDBEFIJRKJVCohCIlE KpFKpRKJRCKVSqUEwfGA3QKBJMlEIhFPxBOJROLD/xOJRJwkySJ2xeX+2TGmh6IuLcvJJEnG4nEU j7Nx/xjPg6AtE9pMTZMQYy0WOqAva77MP1DI9eK4f5nQQElcRAnBQz3wiYVYXBfiNWOY0QMdkT8W DjxrLLGcNr/gVf2Qx20viSdUEhfBPGzeJv7oQSwcItzDgB4KKdi8FAMvjWKYhXjNVPhTP+RBSTy0 krgIYZPmEdCth5KpHNiC/51ptgzg/BoQ4kH9wIu7IJKBBfWEuNUDj281s6bx+MIXNrT6a7AyXioW JcYQby039YN43z9EvBFZYdlvir76ISezxAKA6L8J4k2lDzbrB+GMQYglbKHCzvoHsXzxn0IXpjGZ O/vQVD8ws61XKSLeDV7DaP1A87MvsaJUOpdTOldCix4KWk3FX4Rlu7CszRP2L46J/nRJP6KiEO8M 36FdD0w9crEoMckCvLvpL7no9hKR5i+R0mABPlG66odSuXUMXgcx7wcR3lBc/UBfqJTs+YikUiL3 hUeXUWT9wKMrESkU8SF+RMH1AyHexnwQb5YwKKx+YPXpll5REsQVcW4kJw6iBeiB8xvFGKV7ZQxS Wjctr/YSkfZPkWwwc7PER8AAudcP4u0vScTHehE56oHI8IlR2MtKLBjcwMl9nzfTrO0lLotJSRTR 5IsoiYsqWTLXD+menfg8S4d5nyXnD5krAzLogeN7wvkjoQOxchAYadtL4lMTWaCk1g8ZxVCqy2nF NwA38KszjS6uH/hSKPhiR7EIdYeShbYNBxVcP+RwZSV38SzDs/vHM3MKgIErkPHtvnBgDSNZ8uuu iuRIzvPT4vMtDvH+pcDH0V7O491fhFho2GLB3uksF56bHli5eyX0iAR8KQI2nQ74VT+IiHAIkZMe SrtyoD9j5sOzLfB3OJPwon4Qn+/Cg6fPPJseeGq2kODfLeTjwA6G25lG7usHPjwD+iitq1l4ZNQD 8w9X9KFdkPD3vnNfP5QQ/H3MFARhJGfMr4eSrxxYoZSvUWDXlsVc+Jmz+kFgNzM7gr8gwV8AHcyj B4bvDS9uvVgBChpmbi4H9UMplhKhXBMf7MxkA+f2pVsvyphRnF9tKSDeRCZhr34QnyOfKfWnk+v1 pehhgcRWpNOg9Gnx7pJ5AU/vCjaLjfqBp/dgwSE+h+xcrAcG7lipP4RSv74FBrP1w4ItLMK6cJ5Y ywczKHqg2xw+XF56aLOMv5coQiGPx8RU/SCWFEYo/Lby4W0ngEIxpwdaTRXAddMAr1cRiBSGBCFR DAsa8XlR7wDN7SUB3FwBmFiSCOOlK6Mr6QVWzITVWOKlUSyR37XTUz8s5PstQgs8KUI06IEnV8Ii C++KFwzF6kFgRWMhrOvIB7YM5u+NSbKsKD3w9yoZhLuLLjDnBfmUCqVwPYi3WYT35F1IC9TDQhUD r9d25Qt/DOaPJYXogT/W54dQ7RY6QrrveetBSBdHM0K8dCHaEPl8swAAAAhJREFUzCX/HylvQL4a oQ98AAAAAElFTkSuQmCC "
-           preserveAspectRatio="none"
-           height="2096.7954"
-           width="1663.4153"
-           x="-309.02106"
-           y="-480.3855"
-           style="stroke-width:0.156906" />
-      </g>
-      <g
-         sodipodi:insensitive="true"
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.89135;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           sodipodi:insensitive="true" /><path
+           d="m 832.00001,960.88865 c 71.18327,0 128.88863,-57.70538 128.88863,-128.88865 0,-71.18327 -57.70536,-128.88865 -128.88863,-128.88865 -71.18327,0 -128.88865,57.70538 -128.88865,128.88865 0,71.18326 57.70538,128.88865 128.88865,128.88865 z m 81.62905,-85.49184 -9.28127,28.6397 c -0.38021,1.17611 -1.02788,2.24589 -1.88821,3.13198 l -8.94391,9.19912 -10.25245,10.54567 -2.24911,2.31354 c -3.89275,4.00393 -10.57917,2.929 -13.02065,-2.09444 l -4.6677,-9.60188 c -0.37378,-0.77011 -0.87,-1.47899 -1.46933,-2.09445 l -9.34958,-9.6167 -7.88026,-8.10516 c -1.51766,-1.55954 -3.59985,-2.43921 -5.77582,-2.43921 h -12.06043 c -3.08366,0 -5.89699,-1.75934 -7.24483,-4.53367 l -7.23806,-14.88953 c -0.53489,-1.09879 -0.81201,-2.30066 -0.81201,-3.52188 v -24.8665 c 0,-3.01921 -1.68844,-5.78323 -4.37125,-7.16363 l -14.39848,-7.40368 c -1.14067,-0.58645 -2.40377,-0.89256 -3.68428,-0.89256 h -15.15151 c -2.17499,0 -4.25912,-0.87966 -5.77582,-2.43922 l -15.67544,-16.12332 c -1.566,-1.61112 -2.38768,-3.80319 -2.26845,-6.04714 l 1.05366,-19.62201 c 0.16111,-2.72277 0.65733,-5.41654 1.52088,-8.00463 l 3.60664,-10.81924 c 7.04731,-21.14193 23.70423,-37.68832 44.89288,-44.59449 l 0.45756,-0.1289 c 19.63199,-6.07646 40.73332,-5.40301 59.93741,1.91399 0.73789,0.29 1.40488,0.71856 1.95266,1.28567 l 14.21095,14.61694 c 3.03855,3.12555 3.03855,8.1042 0,11.23072 l -23.01823,23.6762 c -1.46289,1.50478 -2.27811,3.51802 -2.27811,5.61536 v 7.93889 c 0,5.10142 -4.68187,8.91845 -9.67889,7.89024 l -31.9051,-6.56333 c -4.99668,-1.02789 -9.67857,2.78721 -9.67857,7.89057 v 3.15455 c 0,4.44891 3.60663,8.05553 8.05554,8.05553 h 14.64626 c 4.44925,0 8.05554,3.60663 8.05554,8.05554 v 4.97961 c 0,4.44891 3.60663,8.05555 8.05554,8.05555 h 29.55127 c 2.175,0 4.25912,0.87967 5.77583,2.43922 l 6.96096,7.16008 c 0.60899,0.62511 1.31465,1.15033 2.09121,1.54666 l 18.16009,9.33928 c 0.77656,0.39956 1.48223,0.92155 2.09121,1.54988 l 7.05376,7.25515 c 1.46289,1.50478 2.28133,3.51802 2.28133,5.61536 v 6.00234 c 0,0.84422 -0.12889,1.682 -0.39311,2.48433 z"
+           fill="#a9b2bc"
+           id="path1-6"
+           style="display:inline;fill:#737d8c;fill-opacity:0.999736;stroke-width:32.2221"
+           sodipodi:insensitive="true" /></g><g
          inkscape:groupmode="layer"
          id="g1432"
          inkscape:label="MASK"
-         style="display:none">
-        <circle
+         style="display:none"
+         sodipodi:insensitive="true"><circle
            style="color:#000000;overflow:visible;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2.89135;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
            id="circle1428"
            cx="832"
            cy="832"
-           r="192.00002" />
-      </g>
-    </g>
-    <g
-       sodipodi:insensitive="true"
+           r="192.00002" /></g></g><g
        style="display:inline"
        inkscape:label="__README__"
        inkscape:groupmode="layer"
-       id="layer1">
-      <rect
+       id="layer1"
+       sodipodi:insensitive="true"><rect
          y="-234.4324"
          x="-1243.5376"
          height="1432.0448"
          width="987.23865"
          id="rect25"
-         style="color:#000000;overflow:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" />
-      <text
+         style="color:#000000;overflow:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.89134;stroke-linecap:round;stroke-linejoin:round" /><text
          transform="translate(-1178.3015,-3.3641336)"
          style="font-size:40px;line-height:1;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;white-space:pre;shape-inside:url(#rect17);display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          id="text15"
          xml:space="preserve"><tspan
-           x="-39.911133"
-           y="42.931641"
-           id="tspan2"><tspan
+           x="-39.087387"
+           y="43.936023"
+           id="tspan3"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan1">This document holds all the current icons used </tspan></tspan><tspan
-           x="89.639648"
-           y="82.931641"
-           id="tspan4"><tspan
+             id="tspan1">This document holds all the current icons used </tspan><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan3">on the Matrix space for the NixOS </tspan></tspan><tspan
-           x="297.55957"
-           y="122.93164"
+             id="tspan2">on </tspan></tspan><tspan
+           x="11.992554"
+           y="83.936023"
            id="tspan6"><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan4">the Matrix space for the NixOS </tspan><tspan
              style="shape-inside:url(#rect17)"
              id="tspan5">organization.
 </tspan></tspan><tspan
            x="428.27246"
-           y="162.93164"
+           y="123.93602"
            id="tspan8"><tspan
              style="shape-inside:url(#rect17)"
              id="tspan7">
 </tspan></tspan><tspan
-           x="20.889648"
-           y="202.93164"
-           id="tspan10"><tspan
+           x="-36.36747"
+           y="163.93602"
+           id="tspan11"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan9">Look at the layers, there are folders with </tspan></tspan><tspan
-           x="-25.291992"
-           y="242.93164"
-           id="tspan12"><tspan
+             id="tspan9">Look at the layers, there are folders with </tspan><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan11">&quot;mattes&quot; to preview how the icon looks when </tspan></tspan><tspan
-           x="44.698242"
-           y="282.93164"
+             id="tspan10">&quot;mattes&quot; </tspan></tspan><tspan
+           x="-33.787285"
+           y="203.93602"
            id="tspan14"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan13">cut in a circle or a rounded-off square.
-</tspan></tspan><tspan
-           x="428.27246"
-           y="322.93164"
+             id="tspan12">to preview how the icon looks when </tspan><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan13">cut in a circle </tspan></tspan><tspan
+           x="198.2725"
+           y="243.93602"
            id="tspan16"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan15">
+             id="tspan15">or a rounded-off square.
 </tspan></tspan><tspan
-           x="14.786133"
-           y="362.93164"
+           x="428.27246"
+           y="283.93602"
            id="tspan18"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan17">The rounded-off square is approximative.
+             id="tspan17">
 </tspan></tspan><tspan
-           x="428.27246"
-           y="402.93164"
+           x="40.29261"
+           y="323.93602"
            id="tspan20"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan19">
+             id="tspan19">The rounded-off square is approximative.
 </tspan></tspan><tspan
-           x="47.305664"
-           y="442.93164"
+           x="428.27246"
+           y="363.93602"
            id="tspan22"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan21">The channel icons shouldn't move the </tspan></tspan><tspan
-           x="61.026367"
-           y="482.93164"
+             id="tspan21">
+</tspan></tspan><tspan
+           x="73.932594"
+           y="403.93602"
            id="tspan24"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan23">lambdaflake from the position it's in.
-</tspan></tspan><tspan
-           x="428.27246"
-           y="522.93164"
+             id="tspan23">The channel icons shouldn't move the </tspan></tspan><tspan
+           x="84.632553"
+           y="443.93602"
            id="tspan26"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan25">
+             id="tspan25">lambdaflake from the position it's in.
 </tspan></tspan><tspan
-           x="294.20996"
-           y="562.93164"
+           x="428.27246"
+           y="483.93602"
            id="tspan28"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan27">========
+             id="tspan27">
 </tspan></tspan><tspan
-           x="428.27246"
-           y="602.93164"
+           x="336.75238"
+           y="523.93602"
            id="tspan30"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan29">
+             id="tspan29">========
 </tspan></tspan><tspan
-           x="-11.629883"
-           y="642.93164"
+           x="428.27246"
+           y="563.93602"
            id="tspan32"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan31">ALWAYS hide the Widgets and Mattes layers </tspan></tspan><tspan
-           x="264.1709"
-           y="682.93164"
-           id="tspan34"><tspan
+             id="tspan31">
+</tspan></tspan><tspan
+           x="-39.027458"
+           y="603.93602"
+           id="tspan35"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan33">when exporting!
+             id="tspan33">ALWAYS hide the Widgets and Mattes layers </tspan><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan34">when </tspan></tspan><tspan
+           x="331.73254"
+           y="643.93602"
+           id="tspan37"><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan36">exporting!
 </tspan></tspan><tspan
            x="428.27246"
-           y="722.93164"
-           id="tspan36"><tspan
+           y="683.93602"
+           id="tspan39"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan35">
+             id="tspan38">
 </tspan></tspan><tspan
-           x="0.10839844"
-           y="762.93164"
-           id="tspan38"><tspan
+           x="28.152565"
+           y="723.93602"
+           id="tspan41"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan37">Prefer only showing the layers you want to </tspan></tspan><tspan
-           x="357.12988"
-           y="802.93164"
-           id="tspan40"><tspan
+             id="tspan40">Prefer only showing the layers you want to </tspan></tspan><tspan
+           x="361.57252"
+           y="763.93602"
+           id="tspan43"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan39">export.
-</tspan></tspan><tspan
-           x="428.27246"
-           y="842.93164"
-           id="tspan42"><tspan
-             style="shape-inside:url(#rect17)"
-             id="tspan41">
-</tspan></tspan><tspan
-           x="227.17871"
-           y="882.93164"
-           id="tspan44"><tspan
-             style="shape-inside:url(#rect17)"
-             id="tspan43">============
+             id="tspan42">export.
 </tspan></tspan><tspan
            x="428.27246"
-           y="922.93164"
-           id="tspan46"><tspan
+           y="803.93602"
+           id="tspan45"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan45">
+             id="tspan44">
 </tspan></tspan><tspan
-           x="119.13184"
-           y="962.93164"
-           id="tspan48"><tspan
+           x="290.99234"
+           y="843.93602"
+           id="tspan47"><tspan
              style="shape-inside:url(#rect17)"
-             id="tspan47">Encode Sans is the font used...</tspan></tspan></text>
-    </g>
-  </g>
-</svg>
+             id="tspan46">============
+</tspan></tspan><tspan
+           x="428.27246"
+           y="883.93602"
+           id="tspan100"><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan48">
+</tspan></tspan><tspan
+           x="143.61254"
+           y="923.93602"
+           id="tspan102"><tspan
+             style="shape-inside:url(#rect17)"
+             id="tspan101">Encode Sans is the font used...</tspan></tspan></text></g></g></svg>


### PR DESCRIPTION
The KDE Matrix room icon was added as a layer to the room template. The colors used were selected to be unique and as close to the KDE project as possible.

This commit also replaces the default Matrix room globe png with it's correct svg image taken from their SDK.